### PR TITLE
feat(ai): #204 Spring Django AI 호출 클라이언트 (WebClient+CB)

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -28,7 +28,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
 
-    // Resilience4j
+    // Resilience4j (AOP required for @CircuitBreaker, @Retry, @TimeLimiter annotations)
+    implementation("org.springframework.boot:spring-boot-starter-aop")
     implementation("io.github.resilience4j:resilience4j-spring-boot3:2.2.0")
     implementation("io.github.resilience4j:resilience4j-kotlin:2.2.0")
 

--- a/backend/src/main/kotlin/com/fanpulse/domain/ai/FilterResult.kt
+++ b/backend/src/main/kotlin/com/fanpulse/domain/ai/FilterResult.kt
@@ -1,0 +1,22 @@
+package com.fanpulse.domain.ai
+
+/**
+ * Django AI 서비스의 댓글 필터링 결과를 나타내는 값 객체.
+ *
+ * Django API 계약:
+ * ```json
+ * {"is_filtered": false, "action": null, "rule_id": null, "rule_name": null,
+ *  "filter_type": "LLM", "matched_pattern": null, "reason": null}
+ * ```
+ *
+ * @property isFiltered 댓글이 필터링(차단)되었는지 여부
+ * @property filterType 필터링 방식: "LLM", "rule", "fallback" 중 하나
+ * @property reason 필터링 이유 (필터링된 경우에만 존재, 아니면 null)
+ * @property ruleName 적용된 규칙 이름 (rule 기반 필터링 시에만 존재, 아니면 null)
+ */
+data class FilterResult(
+    val isFiltered: Boolean,
+    val filterType: String,
+    val reason: String? = null,
+    val ruleName: String? = null
+)

--- a/backend/src/main/kotlin/com/fanpulse/domain/ai/ModerationResult.kt
+++ b/backend/src/main/kotlin/com/fanpulse/domain/ai/ModerationResult.kt
@@ -1,0 +1,30 @@
+package com.fanpulse.domain.ai
+
+/**
+ * Django AI 모더레이션 서비스의 콘텐츠 검사 결과를 나타내는 값 객체.
+ *
+ * Django API 계약:
+ * ```json
+ * {"is_flagged": false, "action": "allow", "highest_category": null, "highest_score": 0.1,
+ *  "confidence": 0.9, "model_used": "ko", "processing_time_ms": 38, "error": null}
+ * ```
+ *
+ * @property isFlagged 콘텐츠가 유해하다고 판단되었는지 여부
+ * @property action 처리 액션: "allow", "flag", "block" 중 하나
+ * @property highestCategory 가장 높은 점수를 받은 유해 카테고리 (없으면 null)
+ * @property highestScore 가장 높은 유해 카테고리의 점수 (0.0 ~ 1.0, 없으면 null)
+ * @property confidence 모더레이션 판단의 신뢰도 (0.0 ~ 1.0)
+ * @property modelUsed 사용된 AI 모델 식별자 (예: "ko", "fallback")
+ * @property processingTimeMs 처리 시간 (밀리초, 없으면 null)
+ * @property error 에러 발생 시 에러 메시지 (정상 처리 시 null)
+ */
+data class ModerationResult(
+    val isFlagged: Boolean,
+    val action: String,
+    val highestCategory: String? = null,
+    val highestScore: Double? = null,
+    val confidence: Double,
+    val modelUsed: String,
+    val processingTimeMs: Long? = null,
+    val error: String? = null
+)

--- a/backend/src/main/kotlin/com/fanpulse/domain/ai/SummaryResult.kt
+++ b/backend/src/main/kotlin/com/fanpulse/domain/ai/SummaryResult.kt
@@ -1,0 +1,24 @@
+package com.fanpulse.domain.ai
+
+/**
+ * Django AI 서비스의 뉴스 요약 결과를 나타내는 값 객체.
+ *
+ * Django API 계약:
+ * ```json
+ * {"request_id": "uuid", "summary": "요약 결과", "bullets": ["핵심 포인트 1"],
+ *  "keywords": ["키워드1"], "elapsed_ms": 125}
+ * ```
+ *
+ * @property summary 요약된 텍스트
+ * @property bullets 핵심 포인트 목록 (없으면 빈 리스트)
+ * @property keywords 주요 키워드 목록 (없으면 빈 리스트)
+ * @property elapsedMs 요약 처리에 소요된 시간 (밀리초, 없으면 null)
+ * @property error 에러 발생 시 에러 메시지 (정상 처리 시 null)
+ */
+data class SummaryResult(
+    val summary: String,
+    val bullets: List<String> = emptyList(),
+    val keywords: List<String> = emptyList(),
+    val elapsedMs: Long? = null,
+    val error: String? = null
+)

--- a/backend/src/main/kotlin/com/fanpulse/domain/ai/port/CommentFilterPort.kt
+++ b/backend/src/main/kotlin/com/fanpulse/domain/ai/port/CommentFilterPort.kt
@@ -1,0 +1,25 @@
+package com.fanpulse.domain.ai.port
+
+import com.fanpulse.domain.ai.FilterResult
+
+/**
+ * Django AI 사이드카의 댓글 필터링 서비스에 대한 도메인 포트.
+ *
+ * Hexagonal Architecture의 출력 포트(Output Port)로, 도메인 레이어가 외부 AI 서비스에
+ * 의존하지 않도록 추상화합니다. 실제 구현체는 infrastructure 레이어에 위치합니다.
+ *
+ * Django API 엔드포인트: POST /api/comments/filter/test
+ */
+interface CommentFilterPort {
+
+    /**
+     * 댓글 내용에 대한 AI 필터링 검사를 수행합니다.
+     *
+     * LLM 기반 필터링과 규칙 기반 필터링을 조합하여 검사합니다.
+     * AI 서비스 장애 시 Fail-Open 전략에 따라 허용(isFiltered=false) 결과를 반환합니다.
+     *
+     * @param content 필터링할 댓글 내용
+     * @return 필터링 결과 ([FilterResult])
+     */
+    fun filterComment(content: String): FilterResult
+}

--- a/backend/src/main/kotlin/com/fanpulse/domain/ai/port/ContentModerationPort.kt
+++ b/backend/src/main/kotlin/com/fanpulse/domain/ai/port/ContentModerationPort.kt
@@ -1,0 +1,34 @@
+package com.fanpulse.domain.ai.port
+
+import com.fanpulse.domain.ai.ModerationResult
+
+/**
+ * Django AI 사이드카의 콘텐츠 모더레이션 서비스에 대한 도메인 포트.
+ *
+ * Hexagonal Architecture의 출력 포트(Output Port)로, 도메인 레이어가 외부 AI 서비스에
+ * 의존하지 않도록 추상화합니다. 실제 구현체는 infrastructure 레이어에 위치합니다.
+ *
+ * Django API 엔드포인트: POST /api/moderation/check
+ */
+interface ContentModerationPort {
+
+    /**
+     * 단일 텍스트에 대한 콘텐츠 모더레이션 검사를 수행합니다.
+     *
+     * AI 서비스 장애 시 Fail-Open 전략에 따라 허용(allow) 결과를 반환합니다.
+     *
+     * @param text 검사할 텍스트
+     * @return 모더레이션 결과 ([ModerationResult])
+     */
+    fun checkContent(text: String): ModerationResult
+
+    /**
+     * 여러 텍스트에 대한 일괄 콘텐츠 모더레이션 검사를 수행합니다.
+     *
+     * Django API 엔드포인트: POST /api/moderation/batch
+     *
+     * @param texts 검사할 텍스트 목록
+     * @return 각 텍스트에 대한 모더레이션 결과 목록 (입력 순서와 동일)
+     */
+    fun batchCheck(texts: List<String>): List<ModerationResult>
+}

--- a/backend/src/main/kotlin/com/fanpulse/domain/ai/port/NewsSummarizerPort.kt
+++ b/backend/src/main/kotlin/com/fanpulse/domain/ai/port/NewsSummarizerPort.kt
@@ -1,0 +1,32 @@
+package com.fanpulse.domain.ai.port
+
+import com.fanpulse.domain.ai.SummaryResult
+
+/**
+ * Django AI 사이드카의 뉴스 요약 서비스에 대한 도메인 포트.
+ *
+ * Hexagonal Architecture의 출력 포트(Output Port)로, 도메인 레이어가 외부 AI 서비스에
+ * 의존하지 않도록 추상화합니다. 실제 구현체는 infrastructure 레이어에 위치합니다.
+ *
+ * Django API 엔드포인트: POST /api/summarize
+ */
+interface NewsSummarizerPort {
+
+    /**
+     * 뉴스 텍스트를 요약합니다.
+     *
+     * 요약 방식에 따라 AI 기반 또는 추출 기반 요약을 수행합니다.
+     * AI 서비스 장애 시 Fail-Open 전략에 따라 빈 요약과 에러 메시지를 반환합니다.
+     *
+     * Django 요청 형식:
+     * ```json
+     * {"input_type": "text", "summarize_method": "{method}", "text": "{text}",
+     *  "language": "ko", "max_length": 200, "min_length": 50}
+     * ```
+     *
+     * @param text 요약할 뉴스 텍스트
+     * @param method 요약 방식 (예: "ai", "extractive")
+     * @return 요약 결과 ([SummaryResult])
+     */
+    fun summarize(text: String, method: String): SummaryResult
+}

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/external/ai/AiCommentFilterAdapter.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/external/ai/AiCommentFilterAdapter.kt
@@ -1,0 +1,135 @@
+package com.fanpulse.infrastructure.external.ai
+
+import com.fanpulse.domain.ai.FilterResult
+import com.fanpulse.domain.ai.port.CommentFilterPort
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
+import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * HTTP adapter that calls the Django AI Sidecar's comment filtering API.
+ *
+ * Implements [CommentFilterPort] using WebClient for non-blocking HTTP calls.
+ * Only active when `fanpulse.ai-service.enabled=true` (default).
+ *
+ * Resilience4j integration:
+ * - @CircuitBreaker(name = "aiCommentFilter"): separate circuit breaker for comment filtering
+ * - @Retry(name = "aiService"): up to 2 attempts with 500ms wait on failure
+ * - Fail-Open fallback: [filterCommentFallback] returns permissive result via [AiServiceFallback]
+ *
+ * Django API endpoint: POST /api/comments/filter/test
+ *
+ * JSON is deserialized using snake_case -> camelCase mapping via the shared
+ * `aiServiceObjectMapper` configured in [AiServiceConfig].
+ */
+@Component
+@ConditionalOnProperty(name = ["fanpulse.ai-service.enabled"], havingValue = "true", matchIfMissing = true)
+class AiCommentFilterAdapter(
+    @Qualifier("aiServiceWebClient")
+    private val webClient: WebClient,
+    private val aiServiceFallback: AiServiceFallback
+) : CommentFilterPort {
+
+    companion object {
+        private const val COMMENT_FILTER_PATH = "/api/comments/filter/test"
+    }
+
+    /**
+     * Sends a comment filter check request to Django AI service.
+     *
+     * Decorated with:
+     * - @Retry: retries up to 2 times on failure (config: resilience4j.retry.instances.aiService)
+     * - @CircuitBreaker: opens circuit after 60% failure rate; calls [filterCommentFallback] on open
+     *
+     * Request body: `{"content": "..."}`
+     * Response: [CommentFilterResponse] deserialized as [FilterResult]
+     *
+     * @param content Comment text to filter
+     * @return [FilterResult] with filtering decision, or Fail-Open fallback result
+     */
+    @Retry(name = "aiService")
+    @CircuitBreaker(name = "aiCommentFilter", fallbackMethod = "filterCommentFallback")
+    override fun filterComment(content: String): FilterResult {
+        logger.debug { "Filtering comment (length=${content.length})" }
+
+        val request = CommentFilterRequest(content = content)
+
+        val response = webClient.post()
+            .uri(COMMENT_FILTER_PATH)
+            .bodyValue(request)
+            .retrieve()
+            .bodyToMono(CommentFilterResponse::class.java)
+            .doOnError { e ->
+                logger.warn(e) { "Failed to filter comment: ${e.message}" }
+            }
+            .block()
+            ?: throw AiServiceException("Empty response from comment filter endpoint")
+
+        logger.debug { "Comment filter result: isFiltered=${response.isFiltered}, filterType=${response.filterType}" }
+
+        return response.toDomain()
+    }
+
+    // =========================================================================
+    // Fallback method (called by @CircuitBreaker on open circuit or exception)
+    // =========================================================================
+
+    /**
+     * Fallback for [filterComment] when circuit is open or all retries are exhausted.
+     * Returns a Fail-Open [FilterResult] via [AiServiceFallback.filterFallback].
+     *
+     * Method signature must match [filterComment] with an additional [Exception] parameter.
+     */
+    @Suppress("unused")
+    private fun filterCommentFallback(content: String, e: Exception): FilterResult {
+        logger.warn { "filterComment fallback triggered for content (length=${content.length}): ${e.javaClass.simpleName}" }
+        return aiServiceFallback.filterFallback(content, e)
+    }
+}
+
+// =============================================================================
+// Request / Response DTOs (Django API contract)
+// =============================================================================
+
+/**
+ * Request body for POST /api/comments/filter/test.
+ * Serialized as snake_case JSON by aiServiceObjectMapper.
+ */
+data class CommentFilterRequest(
+    val content: String
+)
+
+/**
+ * Response from Django comment filter API.
+ * Deserialized from snake_case JSON:
+ * ```json
+ * {"is_filtered": false, "action": null, "rule_id": null, "rule_name": null,
+ *  "filter_type": "LLM", "matched_pattern": null, "reason": null}
+ * ```
+ *
+ * Note: Field names here are camelCase; snake_case deserialization is handled
+ * by the shared ObjectMapper with PropertyNamingStrategies.SNAKE_CASE.
+ */
+data class CommentFilterResponse(
+    val isFiltered: Boolean = false,
+    val action: String? = null,
+    val ruleId: Int? = null,
+    val ruleName: String? = null,
+    val filterType: String = "LLM",
+    val matchedPattern: String? = null,
+    val reason: String? = null
+) {
+    /** Converts this response DTO to a domain [FilterResult] value object. */
+    fun toDomain(): FilterResult = FilterResult(
+        isFiltered = isFiltered,
+        filterType = filterType,
+        reason = reason,
+        ruleName = ruleName
+    )
+}

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/external/ai/AiModerationAdapter.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/external/ai/AiModerationAdapter.kt
@@ -1,0 +1,208 @@
+package com.fanpulse.infrastructure.external.ai
+
+import com.fanpulse.domain.ai.ModerationResult
+import com.fanpulse.domain.ai.port.ContentModerationPort
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
+import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * HTTP adapter that calls the Django AI Sidecar's content moderation API.
+ *
+ * Implements [ContentModerationPort] using WebClient for non-blocking HTTP calls.
+ * Only active when `fanpulse.ai-service.enabled=true` (default).
+ *
+ * Resilience4j integration:
+ * - @CircuitBreaker(name = "aiModeration"): opens after 60% failure rate over 10 calls
+ * - @Retry(name = "aiService"): up to 2 attempts with 500ms wait on failure
+ * - Fail-Open fallback: all fallback methods return permissive results via [AiServiceFallback]
+ *
+ * Django API endpoints:
+ * - Single check: POST /api/moderation/check
+ * - Batch check:  POST /api/moderation/batch
+ *
+ * JSON is deserialized using snake_case -> camelCase mapping via the shared
+ * `aiServiceObjectMapper` configured in [AiServiceConfig].
+ */
+@Component
+@ConditionalOnProperty(name = ["fanpulse.ai-service.enabled"], havingValue = "true", matchIfMissing = true)
+class AiModerationAdapter(
+    @Qualifier("aiServiceWebClient")
+    private val webClient: WebClient,
+    private val aiServiceFallback: AiServiceFallback
+) : ContentModerationPort {
+
+    companion object {
+        private const val MODERATION_CHECK_PATH = "/api/moderation/check"
+        private const val MODERATION_BATCH_PATH = "/api/moderation/batch"
+    }
+
+    /**
+     * Sends a single content moderation check request to Django AI service.
+     *
+     * Decorated with:
+     * - @Retry: retries up to 2 times on failure (config: resilience4j.retry.instances.aiService)
+     * - @CircuitBreaker: opens circuit after 60% failure rate; calls [checkContentFallback] on open
+     *
+     * Request body: `{"text": "...", "use_cache": true}`
+     * Response: [ModerationCheckResponse] deserialized as [ModerationResult]
+     *
+     * @param text Text content to check
+     * @return [ModerationResult] with moderation decision, or Fail-Open fallback result
+     */
+    @Retry(name = "aiService")
+    @CircuitBreaker(name = "aiModeration", fallbackMethod = "checkContentFallback")
+    override fun checkContent(text: String): ModerationResult {
+        logger.debug { "Checking content moderation for text (length=${text.length})" }
+
+        val request = ModerationCheckRequest(text = text)
+
+        val response = webClient.post()
+            .uri(MODERATION_CHECK_PATH)
+            .bodyValue(request)
+            .retrieve()
+            .bodyToMono(ModerationCheckResponse::class.java)
+            .doOnError { e ->
+                logger.warn(e) { "Failed to check content moderation: ${e.message}" }
+            }
+            .block()
+            ?: throw AiServiceException("Empty response from moderation check endpoint")
+
+        logger.debug { "Moderation check result: isFlagged=${response.isFlagged}, action=${response.action}" }
+
+        return response.toDomain()
+    }
+
+    /**
+     * Sends a batch content moderation check request to Django AI service.
+     *
+     * Decorated with:
+     * - @Retry: retries up to 2 times on failure (config: resilience4j.retry.instances.aiService)
+     * - @CircuitBreaker: opens circuit after 60% failure rate; calls [batchCheckFallback] on open
+     *
+     * Request body: `{"texts": ["...", "..."]}`
+     * Response: Array of [ModerationCheckResponse] deserialized as [List<ModerationResult>]
+     *
+     * @param texts List of text contents to check
+     * @return List of [ModerationResult] in the same order as input, or Fail-Open fallback results
+     */
+    @Retry(name = "aiService")
+    @CircuitBreaker(name = "aiModeration", fallbackMethod = "batchCheckFallback")
+    override fun batchCheck(texts: List<String>): List<ModerationResult> {
+        if (texts.isEmpty()) {
+            logger.debug { "Empty batch, returning empty results" }
+            return emptyList()
+        }
+
+        logger.debug { "Batch checking moderation for ${texts.size} texts" }
+
+        val request = ModerationBatchRequest(texts = texts)
+
+        val responses = webClient.post()
+            .uri(MODERATION_BATCH_PATH)
+            .bodyValue(request)
+            .retrieve()
+            .bodyToFlux(ModerationCheckResponse::class.java)
+            .collectList()
+            .doOnError { e ->
+                logger.warn(e) { "Failed to batch check content moderation: ${e.message}" }
+            }
+            .block() ?: emptyList()
+
+        logger.debug { "Batch moderation check completed: ${responses.size} results" }
+
+        return responses.map { it.toDomain() }
+    }
+
+    // =========================================================================
+    // Fallback methods (called by @CircuitBreaker on open circuit or exception)
+    // Fail-Open strategy: all fallbacks return permissive results
+    // =========================================================================
+
+    /**
+     * Fallback for [checkContent] when circuit is open or all retries are exhausted.
+     * Returns a Fail-Open [ModerationResult] via [AiServiceFallback.moderationFallback].
+     *
+     * Method signature must match [checkContent] with an additional [Exception] parameter.
+     */
+    @Suppress("unused")
+    private fun checkContentFallback(text: String, e: Exception): ModerationResult {
+        logger.warn { "checkContent fallback triggered for text (length=${text.length}): ${e.javaClass.simpleName}" }
+        return aiServiceFallback.moderationFallback(text, e)
+    }
+
+    /**
+     * Fallback for [batchCheck] when circuit is open or all retries are exhausted.
+     * Returns a Fail-Open list of [ModerationResult] via [AiServiceFallback.batchModerationFallback].
+     *
+     * Method signature must match [batchCheck] with an additional [Exception] parameter.
+     */
+    @Suppress("unused")
+    private fun batchCheckFallback(texts: List<String>, e: Exception): List<ModerationResult> {
+        logger.warn { "batchCheck fallback triggered for ${texts.size} texts: ${e.javaClass.simpleName}" }
+        return aiServiceFallback.batchModerationFallback(texts, e)
+    }
+}
+
+// =============================================================================
+// Request / Response DTOs (Django API contract)
+// =============================================================================
+
+/**
+ * Request body for POST /api/moderation/check.
+ * Serialized as snake_case JSON by aiServiceObjectMapper.
+ */
+data class ModerationCheckRequest(
+    val text: String,
+    val useCache: Boolean = true
+)
+
+/**
+ * Request body for POST /api/moderation/batch.
+ * Serialized as snake_case JSON by aiServiceObjectMapper.
+ */
+data class ModerationBatchRequest(
+    val texts: List<String>
+)
+
+/**
+ * Response from Django moderation API.
+ * Deserialized from snake_case JSON:
+ * ```json
+ * {"is_flagged": false, "action": "allow", "highest_category": null,
+ *  "highest_score": 0.1, "confidence": 0.9, "model_used": "ko",
+ *  "processing_time_ms": 38, "cached": false, "error": null}
+ * ```
+ *
+ * Note: Field names here are camelCase; snake_case deserialization is handled
+ * by the shared ObjectMapper with PropertyNamingStrategies.SNAKE_CASE.
+ */
+data class ModerationCheckResponse(
+    val isFlagged: Boolean = false,
+    val action: String = "allow",
+    val highestCategory: String? = null,
+    val highestScore: Double? = null,
+    val confidence: Double = 0.0,
+    val modelUsed: String = "unknown",
+    val processingTimeMs: Long? = null,
+    val cached: Boolean = false,
+    val error: String? = null
+) {
+    /** Converts this response DTO to a domain [ModerationResult] value object. */
+    fun toDomain(): ModerationResult = ModerationResult(
+        isFlagged = isFlagged,
+        action = action,
+        highestCategory = highestCategory,
+        highestScore = highestScore,
+        confidence = confidence,
+        modelUsed = modelUsed,
+        processingTimeMs = processingTimeMs,
+        error = error
+    )
+}

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/external/ai/AiNewsSummarizerAdapter.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/external/ai/AiNewsSummarizerAdapter.kt
@@ -1,0 +1,162 @@
+package com.fanpulse.infrastructure.external.ai
+
+import com.fanpulse.domain.ai.SummaryResult
+import com.fanpulse.domain.ai.port.NewsSummarizerPort
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import io.github.resilience4j.retry.annotation.Retry
+import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * HTTP adapter that calls the Django AI Sidecar's news summarization API.
+ *
+ * Implements [NewsSummarizerPort] using WebClient for non-blocking HTTP calls.
+ * Only active when `fanpulse.ai-service.enabled=true` (default).
+ *
+ * Resilience4j integration:
+ * - @CircuitBreaker(name = "aiSummarizer"): separate circuit breaker (slower AI model inference)
+ * - @Retry(name = "aiService"): up to 2 attempts with 500ms wait on failure
+ * - Fail-Open fallback: [summarizeFallback] returns empty summary via [AiServiceFallback]
+ *
+ * Django API endpoint: POST /api/summarize
+ *
+ * Note: Summarization is slower than moderation (AI model inference).
+ * A longer timeout is configured for the aiSummarizer circuit breaker instance.
+ *
+ * JSON is deserialized using snake_case -> camelCase mapping via the shared
+ * `aiServiceObjectMapper` configured in [AiServiceConfig].
+ */
+@Component
+@ConditionalOnProperty(name = ["fanpulse.ai-service.enabled"], havingValue = "true", matchIfMissing = true)
+class AiNewsSummarizerAdapter(
+    @Qualifier("aiServiceWebClient")
+    private val webClient: WebClient,
+    private val aiServiceFallback: AiServiceFallback,
+    private val aiServiceProperties: AiServiceProperties = AiServiceProperties()
+) : NewsSummarizerPort {
+
+    companion object {
+        private const val SUMMARIZE_PATH = "/api/summarize"
+        private const val DEFAULT_LANGUAGE = "ko"
+        private const val DEFAULT_MAX_LENGTH = 200
+        private const val DEFAULT_MIN_LENGTH = 50
+    }
+
+    /**
+     * Sends a news summarization request to Django AI service.
+     *
+     * Decorated with:
+     * - @Retry: retries up to 2 times on failure (config: resilience4j.retry.instances.aiService)
+     * - @CircuitBreaker: opens circuit after 60% failure rate; calls [summarizeFallback] on open
+     *
+     * Request body:
+     * ```json
+     * {"input_type": "text", "summarize_method": "ai", "text": "...",
+     *  "language": "ko", "max_length": 200, "min_length": 50}
+     * ```
+     * Response: [SummarizeResponse] deserialized as [SummaryResult]
+     *
+     * @param text News text to summarize
+     * @param method Summarization method: "ai" or "extractive"
+     * @return [SummaryResult] with summary, bullets, and keywords, or Fail-Open fallback result
+     */
+    @Retry(name = "aiService")
+    @CircuitBreaker(name = "aiSummarizer", fallbackMethod = "summarizeFallback")
+    override fun summarize(text: String, method: String): SummaryResult {
+        logger.debug { "Summarizing news text (length=${text.length}, method=$method)" }
+
+        val request = SummarizeRequest(
+            inputType = "text",
+            summarizeMethod = method,
+            text = text,
+            language = DEFAULT_LANGUAGE,
+            maxLength = DEFAULT_MAX_LENGTH,
+            minLength = DEFAULT_MIN_LENGTH
+        )
+
+        val response = webClient.post()
+            .uri(SUMMARIZE_PATH)
+            .bodyValue(request)
+            .retrieve()
+            .bodyToMono(SummarizeResponse::class.java)
+            .timeout(aiServiceProperties.timeout.summarizeRead)
+            .doOnError { e ->
+                logger.warn(e) { "Failed to summarize news text: ${e.message}" }
+            }
+            .block()
+            ?: throw AiServiceException("Empty response from summarize endpoint")
+
+        logger.debug { "Summarization completed in ${response.elapsedMs}ms" }
+
+        return response.toDomain()
+    }
+
+    // =========================================================================
+    // Fallback method (called by @CircuitBreaker on open circuit or exception)
+    // =========================================================================
+
+    /**
+     * Fallback for [summarize] when circuit is open or all retries are exhausted.
+     * Returns a Fail-Open [SummaryResult] with empty summary via [AiServiceFallback.summaryFallback].
+     *
+     * Method signature must match [summarize] with an additional [Exception] parameter.
+     */
+    @Suppress("unused")
+    private fun summarizeFallback(text: String, method: String, e: Exception): SummaryResult {
+        logger.warn { "summarize fallback triggered for text (length=${text.length}, method=$method): ${e.javaClass.simpleName}" }
+        return aiServiceFallback.summaryFallback(text, method, e)
+    }
+}
+
+// =============================================================================
+// Request / Response DTOs (Django API contract)
+// =============================================================================
+
+/**
+ * Request body for POST /api/summarize.
+ * Serialized as snake_case JSON by aiServiceObjectMapper:
+ * ```json
+ * {"input_type": "text", "summarize_method": "ai", "text": "...",
+ *  "language": "ko", "max_length": 200, "min_length": 50}
+ * ```
+ */
+data class SummarizeRequest(
+    val inputType: String = "text",
+    val summarizeMethod: String = "ai",
+    val text: String,
+    val language: String = "ko",
+    val maxLength: Int = 200,
+    val minLength: Int = 50
+)
+
+/**
+ * Response from Django summarize API.
+ * Deserialized from snake_case JSON:
+ * ```json
+ * {"request_id": "uuid", "summary": "요약 결과",
+ *  "bullets": ["핵심 포인트 1"], "keywords": ["키워드1"], "elapsed_ms": 125}
+ * ```
+ *
+ * Note: Field names here are camelCase; snake_case deserialization is handled
+ * by the shared ObjectMapper with PropertyNamingStrategies.SNAKE_CASE.
+ */
+data class SummarizeResponse(
+    val requestId: String = "",
+    val summary: String = "",
+    val bullets: List<String> = emptyList(),
+    val keywords: List<String> = emptyList(),
+    val elapsedMs: Long? = null
+) {
+    /** Converts this response DTO to a domain [SummaryResult] value object. */
+    fun toDomain(): SummaryResult = SummaryResult(
+        summary = summary,
+        bullets = bullets,
+        keywords = keywords,
+        elapsedMs = elapsedMs
+    )
+}

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/external/ai/AiServiceConfig.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/external/ai/AiServiceConfig.kt
@@ -1,0 +1,111 @@
+package com.fanpulse.infrastructure.external.ai
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import mu.KotlinLogging
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.codec.json.Jackson2JsonDecoder
+import org.springframework.http.codec.json.Jackson2JsonEncoder
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
+import org.springframework.web.reactive.function.client.ExchangeStrategies
+import org.springframework.web.reactive.function.client.WebClient
+import reactor.netty.http.client.HttpClient
+import java.time.Duration
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Configuration properties for the Django AI Sidecar service.
+ *
+ * Bound from `fanpulse.ai-service.*` in application.yml.
+ *
+ * @property enabled Whether the AI service integration is enabled (Feature Flag)
+ * @property baseUrl Base URL of the Django AI service
+ * @property timeout Timeout settings for different types of requests
+ */
+@ConfigurationProperties(prefix = "fanpulse.ai-service")
+data class AiServiceProperties(
+    val enabled: Boolean = true,
+    val baseUrl: String = "http://localhost:8001",
+    val timeout: AiServiceTimeout = AiServiceTimeout()
+)
+
+/**
+ * Timeout configuration for AI service requests.
+ *
+ * @property connect Connection timeout
+ * @property read Default read timeout (for moderation/filter)
+ * @property summarizeRead Extended read timeout for summarization (AI model is slower)
+ */
+data class AiServiceTimeout(
+    val connect: Duration = Duration.ofSeconds(3),
+    val read: Duration = Duration.ofSeconds(5),
+    val summarizeRead: Duration = Duration.ofSeconds(30)
+)
+
+/**
+ * Spring configuration for Django AI Sidecar WebClient beans.
+ *
+ * Creates a shared WebClient bean with snake_case Jackson ObjectMapper
+ * to correctly deserialize Django API responses.
+ */
+@Configuration
+@EnableConfigurationProperties(AiServiceProperties::class)
+class AiServiceConfig(
+    private val aiServiceProperties: AiServiceProperties
+) {
+
+    /**
+     * Shared ObjectMapper configured for Django API snake_case JSON convention.
+     *
+     * Django uses snake_case field names (e.g., `is_flagged`, `model_used`)
+     * while Kotlin uses camelCase (e.g., `isFlagged`, `modelUsed`).
+     * This mapper handles the conversion automatically.
+     */
+    @Bean(name = ["aiServiceObjectMapper"])
+    fun aiServiceObjectMapper(): ObjectMapper {
+        return ObjectMapper()
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+            .registerKotlinModule()
+    }
+
+    /**
+     * WebClient configured for the Django AI Sidecar service.
+     *
+     * Features:
+     * - Base URL from `fanpulse.ai-service.base-url`
+     * - Jackson snake_case codec for request/response serialization
+     * - Netty HttpClient with connect + read timeouts from AiServiceProperties
+     * - Used by all AI adapter implementations
+     */
+    @Bean(name = ["aiServiceWebClient"])
+    fun aiServiceWebClient(aiServiceObjectMapper: ObjectMapper): WebClient {
+        logger.info { "Configuring AI service WebClient with base URL: ${aiServiceProperties.baseUrl}" }
+
+        val httpClient = HttpClient.create()
+            .option(io.netty.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS,
+                aiServiceProperties.timeout.connect.toMillis().toInt())
+            .responseTimeout(aiServiceProperties.timeout.read)
+
+        val strategies = ExchangeStrategies.builder()
+            .codecs { configurer ->
+                configurer.defaultCodecs().jackson2JsonDecoder(
+                    Jackson2JsonDecoder(aiServiceObjectMapper)
+                )
+                configurer.defaultCodecs().jackson2JsonEncoder(
+                    Jackson2JsonEncoder(aiServiceObjectMapper)
+                )
+            }
+            .build()
+
+        return WebClient.builder()
+            .baseUrl(aiServiceProperties.baseUrl)
+            .clientConnector(ReactorClientHttpConnector(httpClient))
+            .exchangeStrategies(strategies)
+            .build()
+    }
+}

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/external/ai/AiServiceException.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/external/ai/AiServiceException.kt
@@ -1,0 +1,14 @@
+package com.fanpulse.infrastructure.external.ai
+
+/**
+ * Exception thrown when the Django AI Sidecar service returns an unexpected response.
+ *
+ * This includes cases such as empty responses, malformed JSON, or connection failures
+ * that are not covered by [org.springframework.web.reactive.function.client.WebClientResponseException].
+ *
+ * Circuit Breaker will record this exception as a failure.
+ */
+class AiServiceException(
+    message: String,
+    cause: Throwable? = null
+) : RuntimeException(message, cause)

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/external/ai/AiServiceFallback.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/external/ai/AiServiceFallback.kt
@@ -1,0 +1,113 @@
+package com.fanpulse.infrastructure.external.ai
+
+import com.fanpulse.domain.ai.FilterResult
+import com.fanpulse.domain.ai.ModerationResult
+import com.fanpulse.domain.ai.SummaryResult
+import mu.KotlinLogging
+import org.springframework.stereotype.Component
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Fail-Open fallback implementation for the Django AI Sidecar service.
+ *
+ * When the AI service is unavailable (timeout, circuit open, connection error),
+ * all methods return permissive results that **allow** content to pass through.
+ *
+ * Fail-Open strategy rationale:
+ * - User experience takes priority over strict AI moderation during outages
+ * - Blocking all content when AI is down causes unacceptable UX degradation
+ * - Human moderation remains as the last line of defense
+ *
+ * All fallback results are identifiable via:
+ * - [ModerationResult.modelUsed] = "fallback"
+ * - [FilterResult.filterType] = "fallback"
+ * - [SummaryResult.error] = "AI service unavailable"
+ */
+@Component
+class AiServiceFallback {
+
+    /**
+     * Fallback for content moderation when AI service is unavailable.
+     *
+     * Returns a permissive result that allows the content:
+     * - isFlagged = false (content is NOT flagged)
+     * - action = "allow" (content is allowed through)
+     * - modelUsed = "fallback" (identifies this as a fallback response)
+     *
+     * @param text The content that was being checked (unused in fallback)
+     * @param e The exception that triggered the fallback
+     * @return [ModerationResult] with Fail-Open permissive values
+     */
+    fun moderationFallback(text: String, e: Exception): ModerationResult {
+        logger.warn { "Moderation fallback triggered for text (length=${text.length}): ${e.message}" }
+        return ModerationResult(
+            isFlagged = false,
+            action = "allow",
+            highestCategory = null,
+            highestScore = null,
+            confidence = 0.0,
+            modelUsed = "fallback",
+            processingTimeMs = null,
+            error = e.message
+        )
+    }
+
+    /**
+     * Fallback for batch content moderation when AI service is unavailable.
+     *
+     * Returns a list of permissive results, one per input text.
+     *
+     * @param texts The list of contents that were being checked
+     * @param e The exception that triggered the fallback
+     * @return List of [ModerationResult] with Fail-Open permissive values
+     */
+    fun batchModerationFallback(texts: List<String>, e: Exception): List<ModerationResult> {
+        logger.warn { "Batch moderation fallback triggered for ${texts.size} texts: ${e.message}" }
+        return texts.map { moderationFallback(it, e) }
+    }
+
+    /**
+     * Fallback for comment filtering when AI service is unavailable.
+     *
+     * Returns a permissive result that allows the comment:
+     * - isFiltered = false (comment is NOT filtered)
+     * - filterType = "fallback" (identifies this as a fallback response)
+     *
+     * @param content The comment content that was being filtered (unused in fallback)
+     * @param e The exception that triggered the fallback
+     * @return [FilterResult] with Fail-Open permissive values
+     */
+    fun filterFallback(content: String, e: Exception): FilterResult {
+        logger.warn { "Comment filter fallback triggered for content (length=${content.length}): ${e.message}" }
+        return FilterResult(
+            isFiltered = false,
+            filterType = "fallback",
+            reason = null,
+            ruleName = null
+        )
+    }
+
+    /**
+     * Fallback for news summarization when AI service is unavailable.
+     *
+     * Returns an empty summary with an error message:
+     * - summary = "" (empty, no summary available)
+     * - error = "AI service unavailable" (indicates the failure reason)
+     *
+     * @param text The news text that was being summarized (unused in fallback)
+     * @param method The summarization method (unused in fallback)
+     * @param e The exception that triggered the fallback
+     * @return [SummaryResult] with empty summary and error indicator
+     */
+    fun summaryFallback(text: String, method: String, e: Exception): SummaryResult {
+        logger.warn { "News summarizer fallback triggered for text (length=${text.length}): ${e.message}" }
+        return SummaryResult(
+            summary = "",
+            bullets = emptyList(),
+            keywords = emptyList(),
+            elapsedMs = null,
+            error = "AI service unavailable"
+        )
+    }
+}

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/external/ai/NoOpCommentFilterAdapter.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/external/ai/NoOpCommentFilterAdapter.kt
@@ -1,0 +1,44 @@
+package com.fanpulse.infrastructure.external.ai
+
+import com.fanpulse.domain.ai.FilterResult
+import com.fanpulse.domain.ai.port.CommentFilterPort
+import mu.KotlinLogging
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * No-Op implementation of [CommentFilterPort] used when the AI service is disabled.
+ *
+ * Active only when `fanpulse.ai-service.enabled=false`.
+ * When the AI service feature flag is turned off, this bean replaces [AiCommentFilterAdapter]
+ * and returns permissive (Fail-Open) results without making any HTTP calls.
+ *
+ * Fail-Open strategy:
+ * - [filterComment] → isFiltered=false, filterType="noop"
+ *
+ * @see AiCommentFilterAdapter for the real implementation
+ * @see CommentFilterPort for the port contract
+ */
+@Component
+@ConditionalOnProperty(name = ["fanpulse.ai-service.enabled"], havingValue = "false")
+class NoOpCommentFilterAdapter : CommentFilterPort {
+
+    /**
+     * Returns a permissive filter result without calling the AI service.
+     *
+     * @param content Comment content to filter (ignored)
+     * @return [FilterResult] with Fail-Open permissive values:
+     *   isFiltered=false, filterType="noop"
+     */
+    override fun filterComment(content: String): FilterResult {
+        logger.debug { "NoOp: filterComment called (AI service disabled), returning permissive result" }
+        return FilterResult(
+            isFiltered = false,
+            filterType = "noop",
+            reason = null,
+            ruleName = null
+        )
+    }
+}

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/external/ai/NoOpContentModerationAdapter.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/external/ai/NoOpContentModerationAdapter.kt
@@ -1,0 +1,71 @@
+package com.fanpulse.infrastructure.external.ai
+
+import com.fanpulse.domain.ai.ModerationResult
+import com.fanpulse.domain.ai.port.ContentModerationPort
+import mu.KotlinLogging
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * No-Op implementation of [ContentModerationPort] used when the AI service is disabled.
+ *
+ * Active only when `fanpulse.ai-service.enabled=false`.
+ * When the AI service feature flag is turned off, this bean replaces [AiModerationAdapter]
+ * and returns permissive (Fail-Open) results without making any HTTP calls.
+ *
+ * Fail-Open strategy:
+ * - [checkContent] → isFlagged=false, action="allow"
+ * - [batchCheck] → list of permissive results
+ *
+ * @see AiModerationAdapter for the real implementation
+ * @see ContentModerationPort for the port contract
+ */
+@Component
+@ConditionalOnProperty(name = ["fanpulse.ai-service.enabled"], havingValue = "false")
+class NoOpContentModerationAdapter : ContentModerationPort {
+
+    /**
+     * Returns a permissive moderation result without calling the AI service.
+     *
+     * @param text Text content to check (ignored)
+     * @return [ModerationResult] with Fail-Open permissive values:
+     *   isFlagged=false, action="allow", modelUsed="noop"
+     */
+    override fun checkContent(text: String): ModerationResult {
+        logger.debug { "NoOp: checkContent called (AI service disabled), returning permissive result" }
+        return ModerationResult(
+            isFlagged = false,
+            action = "allow",
+            highestCategory = null,
+            highestScore = null,
+            confidence = 0.0,
+            modelUsed = "noop",
+            processingTimeMs = null,
+            error = null
+        )
+    }
+
+    /**
+     * Returns a list of permissive moderation results without calling the AI service.
+     *
+     * @param texts List of text contents to check (ignored)
+     * @return List of [ModerationResult] with Fail-Open permissive values
+     */
+    override fun batchCheck(texts: List<String>): List<ModerationResult> {
+        logger.debug { "NoOp: batchCheck called for ${texts.size} texts (AI service disabled), returning permissive results" }
+        return texts.map {
+            ModerationResult(
+                isFlagged = false,
+                action = "allow",
+                highestCategory = null,
+                highestScore = null,
+                confidence = 0.0,
+                modelUsed = "noop",
+                processingTimeMs = null,
+                error = null
+            )
+        }
+    }
+}

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/external/ai/NoOpNewsSummarizerAdapter.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/external/ai/NoOpNewsSummarizerAdapter.kt
@@ -1,0 +1,46 @@
+package com.fanpulse.infrastructure.external.ai
+
+import com.fanpulse.domain.ai.SummaryResult
+import com.fanpulse.domain.ai.port.NewsSummarizerPort
+import mu.KotlinLogging
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * No-Op implementation of [NewsSummarizerPort] used when the AI service is disabled.
+ *
+ * Active only when `fanpulse.ai-service.enabled=false`.
+ * When the AI service feature flag is turned off, this bean replaces [AiNewsSummarizerAdapter]
+ * and returns an empty summary with an error indicator without making any HTTP calls.
+ *
+ * Fail-Open strategy:
+ * - [summarize] → summary="", error="AI service disabled"
+ *
+ * @see AiNewsSummarizerAdapter for the real implementation
+ * @see NewsSummarizerPort for the port contract
+ */
+@Component
+@ConditionalOnProperty(name = ["fanpulse.ai-service.enabled"], havingValue = "false")
+class NoOpNewsSummarizerAdapter : NewsSummarizerPort {
+
+    /**
+     * Returns an empty summary result without calling the AI service.
+     *
+     * @param text News text to summarize (ignored)
+     * @param method Summarization method (ignored)
+     * @return [SummaryResult] with empty summary and disabled indicator:
+     *   summary="", error="AI service disabled"
+     */
+    override fun summarize(text: String, method: String): SummaryResult {
+        logger.debug { "NoOp: summarize called (AI service disabled), returning empty result" }
+        return SummaryResult(
+            summary = "",
+            bullets = emptyList(),
+            keywords = emptyList(),
+            elapsedMs = null,
+            error = "AI service disabled"
+        )
+    }
+}

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/seed/SeedLoaderRunner.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/seed/SeedLoaderRunner.kt
@@ -19,6 +19,7 @@ import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.support.TransactionTemplate
 import java.io.File
 import java.time.Instant
+import java.time.ZoneOffset
 import kotlin.system.exitProcess
 
 private val logger = KotlinLogging.logger {}
@@ -97,7 +98,7 @@ class SeedLoaderRunner(
 
                     seed.description?.let { created.updateDescription(it) }
                     seed.profileImageUrl?.let { created.updateProfileImage(it) }
-                    seed.debutDate?.let { created.updateDebutDate(it) }
+                    seed.debutDate?.let { created.updateDebutDate(it.atZone(ZoneOffset.UTC).toLocalDate()) }
                     seed.active?.let { active -> if (active) created.activate() else created.deactivate() }
 
                     if (seed.isGroup && !seed.members.isNullOrEmpty()) {
@@ -116,7 +117,7 @@ class SeedLoaderRunner(
                     seed.agency?.let { existing.agency = it }
                     seed.description?.let { existing.updateDescription(it) }
                     seed.profileImageUrl?.let { existing.updateProfileImage(it) }
-                    seed.debutDate?.let { existing.updateDebutDate(it) }
+                    seed.debutDate?.let { existing.updateDebutDate(it.atZone(ZoneOffset.UTC).toLocalDate()) }
                     seed.active?.let { active -> if (active) existing.activate() else existing.deactivate() }
 
                     // NOTE: existing.isGroup is immutable (val). We cannot change it during upsert.

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -33,6 +33,17 @@ jwt:
   refresh-expiration: 604800000  # 7일 (밀리초)
 
 fanpulse:
+  ai-service:
+    # Feature Flag: set to false to disable AI service integration and use NoOp adapters (Fail-Open).
+    # true  → AiModerationAdapter / AiCommentFilterAdapter / AiNewsSummarizerAdapter (real HTTP calls)
+    # false → NoOpContentModerationAdapter / NoOpCommentFilterAdapter / NoOpNewsSummarizerAdapter (permissive no-op)
+    enabled: true
+    base-url: ${AI_SERVICE_URL:http://localhost:8001}
+    timeout:
+      connect: 3s
+      read: 5s
+      summarize-read: 30s
+
   seed:
     enabled: ${FANPULSE_SEED_ENABLED:false}
     dir: ${FANPULSE_SEED_DIR:seed}
@@ -72,6 +83,54 @@ fanpulse:
 resilience4j:
   circuitbreaker:
     instances:
+      # AI Content Moderation (moderation check + batch)
+      aiModeration:
+        registerHealthIndicator: true
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 10
+        failureRateThreshold: 60
+        waitDurationInOpenState: 30s
+        permittedNumberOfCallsInHalfOpenState: 3
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+        recordExceptions:
+          - java.io.IOException
+          - java.util.concurrent.TimeoutException
+          - org.springframework.web.reactive.function.client.WebClientResponseException
+          - com.fanpulse.infrastructure.external.ai.AiServiceException
+
+      # AI Comment Filter (separate circuit breaker for comment filtering)
+      aiCommentFilter:
+        registerHealthIndicator: true
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 10
+        failureRateThreshold: 60
+        waitDurationInOpenState: 30s
+        permittedNumberOfCallsInHalfOpenState: 3
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+        recordExceptions:
+          - java.io.IOException
+          - java.util.concurrent.TimeoutException
+          - org.springframework.web.reactive.function.client.WebClientResponseException
+          - com.fanpulse.infrastructure.external.ai.AiServiceException
+
+      # AI Summarizer (separate circuit breaker, longer wait for AI inference)
+      aiSummarizer:
+        registerHealthIndicator: true
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 10
+        minimumNumberOfCalls: 10
+        failureRateThreshold: 60
+        waitDurationInOpenState: 30s
+        permittedNumberOfCallsInHalfOpenState: 3
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+        recordExceptions:
+          - java.io.IOException
+          - java.util.concurrent.TimeoutException
+          - org.springframework.web.reactive.function.client.WebClientResponseException
+          - com.fanpulse.infrastructure.external.ai.AiServiceException
+
       youtubeOEmbed:
         registerHealthIndicator: true
         slidingWindowType: COUNT_BASED
@@ -107,9 +166,20 @@ resilience4j:
           - java.io.IOException
           - java.util.concurrent.TimeoutException
 
-  # P0-2: Retry 설정
+  # Retry 설정
   retry:
     instances:
+      # AI Service: shared retry for moderation, filter, summarizer
+      aiService:
+        maxAttempts: 2
+        waitDuration: 500ms
+        retryExceptions:
+          - java.io.IOException
+          - java.util.concurrent.TimeoutException
+          - org.springframework.web.reactive.function.client.WebClientResponseException$InternalServerError
+          - org.springframework.web.reactive.function.client.WebClientResponseException$ServiceUnavailable
+          - com.fanpulse.infrastructure.external.ai.AiServiceException
+
       ytdlp:
         maxAttempts: 3
         waitDuration: 2s
@@ -118,6 +188,16 @@ resilience4j:
         retryExceptions:
           - java.lang.IllegalStateException
           - java.io.IOException
+
+  # TimeLimiter 설정 (reactive WebClient에서는 .timeout() operator로 처리)
+  timelimiter:
+    instances:
+      aiModeration:
+        timeoutDuration: 5s
+      aiCommentFilter:
+        timeoutDuration: 5s
+      aiSummarizer:
+        timeoutDuration: 30s
 
 management:
   endpoints:

--- a/backend/src/test/kotlin/com/fanpulse/domain/ai/FilterResultTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/domain/ai/FilterResultTest.kt
@@ -1,0 +1,103 @@
+package com.fanpulse.domain.ai
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * FilterResult Value Object Tests
+ *
+ * Verifies that FilterResult is an immutable data class with correct field types and defaults.
+ */
+@DisplayName("FilterResult")
+class FilterResultTest {
+
+    @Nested
+    @DisplayName("기본 생성")
+    inner class Construction {
+
+        @Test
+        @DisplayName("필수 필드로 생성할 수 있다")
+        fun `should create with required fields`() {
+            val result = FilterResult(
+                isFiltered = false,
+                filterType = "LLM"
+            )
+
+            assertFalse(result.isFiltered)
+            assertEquals("LLM", result.filterType)
+        }
+
+        @Test
+        @DisplayName("선택 필드의 기본값은 null이다")
+        fun `should have null defaults for optional fields`() {
+            val result = FilterResult(
+                isFiltered = false,
+                filterType = "LLM"
+            )
+
+            assertNull(result.reason)
+            assertNull(result.ruleName)
+        }
+
+        @Test
+        @DisplayName("모든 필드를 명시적으로 설정할 수 있다")
+        fun `should create with all fields`() {
+            val result = FilterResult(
+                isFiltered = true,
+                filterType = "rule",
+                reason = "욕설 감지",
+                ruleName = "profanity_filter"
+            )
+
+            assertTrue(result.isFiltered)
+            assertEquals("rule", result.filterType)
+            assertEquals("욕설 감지", result.reason)
+            assertEquals("profanity_filter", result.ruleName)
+        }
+    }
+
+    @Nested
+    @DisplayName("filterType 값 검증")
+    inner class FilterTypeValues {
+
+        @Test
+        @DisplayName("filterType은 LLM, rule, fallback 중 하나일 수 있다")
+        fun `should accept LLM rule fallback filter type values`() {
+            val llm = FilterResult(false, "LLM")
+            val rule = FilterResult(true, "rule", reason = "스팸")
+            val fallback = FilterResult(false, "fallback")
+
+            assertEquals("LLM", llm.filterType)
+            assertEquals("rule", rule.filterType)
+            assertEquals("fallback", fallback.filterType)
+        }
+    }
+
+    @Nested
+    @DisplayName("data class 동작")
+    inner class DataClassBehavior {
+
+        @Test
+        @DisplayName("동일한 필드 값을 가지면 equal이다")
+        fun `should be equal when fields are equal`() {
+            val result1 = FilterResult(isFiltered = false, filterType = "LLM")
+            val result2 = FilterResult(isFiltered = false, filterType = "LLM")
+
+            assertEquals(result1, result2)
+        }
+
+        @Test
+        @DisplayName("copy()로 필드를 변경한 새 인스턴스를 만들 수 있다")
+        fun `should support copy with modified fields`() {
+            val original = FilterResult(isFiltered = false, filterType = "LLM")
+            val filtered = original.copy(isFiltered = true, reason = "욕설")
+
+            assertFalse(original.isFiltered)
+            assertTrue(filtered.isFiltered)
+            assertEquals("욕설", filtered.reason)
+            assertEquals(original.filterType, filtered.filterType)
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/fanpulse/domain/ai/ModerationResultTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/domain/ai/ModerationResultTest.kt
@@ -1,0 +1,148 @@
+package com.fanpulse.domain.ai
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * ModerationResult Value Object Tests
+ *
+ * Verifies that ModerationResult is an immutable data class with correct field types and defaults.
+ */
+@DisplayName("ModerationResult")
+class ModerationResultTest {
+
+    @Nested
+    @DisplayName("기본 생성")
+    inner class Construction {
+
+        @Test
+        @DisplayName("필수 필드로 생성할 수 있다")
+        fun `should create with required fields`() {
+            val result = ModerationResult(
+                isFlagged = false,
+                action = "allow",
+                confidence = 0.9,
+                modelUsed = "ko"
+            )
+
+            assertFalse(result.isFlagged)
+            assertEquals("allow", result.action)
+            assertEquals(0.9, result.confidence)
+            assertEquals("ko", result.modelUsed)
+        }
+
+        @Test
+        @DisplayName("선택 필드의 기본값은 null이다")
+        fun `should have null defaults for optional fields`() {
+            val result = ModerationResult(
+                isFlagged = false,
+                action = "allow",
+                confidence = 0.9,
+                modelUsed = "ko"
+            )
+
+            assertNull(result.highestCategory)
+            assertNull(result.highestScore)
+            assertNull(result.processingTimeMs)
+            assertNull(result.error)
+        }
+
+        @Test
+        @DisplayName("모든 필드를 명시적으로 설정할 수 있다")
+        fun `should create with all fields`() {
+            val result = ModerationResult(
+                isFlagged = true,
+                action = "block",
+                highestCategory = "hate",
+                highestScore = 0.95,
+                confidence = 0.98,
+                modelUsed = "ko",
+                processingTimeMs = 38L,
+                error = null
+            )
+
+            assertTrue(result.isFlagged)
+            assertEquals("block", result.action)
+            assertEquals("hate", result.highestCategory)
+            assertEquals(0.95, result.highestScore)
+            assertEquals(0.98, result.confidence)
+            assertEquals("ko", result.modelUsed)
+            assertEquals(38L, result.processingTimeMs)
+            assertNull(result.error)
+        }
+
+        @Test
+        @DisplayName("에러 필드를 설정할 수 있다")
+        fun `should set error field`() {
+            val result = ModerationResult(
+                isFlagged = false,
+                action = "allow",
+                confidence = 0.0,
+                modelUsed = "fallback",
+                error = "AI service unavailable"
+            )
+
+            assertEquals("AI service unavailable", result.error)
+        }
+    }
+
+    @Nested
+    @DisplayName("data class 동작")
+    inner class DataClassBehavior {
+
+        @Test
+        @DisplayName("동일한 필드 값을 가지면 equal이다")
+        fun `should be equal when fields are equal`() {
+            val result1 = ModerationResult(
+                isFlagged = false,
+                action = "allow",
+                confidence = 0.9,
+                modelUsed = "ko"
+            )
+            val result2 = ModerationResult(
+                isFlagged = false,
+                action = "allow",
+                confidence = 0.9,
+                modelUsed = "ko"
+            )
+
+            assertEquals(result1, result2)
+        }
+
+        @Test
+        @DisplayName("copy()로 필드를 변경한 새 인스턴스를 만들 수 있다")
+        fun `should support copy with modified fields`() {
+            val original = ModerationResult(
+                isFlagged = false,
+                action = "allow",
+                confidence = 0.9,
+                modelUsed = "ko"
+            )
+            val flagged = original.copy(isFlagged = true, action = "block")
+
+            assertFalse(original.isFlagged)
+            assertTrue(flagged.isFlagged)
+            assertEquals("block", flagged.action)
+            assertEquals(original.confidence, flagged.confidence)
+        }
+    }
+
+    @Nested
+    @DisplayName("action 값 검증")
+    inner class ActionValues {
+
+        @Test
+        @DisplayName("action은 allow, flag, block 중 하나일 수 있다")
+        fun `should accept allow flag block action values`() {
+            val allow = ModerationResult(false, "allow", confidence = 0.9, modelUsed = "ko")
+            val flag = ModerationResult(true, "flag", confidence = 0.7, modelUsed = "ko")
+            val block = ModerationResult(true, "block", confidence = 0.95, modelUsed = "ko")
+
+            assertEquals("allow", allow.action)
+            assertEquals("flag", flag.action)
+            assertEquals("block", block.action)
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/fanpulse/domain/ai/SummaryResultTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/domain/ai/SummaryResultTest.kt
@@ -1,0 +1,134 @@
+package com.fanpulse.domain.ai
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * SummaryResult Value Object Tests
+ *
+ * Verifies that SummaryResult is an immutable data class with correct field types and defaults.
+ */
+@DisplayName("SummaryResult")
+class SummaryResultTest {
+
+    @Nested
+    @DisplayName("기본 생성")
+    inner class Construction {
+
+        @Test
+        @DisplayName("필수 필드(summary)만으로 생성할 수 있다")
+        fun `should create with required summary field`() {
+            val result = SummaryResult(summary = "뉴스 요약 결과입니다.")
+
+            assertEquals("뉴스 요약 결과입니다.", result.summary)
+        }
+
+        @Test
+        @DisplayName("선택 필드의 기본값이 올바르다")
+        fun `should have correct defaults for optional fields`() {
+            val result = SummaryResult(summary = "요약")
+
+            assertEquals(emptyList<String>(), result.bullets)
+            assertEquals(emptyList<String>(), result.keywords)
+            assertNull(result.elapsedMs)
+            assertNull(result.error)
+        }
+
+        @Test
+        @DisplayName("모든 필드를 명시적으로 설정할 수 있다")
+        fun `should create with all fields`() {
+            val result = SummaryResult(
+                summary = "핵심 요약",
+                bullets = listOf("포인트 1", "포인트 2"),
+                keywords = listOf("키워드1", "키워드2"),
+                elapsedMs = 125L,
+                error = null
+            )
+
+            assertEquals("핵심 요약", result.summary)
+            assertEquals(listOf("포인트 1", "포인트 2"), result.bullets)
+            assertEquals(listOf("키워드1", "키워드2"), result.keywords)
+            assertEquals(125L, result.elapsedMs)
+            assertNull(result.error)
+        }
+
+        @Test
+        @DisplayName("에러 상태로 생성할 수 있다")
+        fun `should create with error state`() {
+            val result = SummaryResult(
+                summary = "",
+                error = "AI service unavailable"
+            )
+
+            assertEquals("", result.summary)
+            assertEquals("AI service unavailable", result.error)
+        }
+    }
+
+    @Nested
+    @DisplayName("data class 동작")
+    inner class DataClassBehavior {
+
+        @Test
+        @DisplayName("동일한 필드 값을 가지면 equal이다")
+        fun `should be equal when fields are equal`() {
+            val result1 = SummaryResult(
+                summary = "요약",
+                bullets = listOf("포인트1"),
+                keywords = listOf("키워드1")
+            )
+            val result2 = SummaryResult(
+                summary = "요약",
+                bullets = listOf("포인트1"),
+                keywords = listOf("키워드1")
+            )
+
+            assertEquals(result1, result2)
+        }
+
+        @Test
+        @DisplayName("copy()로 필드를 변경한 새 인스턴스를 만들 수 있다")
+        fun `should support copy with modified fields`() {
+            val original = SummaryResult(summary = "원본 요약")
+            val updated = original.copy(
+                summary = "수정된 요약",
+                elapsedMs = 200L
+            )
+
+            assertEquals("원본 요약", original.summary)
+            assertEquals("수정된 요약", updated.summary)
+            assertEquals(200L, updated.elapsedMs)
+            assertEquals(original.bullets, updated.bullets)
+        }
+    }
+
+    @Nested
+    @DisplayName("컬렉션 필드 검증")
+    inner class CollectionFields {
+
+        @Test
+        @DisplayName("bullets 리스트가 비어 있을 수 있다")
+        fun `should support empty bullets list`() {
+            val result = SummaryResult(summary = "요약", bullets = emptyList())
+            assertTrue(result.bullets.isEmpty())
+        }
+
+        @Test
+        @DisplayName("keywords 리스트가 비어 있을 수 있다")
+        fun `should support empty keywords list`() {
+            val result = SummaryResult(summary = "요약", keywords = emptyList())
+            assertTrue(result.keywords.isEmpty())
+        }
+
+        @Test
+        @DisplayName("여러 bullets를 가질 수 있다")
+        fun `should support multiple bullets`() {
+            val bullets = listOf("핵심 1", "핵심 2", "핵심 3")
+            val result = SummaryResult(summary = "요약", bullets = bullets)
+            assertEquals(3, result.bullets.size)
+            assertEquals("핵심 2", result.bullets[1])
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/fanpulse/domain/ai/port/CommentFilterPortTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/domain/ai/port/CommentFilterPortTest.kt
@@ -1,0 +1,117 @@
+package com.fanpulse.domain.ai.port
+
+import com.fanpulse.domain.ai.FilterResult
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * CommentFilterPort Interface Tests
+ *
+ * Verifies that CommentFilterPort can be mocked and its contract is correct.
+ * Tests follow TDD RED phase - verifying interface contract via MockK.
+ */
+@DisplayName("CommentFilterPort")
+class CommentFilterPortTest {
+
+    private lateinit var commentFilterPort: CommentFilterPort
+
+    @BeforeEach
+    fun setUp() {
+        commentFilterPort = mockk()
+    }
+
+    @Nested
+    @DisplayName("filterComment(content)")
+    inner class FilterComment {
+
+        @Test
+        @DisplayName("댓글 내용을 필터링하여 FilterResult를 반환한다")
+        fun `should return FilterResult for given comment content`() {
+            val content = "일반적인 댓글입니다."
+            val expected = FilterResult(
+                isFiltered = false,
+                filterType = "LLM"
+            )
+            every { commentFilterPort.filterComment(content) } returns expected
+
+            val result = commentFilterPort.filterComment(content)
+
+            assertEquals(expected, result)
+            verify(exactly = 1) { commentFilterPort.filterComment(content) }
+        }
+
+        @Test
+        @DisplayName("필터링된 댓글에 대해 isFiltered=true인 결과를 반환한다")
+        fun `should return filtered result for inappropriate comment`() {
+            val inappropriateContent = "부적절한 댓글"
+            val expected = FilterResult(
+                isFiltered = true,
+                filterType = "rule",
+                reason = "욕설 감지",
+                ruleName = "profanity_filter"
+            )
+            every { commentFilterPort.filterComment(inappropriateContent) } returns expected
+
+            val result = commentFilterPort.filterComment(inappropriateContent)
+
+            assertTrue(result.isFiltered)
+            assertEquals("rule", result.filterType)
+            assertEquals("욕설 감지", result.reason)
+            assertEquals("profanity_filter", result.ruleName)
+        }
+
+        @Test
+        @DisplayName("LLM 필터링 결과를 반환할 수 있다")
+        fun `should return LLM filter type result`() {
+            val content = "댓글 내용"
+            val expected = FilterResult(
+                isFiltered = false,
+                filterType = "LLM",
+                reason = null
+            )
+            every { commentFilterPort.filterComment(content) } returns expected
+
+            val result = commentFilterPort.filterComment(content)
+
+            assertEquals("LLM", result.filterType)
+            assertNull(result.reason)
+        }
+
+        @Test
+        @DisplayName("fallback 필터링 결과를 반환할 수 있다")
+        fun `should return fallback filter type result`() {
+            val content = "댓글"
+            val expected = FilterResult(
+                isFiltered = false,
+                filterType = "fallback"
+            )
+            every { commentFilterPort.filterComment(content) } returns expected
+
+            val result = commentFilterPort.filterComment(content)
+
+            assertEquals("fallback", result.filterType)
+            assertFalse(result.isFiltered)
+        }
+
+        @Test
+        @DisplayName("빈 댓글 내용도 처리할 수 있다")
+        fun `should handle empty comment content`() {
+            val emptyContent = ""
+            val expected = FilterResult(
+                isFiltered = false,
+                filterType = "LLM"
+            )
+            every { commentFilterPort.filterComment(emptyContent) } returns expected
+
+            val result = commentFilterPort.filterComment(emptyContent)
+
+            assertFalse(result.isFiltered)
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/fanpulse/domain/ai/port/ContentModerationPortTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/domain/ai/port/ContentModerationPortTest.kt
@@ -1,0 +1,136 @@
+package com.fanpulse.domain.ai.port
+
+import com.fanpulse.domain.ai.ModerationResult
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * ContentModerationPort Interface Tests
+ *
+ * Verifies that ContentModerationPort can be mocked and its contract is correct.
+ * Tests are written using MockK following TDD RED phase - these tests verify the interface contract.
+ */
+@DisplayName("ContentModerationPort")
+class ContentModerationPortTest {
+
+    private lateinit var contentModerationPort: ContentModerationPort
+
+    @BeforeEach
+    fun setUp() {
+        contentModerationPort = mockk()
+    }
+
+    @Nested
+    @DisplayName("checkContent(text)")
+    inner class CheckContent {
+
+        @Test
+        @DisplayName("텍스트를 검사하여 ModerationResult를 반환한다")
+        fun `should return ModerationResult for given text`() {
+            val text = "검사할 텍스트"
+            val expected = ModerationResult(
+                isFlagged = false,
+                action = "allow",
+                confidence = 0.9,
+                modelUsed = "ko"
+            )
+            every { contentModerationPort.checkContent(text) } returns expected
+
+            val result = contentModerationPort.checkContent(text)
+
+            assertEquals(expected, result)
+            verify(exactly = 1) { contentModerationPort.checkContent(text) }
+        }
+
+        @Test
+        @DisplayName("유해 콘텐츠를 감지하면 isFlagged=true인 결과를 반환한다")
+        fun `should return flagged result for harmful content`() {
+            val harmfulText = "유해한 텍스트"
+            val expected = ModerationResult(
+                isFlagged = true,
+                action = "block",
+                highestCategory = "hate",
+                highestScore = 0.95,
+                confidence = 0.98,
+                modelUsed = "ko"
+            )
+            every { contentModerationPort.checkContent(harmfulText) } returns expected
+
+            val result = contentModerationPort.checkContent(harmfulText)
+
+            assertTrue(result.isFlagged)
+            assertEquals("block", result.action)
+        }
+
+        @Test
+        @DisplayName("빈 텍스트에 대해서도 ModerationResult를 반환한다")
+        fun `should return ModerationResult for empty text`() {
+            val emptyText = ""
+            val expected = ModerationResult(
+                isFlagged = false,
+                action = "allow",
+                confidence = 1.0,
+                modelUsed = "ko"
+            )
+            every { contentModerationPort.checkContent(emptyText) } returns expected
+
+            val result = contentModerationPort.checkContent(emptyText)
+
+            assertFalse(result.isFlagged)
+        }
+    }
+
+    @Nested
+    @DisplayName("batchCheck(texts)")
+    inner class BatchCheck {
+
+        @Test
+        @DisplayName("여러 텍스트를 일괄 검사하여 List<ModerationResult>를 반환한다")
+        fun `should return list of ModerationResult for batch texts`() {
+            val texts = listOf("텍스트1", "텍스트2", "텍스트3")
+            val expected = listOf(
+                ModerationResult(false, "allow", confidence = 0.9, modelUsed = "ko"),
+                ModerationResult(true, "flag", confidence = 0.7, modelUsed = "ko"),
+                ModerationResult(false, "allow", confidence = 0.95, modelUsed = "ko")
+            )
+            every { contentModerationPort.batchCheck(texts) } returns expected
+
+            val results = contentModerationPort.batchCheck(texts)
+
+            assertEquals(3, results.size)
+            assertEquals(expected, results)
+            verify(exactly = 1) { contentModerationPort.batchCheck(texts) }
+        }
+
+        @Test
+        @DisplayName("빈 리스트를 입력하면 빈 리스트를 반환한다")
+        fun `should return empty list for empty input`() {
+            val emptyList = emptyList<String>()
+            every { contentModerationPort.batchCheck(emptyList) } returns emptyList()
+
+            val results = contentModerationPort.batchCheck(emptyList)
+
+            assertTrue(results.isEmpty())
+        }
+
+        @Test
+        @DisplayName("배치 결과의 각 항목이 올바른 타입이다")
+        fun `should return correct type for each batch result`() {
+            val texts = listOf("텍스트1")
+            val expected = listOf(
+                ModerationResult(false, "allow", confidence = 0.9, modelUsed = "ko")
+            )
+            every { contentModerationPort.batchCheck(texts) } returns expected
+
+            val results = contentModerationPort.batchCheck(texts)
+
+            assertTrue(results.all { it is ModerationResult })
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/fanpulse/domain/ai/port/NewsSummarizerPortTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/domain/ai/port/NewsSummarizerPortTest.kt
@@ -1,0 +1,123 @@
+package com.fanpulse.domain.ai.port
+
+import com.fanpulse.domain.ai.SummaryResult
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * NewsSummarizerPort Interface Tests
+ *
+ * Verifies that NewsSummarizerPort can be mocked and its contract is correct.
+ * Tests follow TDD RED phase - verifying interface contract via MockK.
+ */
+@DisplayName("NewsSummarizerPort")
+class NewsSummarizerPortTest {
+
+    private lateinit var newsSummarizerPort: NewsSummarizerPort
+
+    @BeforeEach
+    fun setUp() {
+        newsSummarizerPort = mockk()
+    }
+
+    @Nested
+    @DisplayName("summarize(text, method)")
+    inner class Summarize {
+
+        @Test
+        @DisplayName("텍스트와 요약 방식을 받아 SummaryResult를 반환한다")
+        fun `should return SummaryResult for given text and method`() {
+            val text = "요약할 뉴스 텍스트입니다. 매우 긴 기사 내용..."
+            val method = "ai"
+            val expected = SummaryResult(
+                summary = "핵심 요약 결과",
+                bullets = listOf("핵심 포인트 1"),
+                keywords = listOf("키워드1"),
+                elapsedMs = 125L
+            )
+            every { newsSummarizerPort.summarize(text, method) } returns expected
+
+            val result = newsSummarizerPort.summarize(text, method)
+
+            assertEquals(expected, result)
+            verify(exactly = 1) { newsSummarizerPort.summarize(text, method) }
+        }
+
+        @Test
+        @DisplayName("AI 요약 방식으로 요약할 수 있다")
+        fun `should summarize with ai method`() {
+            val text = "뉴스 텍스트"
+            val method = "ai"
+            val expected = SummaryResult(
+                summary = "AI 요약 결과",
+                bullets = listOf("포인트 1", "포인트 2"),
+                keywords = listOf("키워드1", "키워드2"),
+                elapsedMs = 200L
+            )
+            every { newsSummarizerPort.summarize(text, method) } returns expected
+
+            val result = newsSummarizerPort.summarize(text, method)
+
+            assertEquals("AI 요약 결과", result.summary)
+            assertEquals(2, result.bullets.size)
+            assertEquals(2, result.keywords.size)
+        }
+
+        @Test
+        @DisplayName("extractive 요약 방식으로 요약할 수 있다")
+        fun `should summarize with extractive method`() {
+            val text = "뉴스 텍스트"
+            val method = "extractive"
+            val expected = SummaryResult(
+                summary = "추출 요약 결과",
+                elapsedMs = 50L
+            )
+            every { newsSummarizerPort.summarize(text, method) } returns expected
+
+            val result = newsSummarizerPort.summarize(text, method)
+
+            assertEquals("추출 요약 결과", result.summary)
+        }
+
+        @Test
+        @DisplayName("에러 발생 시 error 필드가 설정된 SummaryResult를 반환한다")
+        fun `should return SummaryResult with error when AI fails`() {
+            val text = "뉴스 텍스트"
+            val method = "ai"
+            val expected = SummaryResult(
+                summary = "",
+                error = "AI service unavailable"
+            )
+            every { newsSummarizerPort.summarize(text, method) } returns expected
+
+            val result = newsSummarizerPort.summarize(text, method)
+
+            assertEquals("", result.summary)
+            assertEquals("AI service unavailable", result.error)
+        }
+
+        @Test
+        @DisplayName("bullets와 keywords 없이도 SummaryResult를 반환할 수 있다")
+        fun `should return SummaryResult without bullets and keywords`() {
+            val text = "간단한 뉴스"
+            val method = "simple"
+            val expected = SummaryResult(
+                summary = "간단한 요약",
+                bullets = emptyList(),
+                keywords = emptyList()
+            )
+            every { newsSummarizerPort.summarize(text, method) } returns expected
+
+            val result = newsSummarizerPort.summarize(text, method)
+
+            assertTrue(result.bullets.isEmpty())
+            assertTrue(result.keywords.isEmpty())
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/fanpulse/infrastructure/external/ai/AbstractAiServiceWireMockTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/infrastructure/external/ai/AbstractAiServiceWireMockTest.kt
@@ -1,0 +1,60 @@
+package com.fanpulse.infrastructure.external.ai
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.http.codec.json.Jackson2JsonDecoder
+import org.springframework.http.codec.json.Jackson2JsonEncoder
+import org.springframework.web.reactive.function.client.ExchangeStrategies
+import org.springframework.web.reactive.function.client.WebClient
+
+/**
+ * Base class for WireMock-based integration tests of AI service adapters.
+ *
+ * Provides:
+ * - [wireMockServer]: dynamic-port WireMock instance (started/stopped per test)
+ * - [webClient]: WebClient configured with snake_case ObjectMapper
+ * - [fallback]: shared [AiServiceFallback] instance
+ *
+ * Subclasses create their own adapter(s) in a separate @BeforeEach method,
+ * which JUnit5 executes after this base class's [setUpWireMock].
+ */
+abstract class AbstractAiServiceWireMockTest {
+
+    protected lateinit var wireMockServer: WireMockServer
+    protected lateinit var webClient: WebClient
+    protected lateinit var fallback: AiServiceFallback
+
+    @BeforeEach
+    fun setUpWireMock() {
+        wireMockServer = WireMockServer(wireMockConfig().dynamicPort())
+        wireMockServer.start()
+
+        val objectMapper = ObjectMapper()
+            .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+            .registerKotlinModule()
+
+        val strategies = ExchangeStrategies.builder()
+            .codecs { configurer ->
+                configurer.defaultCodecs().jackson2JsonDecoder(Jackson2JsonDecoder(objectMapper))
+                configurer.defaultCodecs().jackson2JsonEncoder(Jackson2JsonEncoder(objectMapper))
+            }
+            .build()
+
+        webClient = WebClient.builder()
+            .baseUrl("http://localhost:${wireMockServer.port()}")
+            .exchangeStrategies(strategies)
+            .build()
+
+        fallback = AiServiceFallback()
+    }
+
+    @AfterEach
+    fun tearDownWireMock() {
+        wireMockServer.stop()
+    }
+}

--- a/backend/src/test/kotlin/com/fanpulse/infrastructure/external/ai/AiCommentFilterAdapterTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/infrastructure/external/ai/AiCommentFilterAdapterTest.kt
@@ -1,0 +1,187 @@
+package com.fanpulse.infrastructure.external.ai
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.*
+
+/**
+ * WireMock-based integration tests for AiCommentFilterAdapter.
+ *
+ * Tests verify:
+ * - POST /api/comments/filter/test returns FilterResult
+ * - snake_case (Django) -> camelCase (Kotlin) JSON mapping
+ * - Fail-Open behavior on error
+ */
+@DisplayName("AiCommentFilterAdapter")
+class AiCommentFilterAdapterTest : AbstractAiServiceWireMockTest() {
+
+    private lateinit var adapter: AiCommentFilterAdapter
+
+    @BeforeEach
+    fun setUp() {
+        adapter = AiCommentFilterAdapter(webClient, fallback)
+    }
+
+    @Nested
+    @DisplayName("filterComment")
+    inner class FilterComment {
+
+        @Test
+        @DisplayName("should return FilterResult with isFiltered=false for clean comment")
+        fun shouldReturnAllowResultForCleanComment() {
+            // given
+            val content = "정말 멋진 무대였습니다! 앞으로도 응원할게요"
+            val responseJson = """
+                {
+                    "is_filtered": false,
+                    "action": null,
+                    "rule_id": null,
+                    "rule_name": null,
+                    "filter_type": "LLM",
+                    "matched_pattern": null,
+                    "reason": null
+                }
+            """.trimIndent()
+
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/comments/filter/test"))
+                    .withHeader("Content-Type", containing("application/json"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(responseJson)
+                    )
+            )
+
+            // when
+            val result = adapter.filterComment(content)
+
+            // then
+            assertFalse(result.isFiltered)
+            assertEquals("LLM", result.filterType)
+            assertNull(result.reason)
+            assertNull(result.ruleName)
+        }
+
+        @Test
+        @DisplayName("should return FilterResult with isFiltered=true for spam comment")
+        fun shouldReturnFilteredResultForSpamComment() {
+            // given
+            val content = "광고 스팸 메시지 클릭하세요 http://spam.link"
+            val responseJson = """
+                {
+                    "is_filtered": true,
+                    "action": "block",
+                    "rule_id": 5,
+                    "rule_name": "spam_url_filter",
+                    "filter_type": "rule",
+                    "matched_pattern": "http[s]?://",
+                    "reason": "URL 포함 스팸으로 판단"
+                }
+            """.trimIndent()
+
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/comments/filter/test"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(responseJson)
+                    )
+            )
+
+            // when
+            val result = adapter.filterComment(content)
+
+            // then
+            assertTrue(result.isFiltered)
+            assertEquals("rule", result.filterType)
+            assertEquals("URL 포함 스팸으로 판단", result.reason)
+            assertEquals("spam_url_filter", result.ruleName)
+        }
+
+        @Test
+        @DisplayName("should correctly map snake_case JSON fields to camelCase Kotlin properties")
+        fun shouldMapSnakeCaseFieldsToCamelCase() {
+            // given
+            val responseJson = """
+                {
+                    "is_filtered": true,
+                    "action": "flag",
+                    "rule_id": 3,
+                    "rule_name": "profanity_rule",
+                    "filter_type": "LLM",
+                    "matched_pattern": "욕설 패턴",
+                    "reason": "욕설 감지"
+                }
+            """.trimIndent()
+
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/comments/filter/test"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(responseJson)
+                    )
+            )
+
+            // when
+            val result = adapter.filterComment("욕설 댓글")
+
+            // then - verify snake_case -> camelCase mapping
+            assertTrue(result.isFiltered)          // is_filtered -> isFiltered
+            assertEquals("LLM", result.filterType) // filter_type -> filterType
+            assertEquals("욕설 감지", result.reason)  // reason -> reason
+            assertEquals("profanity_rule", result.ruleName) // rule_name -> ruleName
+        }
+
+        @Test
+        @DisplayName("should send correct request body with content field")
+        fun shouldSendCorrectRequestBody() {
+            // given
+            val content = "테스트 댓글 내용"
+
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/comments/filter/test"))
+                    .withHeader("Content-Type", containing("application/json"))
+                    .withRequestBody(containing("content"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""{"is_filtered": false, "action": null, "rule_id": null, "rule_name": null, "filter_type": "LLM", "matched_pattern": null, "reason": null}""")
+                    )
+            )
+
+            // when
+            adapter.filterComment(content)
+
+            // then - verify correct endpoint was called
+            wireMockServer.verify(
+                postRequestedFor(urlEqualTo("/api/comments/filter/test"))
+                    .withHeader("Content-Type", containing("application/json"))
+            )
+        }
+
+        @Test
+        @DisplayName("should throw exception when Django API returns 500 error")
+        fun shouldThrowExceptionOnServerError() {
+            // given
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/comments/filter/test"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(500)
+                            .withBody("Internal Server Error")
+                    )
+            )
+
+            // when / then
+            assertThrows<Exception> {
+                adapter.filterComment("테스트 댓글")
+            }
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/fanpulse/infrastructure/external/ai/AiFeatureFlagTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/infrastructure/external/ai/AiFeatureFlagTest.kt
@@ -1,0 +1,350 @@
+package com.fanpulse.infrastructure.external.ai
+
+import com.fanpulse.domain.ai.port.CommentFilterPort
+import com.fanpulse.domain.ai.port.ContentModerationPort
+import com.fanpulse.domain.ai.port.NewsSummarizerPort
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.NoSuchBeanDefinitionException
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.mock.env.MockEnvironment
+import org.springframework.web.reactive.function.client.WebClient
+
+/**
+ * Feature Flag tests for `fanpulse.ai-service.enabled`.
+ *
+ * Verifies that:
+ * - When `enabled=true` (default): real Adapter beans (Ai*Adapter) are registered
+ * - When `enabled=false`: NoOp beans (NoOp*Adapter) are registered
+ * - Exactly one implementation per port in each configuration (no bean conflicts)
+ *
+ * Uses a lightweight [AnnotationConfigApplicationContext] with a mock WebClient
+ * to avoid requiring a full Spring Boot context (which needs PostgreSQL).
+ */
+@DisplayName("AI Feature Flag - Bean wiring based on fanpulse.ai-service.enabled")
+class AiFeatureFlagTest {
+
+    private lateinit var context: AnnotationConfigApplicationContext
+
+    @AfterEach
+    fun tearDown() {
+        if (::context.isInitialized) {
+            context.close()
+        }
+    }
+
+    // =========================================================================
+    // Helper: build a minimal Spring context with the given property value
+    // =========================================================================
+
+    /**
+     * Creates a minimal [AnnotationConfigApplicationContext] that includes:
+     * - [AiServiceConfig]: bean factory for WebClient/ObjectMapper
+     * - Real adapters: [AiModerationAdapter], [AiCommentFilterAdapter], [AiNewsSummarizerAdapter]
+     * - NoOp adapters: [NoOpContentModerationAdapter], [NoOpCommentFilterAdapter], [NoOpNewsSummarizerAdapter]
+     * - [AiServiceFallback]: required by the real adapters
+     * - [MockWebClientConfig]: provides a stub WebClient so adapters can be constructed
+     *
+     * @param aiServiceEnabled value for `fanpulse.ai-service.enabled`
+     */
+    private fun buildContext(aiServiceEnabled: Boolean): AnnotationConfigApplicationContext {
+        val env = MockEnvironment().apply {
+            setProperty("fanpulse.ai-service.enabled", aiServiceEnabled.toString())
+            setProperty("fanpulse.ai-service.base-url", "http://localhost:8001")
+            setProperty("fanpulse.ai-service.timeout.connect", "3s")
+            setProperty("fanpulse.ai-service.timeout.read", "5s")
+            setProperty("fanpulse.ai-service.timeout.summarize-read", "30s")
+        }
+
+        return AnnotationConfigApplicationContext().apply {
+            environment = env
+            // Register AiServiceProperties binding + bean configs
+            register(
+                AiServiceConfig::class.java,
+                AiServiceFallback::class.java,
+                // Real adapters (active when enabled=true)
+                AiModerationAdapter::class.java,
+                AiCommentFilterAdapter::class.java,
+                AiNewsSummarizerAdapter::class.java,
+                // NoOp adapters (active when enabled=false)
+                NoOpContentModerationAdapter::class.java,
+                NoOpCommentFilterAdapter::class.java,
+                NoOpNewsSummarizerAdapter::class.java
+            )
+            refresh()
+        }
+    }
+
+    // =========================================================================
+    // Scenario: enabled=true → Real Adapters registered
+    // =========================================================================
+
+    @Nested
+    @DisplayName("When fanpulse.ai-service.enabled=true")
+    inner class WhenEnabled {
+
+        @Test
+        @DisplayName("ContentModerationPort bean should be AiModerationAdapter")
+        fun contentModerationPortShouldBeRealAdapter() {
+            // given
+            context = buildContext(aiServiceEnabled = true)
+
+            // when
+            val bean = context.getBean(ContentModerationPort::class.java)
+
+            // then
+            assertNotNull(bean, "ContentModerationPort bean must exist when AI is enabled")
+            assertInstanceOf(
+                AiModerationAdapter::class.java,
+                bean,
+                "ContentModerationPort should be AiModerationAdapter when enabled=true"
+            )
+            assertFalse(
+                bean is NoOpContentModerationAdapter,
+                "NoOp adapter must NOT be active when enabled=true"
+            )
+        }
+
+        @Test
+        @DisplayName("CommentFilterPort bean should be AiCommentFilterAdapter")
+        fun commentFilterPortShouldBeRealAdapter() {
+            // given
+            context = buildContext(aiServiceEnabled = true)
+
+            // when
+            val bean = context.getBean(CommentFilterPort::class.java)
+
+            // then
+            assertNotNull(bean)
+            assertInstanceOf(
+                AiCommentFilterAdapter::class.java,
+                bean,
+                "CommentFilterPort should be AiCommentFilterAdapter when enabled=true"
+            )
+            assertFalse(bean is NoOpCommentFilterAdapter)
+        }
+
+        @Test
+        @DisplayName("NewsSummarizerPort bean should be AiNewsSummarizerAdapter")
+        fun newsSummarizerPortShouldBeRealAdapter() {
+            // given
+            context = buildContext(aiServiceEnabled = true)
+
+            // when
+            val bean = context.getBean(NewsSummarizerPort::class.java)
+
+            // then
+            assertNotNull(bean)
+            assertInstanceOf(
+                AiNewsSummarizerAdapter::class.java,
+                bean,
+                "NewsSummarizerPort should be AiNewsSummarizerAdapter when enabled=true"
+            )
+            assertFalse(bean is NoOpNewsSummarizerAdapter)
+        }
+
+        @Test
+        @DisplayName("NoOp adapters should NOT be registered in the context")
+        fun noOpAdaptersShouldNotBeRegistered() {
+            // given
+            context = buildContext(aiServiceEnabled = true)
+
+            // then - NoOp beans should not exist
+            assertThrows(NoSuchBeanDefinitionException::class.java) {
+                context.getBean(NoOpContentModerationAdapter::class.java)
+            }
+            assertThrows(NoSuchBeanDefinitionException::class.java) {
+                context.getBean(NoOpCommentFilterAdapter::class.java)
+            }
+            assertThrows(NoSuchBeanDefinitionException::class.java) {
+                context.getBean(NoOpNewsSummarizerAdapter::class.java)
+            }
+        }
+    }
+
+    // =========================================================================
+    // Scenario: enabled=false → NoOp Adapters registered
+    // =========================================================================
+
+    @Nested
+    @DisplayName("When fanpulse.ai-service.enabled=false")
+    inner class WhenDisabled {
+
+        @Test
+        @DisplayName("ContentModerationPort bean should be NoOpContentModerationAdapter")
+        fun contentModerationPortShouldBeNoOpAdapter() {
+            // given
+            context = buildContext(aiServiceEnabled = false)
+
+            // when
+            val bean = context.getBean(ContentModerationPort::class.java)
+
+            // then
+            assertNotNull(bean, "ContentModerationPort bean must exist when AI is disabled")
+            assertInstanceOf(
+                NoOpContentModerationAdapter::class.java,
+                bean,
+                "ContentModerationPort should be NoOpContentModerationAdapter when enabled=false"
+            )
+            assertFalse(
+                bean is AiModerationAdapter,
+                "Real adapter must NOT be active when enabled=false"
+            )
+        }
+
+        @Test
+        @DisplayName("CommentFilterPort bean should be NoOpCommentFilterAdapter")
+        fun commentFilterPortShouldBeNoOpAdapter() {
+            // given
+            context = buildContext(aiServiceEnabled = false)
+
+            // when
+            val bean = context.getBean(CommentFilterPort::class.java)
+
+            // then
+            assertNotNull(bean)
+            assertInstanceOf(
+                NoOpCommentFilterAdapter::class.java,
+                bean,
+                "CommentFilterPort should be NoOpCommentFilterAdapter when enabled=false"
+            )
+            assertFalse(bean is AiCommentFilterAdapter)
+        }
+
+        @Test
+        @DisplayName("NewsSummarizerPort bean should be NoOpNewsSummarizerAdapter")
+        fun newsSummarizerPortShouldBeNoOpAdapter() {
+            // given
+            context = buildContext(aiServiceEnabled = false)
+
+            // when
+            val bean = context.getBean(NewsSummarizerPort::class.java)
+
+            // then
+            assertNotNull(bean)
+            assertInstanceOf(
+                NoOpNewsSummarizerAdapter::class.java,
+                bean,
+                "NewsSummarizerPort should be NoOpNewsSummarizerAdapter when enabled=false"
+            )
+            assertFalse(bean is AiNewsSummarizerAdapter)
+        }
+
+        @Test
+        @DisplayName("Real adapters should NOT be registered in the context")
+        fun realAdaptersShouldNotBeRegistered() {
+            // given
+            context = buildContext(aiServiceEnabled = false)
+
+            // then - Real AI adapter beans should not exist
+            assertThrows(NoSuchBeanDefinitionException::class.java) {
+                context.getBean(AiModerationAdapter::class.java)
+            }
+            assertThrows(NoSuchBeanDefinitionException::class.java) {
+                context.getBean(AiCommentFilterAdapter::class.java)
+            }
+            assertThrows(NoSuchBeanDefinitionException::class.java) {
+                context.getBean(AiNewsSummarizerAdapter::class.java)
+            }
+        }
+
+        @Test
+        @DisplayName("NoOp ContentModerationPort returns permissive result (Fail-Open)")
+        fun noOpContentModerationPortReturnsPermissiveResult() {
+            // given
+            context = buildContext(aiServiceEnabled = false)
+            val port = context.getBean(ContentModerationPort::class.java)
+
+            // when
+            val result = port.checkContent("테스트 텍스트")
+
+            // then
+            assertFalse(result.isFlagged, "NoOp: isFlagged must be false")
+            assertEquals("allow", result.action, "NoOp: action must be 'allow'")
+        }
+
+        @Test
+        @DisplayName("NoOp CommentFilterPort returns permissive result (Fail-Open)")
+        fun noOpCommentFilterPortReturnsPermissiveResult() {
+            // given
+            context = buildContext(aiServiceEnabled = false)
+            val port = context.getBean(CommentFilterPort::class.java)
+
+            // when
+            val result = port.filterComment("테스트 댓글")
+
+            // then
+            assertFalse(result.isFiltered, "NoOp: isFiltered must be false")
+        }
+
+        @Test
+        @DisplayName("NoOp NewsSummarizerPort returns empty summary with 'AI service disabled' error")
+        fun noOpNewsSummarizerPortReturnsEmptySummaryWithError() {
+            // given
+            context = buildContext(aiServiceEnabled = false)
+            val port = context.getBean(NewsSummarizerPort::class.java)
+
+            // when
+            val result = port.summarize("뉴스 기사 텍스트", "ai")
+
+            // then
+            assertEquals("", result.summary, "NoOp: summary must be empty")
+            assertEquals("AI service disabled", result.error, "NoOp: error must be 'AI service disabled'")
+        }
+    }
+
+    // =========================================================================
+    // Scenario: Default behavior (enabled=true by matchIfMissing)
+    // =========================================================================
+
+    @Nested
+    @DisplayName("Default behavior (no explicit enabled property)")
+    inner class DefaultBehavior {
+
+        @Test
+        @DisplayName("When enabled property is absent, real adapters should be active (matchIfMissing=true)")
+        fun realAdaptersShouldBeActiveByDefault() {
+            // given: context with no explicit ai-service.enabled property
+            val env = MockEnvironment().apply {
+                setProperty("fanpulse.ai-service.base-url", "http://localhost:8001")
+                setProperty("fanpulse.ai-service.timeout.connect", "3s")
+                setProperty("fanpulse.ai-service.timeout.read", "5s")
+                setProperty("fanpulse.ai-service.timeout.summarize-read", "30s")
+                // NOTE: fanpulse.ai-service.enabled is NOT set → defaults to true via matchIfMissing
+            }
+
+            context = AnnotationConfigApplicationContext().apply {
+                environment = env
+                register(
+                    AiServiceConfig::class.java,
+                    AiServiceFallback::class.java,
+                    AiModerationAdapter::class.java,
+                    AiCommentFilterAdapter::class.java,
+                    AiNewsSummarizerAdapter::class.java,
+                    NoOpContentModerationAdapter::class.java,
+                    NoOpCommentFilterAdapter::class.java,
+                    NoOpNewsSummarizerAdapter::class.java
+                )
+                refresh()
+            }
+
+            // then: real adapters are active by default
+            val contentPort = context.getBean(ContentModerationPort::class.java)
+            assertInstanceOf(
+                AiModerationAdapter::class.java,
+                contentPort,
+                "Default: ContentModerationPort should be AiModerationAdapter (matchIfMissing=true)"
+            )
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/fanpulse/infrastructure/external/ai/AiModerationAdapterTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/infrastructure/external/ai/AiModerationAdapterTest.kt
@@ -1,0 +1,279 @@
+package com.fanpulse.infrastructure.external.ai
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.*
+
+/**
+ * WireMock-based integration tests for AiModerationAdapter.
+ *
+ * Tests verify:
+ * - POST /api/moderation/check returns ModerationResult
+ * - POST /api/moderation/batch returns List<ModerationResult>
+ * - snake_case (Django) -> camelCase (Kotlin) JSON mapping
+ */
+@DisplayName("AiModerationAdapter")
+class AiModerationAdapterTest : AbstractAiServiceWireMockTest() {
+
+    private lateinit var adapter: AiModerationAdapter
+
+    @BeforeEach
+    fun setUp() {
+        adapter = AiModerationAdapter(webClient, fallback)
+    }
+
+    @Nested
+    @DisplayName("checkContent")
+    inner class CheckContent {
+
+        @Test
+        @DisplayName("should return ModerationResult with isFlagged=false for clean content")
+        fun shouldReturnAllowResultForCleanContent() {
+            // given
+            val text = "안녕하세요 팬분들!"
+            val responseJson = """
+                {
+                    "is_flagged": false,
+                    "action": "allow",
+                    "highest_category": null,
+                    "highest_score": 0.1,
+                    "confidence": 0.9,
+                    "model_used": "ko",
+                    "processing_time_ms": 38,
+                    "cached": false,
+                    "error": null
+                }
+            """.trimIndent()
+
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/moderation/check"))
+                    .withHeader("Content-Type", containing("application/json"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(responseJson)
+                    )
+            )
+
+            // when
+            val result = adapter.checkContent(text)
+
+            // then
+            assertFalse(result.isFlagged)
+            assertEquals("allow", result.action)
+            assertEquals(0.9, result.confidence)
+            assertEquals("ko", result.modelUsed)
+            assertNull(result.error)
+        }
+
+        @Test
+        @DisplayName("should return ModerationResult with isFlagged=true for harmful content")
+        fun shouldReturnFlaggedResultForHarmfulContent() {
+            // given
+            val text = "욕설이 포함된 텍스트"
+            val responseJson = """
+                {
+                    "is_flagged": true,
+                    "action": "block",
+                    "highest_category": "hate_speech",
+                    "highest_score": 0.87,
+                    "confidence": 0.92,
+                    "model_used": "ko",
+                    "processing_time_ms": 45,
+                    "cached": false,
+                    "error": null
+                }
+            """.trimIndent()
+
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/moderation/check"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(responseJson)
+                    )
+            )
+
+            // when
+            val result = adapter.checkContent(text)
+
+            // then
+            assertTrue(result.isFlagged)
+            assertEquals("block", result.action)
+            assertEquals("hate_speech", result.highestCategory)
+            assertEquals(0.87, result.highestScore)
+            assertEquals(0.92, result.confidence)
+        }
+
+        @Test
+        @DisplayName("should correctly map snake_case JSON fields to camelCase Kotlin properties")
+        fun shouldMapSnakeCaseFieldsToCamelCase() {
+            // given
+            val responseJson = """
+                {
+                    "is_flagged": false,
+                    "action": "allow",
+                    "highest_category": "mild_violence",
+                    "highest_score": 0.25,
+                    "confidence": 0.85,
+                    "model_used": "ko",
+                    "processing_time_ms": 52,
+                    "cached": true,
+                    "error": null
+                }
+            """.trimIndent()
+
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/moderation/check"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(responseJson)
+                    )
+            )
+
+            // when
+            val result = adapter.checkContent("테스트 텍스트")
+
+            // then - verify snake_case -> camelCase mapping
+            assertFalse(result.isFlagged)           // is_flagged -> isFlagged
+            assertEquals("mild_violence", result.highestCategory)  // highest_category -> highestCategory
+            assertEquals(0.25, result.highestScore)                // highest_score -> highestScore
+            assertEquals("ko", result.modelUsed)                   // model_used -> modelUsed
+            assertEquals(52L, result.processingTimeMs)             // processing_time_ms -> processingTimeMs
+        }
+
+        @Test
+        @DisplayName("should throw exception when Django API returns 500 error")
+        fun shouldThrowExceptionOnServerError() {
+            // given
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/moderation/check"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(500)
+                            .withBody("Internal Server Error")
+                    )
+            )
+
+            // when / then
+            assertThrows<Exception> {
+                adapter.checkContent("테스트")
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("batchCheck")
+    inner class BatchCheck {
+
+        @Test
+        @DisplayName("should return list of ModerationResults for batch input")
+        fun shouldReturnBatchModerationResults() {
+            // given
+            val texts = listOf("첫 번째 텍스트", "두 번째 텍스트", "세 번째 텍스트")
+            val responseJson = """
+                [
+                    {
+                        "is_flagged": false,
+                        "action": "allow",
+                        "highest_category": null,
+                        "highest_score": 0.05,
+                        "confidence": 0.95,
+                        "model_used": "ko",
+                        "processing_time_ms": 20,
+                        "cached": false,
+                        "error": null
+                    },
+                    {
+                        "is_flagged": true,
+                        "action": "flag",
+                        "highest_category": "spam",
+                        "highest_score": 0.72,
+                        "confidence": 0.80,
+                        "model_used": "ko",
+                        "processing_time_ms": 25,
+                        "cached": false,
+                        "error": null
+                    },
+                    {
+                        "is_flagged": false,
+                        "action": "allow",
+                        "highest_category": null,
+                        "highest_score": 0.03,
+                        "confidence": 0.97,
+                        "model_used": "ko",
+                        "processing_time_ms": 18,
+                        "cached": true,
+                        "error": null
+                    }
+                ]
+            """.trimIndent()
+
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/moderation/batch"))
+                    .withHeader("Content-Type", containing("application/json"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(responseJson)
+                    )
+            )
+
+            // when
+            val results = adapter.batchCheck(texts)
+
+            // then
+            assertEquals(3, results.size)
+            assertFalse(results[0].isFlagged)
+            assertEquals("allow", results[0].action)
+
+            assertTrue(results[1].isFlagged)
+            assertEquals("flag", results[1].action)
+            assertEquals("spam", results[1].highestCategory)
+
+            assertFalse(results[2].isFlagged)
+            assertEquals("ko", results[2].modelUsed)
+        }
+
+        @Test
+        @DisplayName("should return empty list for empty batch input")
+        fun shouldReturnEmptyListForEmptyBatch() {
+            // when
+            val results = adapter.batchCheck(emptyList())
+
+            // then
+            assertTrue(results.isEmpty())
+        }
+
+        @Test
+        @DisplayName("should send correct request body with texts array")
+        fun shouldSendCorrectRequestBody() {
+            // given
+            val texts = listOf("텍스트 하나", "텍스트 둘")
+
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/moderation/batch"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("[]")
+                    )
+            )
+
+            // when
+            adapter.batchCheck(texts)
+
+            // then - verify request was made to batch endpoint
+            wireMockServer.verify(
+                postRequestedFor(urlEqualTo("/api/moderation/batch"))
+                    .withHeader("Content-Type", containing("application/json"))
+            )
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/fanpulse/infrastructure/external/ai/AiNewsSummarizerAdapterTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/infrastructure/external/ai/AiNewsSummarizerAdapterTest.kt
@@ -1,0 +1,225 @@
+package com.fanpulse.infrastructure.external.ai
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.*
+
+/**
+ * WireMock-based integration tests for AiNewsSummarizerAdapter.
+ *
+ * Tests verify:
+ * - POST /api/summarize returns SummaryResult
+ * - snake_case (Django) -> camelCase (Kotlin) JSON mapping
+ * - Various summarize methods (ai, extractive)
+ * - Error handling
+ */
+@DisplayName("AiNewsSummarizerAdapter")
+class AiNewsSummarizerAdapterTest : AbstractAiServiceWireMockTest() {
+
+    private lateinit var adapter: AiNewsSummarizerAdapter
+
+    @BeforeEach
+    fun setUp() {
+        adapter = AiNewsSummarizerAdapter(webClient, fallback)
+    }
+
+    @Nested
+    @DisplayName("summarize")
+    inner class Summarize {
+
+        @Test
+        @DisplayName("should return SummaryResult with summary text and bullets")
+        fun shouldReturnSummaryResultWithAllFields() {
+            // given
+            val newsText = "BTS가 새 앨범을 발매했습니다. 이번 앨범은 팬들의 큰 호응을 받고 있습니다."
+            val responseJson = """
+                {
+                    "request_id": "550e8400-e29b-41d4-a716-446655440000",
+                    "summary": "BTS 새 앨범 발매, 팬들 큰 호응",
+                    "bullets": ["BTS 새 앨범 출시", "팬들 긍정적 반응"],
+                    "keywords": ["BTS", "앨범", "팬"],
+                    "elapsed_ms": 125
+                }
+            """.trimIndent()
+
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/summarize"))
+                    .withHeader("Content-Type", containing("application/json"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(responseJson)
+                    )
+            )
+
+            // when
+            val result = adapter.summarize(newsText, "ai")
+
+            // then
+            assertEquals("BTS 새 앨범 발매, 팬들 큰 호응", result.summary)
+            assertEquals(2, result.bullets.size)
+            assertEquals("BTS 새 앨범 출시", result.bullets[0])
+            assertEquals(3, result.keywords.size)
+            assertEquals(125L, result.elapsedMs)
+            assertNull(result.error)
+        }
+
+        @Test
+        @DisplayName("should correctly map snake_case JSON fields to camelCase Kotlin properties")
+        fun shouldMapSnakeCaseFieldsToCamelCase() {
+            // given
+            val responseJson = """
+                {
+                    "request_id": "test-uuid-1234",
+                    "summary": "요약된 뉴스 내용",
+                    "bullets": ["핵심 포인트 1", "핵심 포인트 2"],
+                    "keywords": ["키워드1", "키워드2"],
+                    "elapsed_ms": 200
+                }
+            """.trimIndent()
+
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/summarize"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(responseJson)
+                    )
+            )
+
+            // when
+            val result = adapter.summarize("뉴스 텍스트", "ai")
+
+            // then - verify snake_case -> camelCase mapping
+            assertEquals("요약된 뉴스 내용", result.summary)      // summary -> summary
+            assertEquals(200L, result.elapsedMs)                 // elapsed_ms -> elapsedMs
+            assertEquals(2, result.bullets.size)                 // bullets array mapping
+            assertEquals(2, result.keywords.size)                // keywords array mapping
+        }
+
+        @Test
+        @DisplayName("should send correct request body for AI summarize method")
+        fun shouldSendCorrectRequestBodyForAiMethod() {
+            // given
+            val newsText = "뉴스 본문 텍스트"
+
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/summarize"))
+                    .withHeader("Content-Type", containing("application/json"))
+                    .withRequestBody(containing("ai"))
+                    .withRequestBody(containing("text"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""{"request_id": "abc", "summary": "요약", "bullets": [], "keywords": [], "elapsed_ms": 50}""")
+                    )
+            )
+
+            // when
+            adapter.summarize(newsText, "ai")
+
+            // then - verify request was made to summarize endpoint
+            wireMockServer.verify(
+                postRequestedFor(urlEqualTo("/api/summarize"))
+                    .withHeader("Content-Type", containing("application/json"))
+            )
+        }
+
+        @Test
+        @DisplayName("should send correct request body for extractive summarize method")
+        fun shouldSendCorrectRequestBodyForExtractiveMethod() {
+            // given
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/summarize"))
+                    .withHeader("Content-Type", containing("application/json"))
+                    .withRequestBody(containing("extractive"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""{"request_id": "def", "summary": "추출 요약", "bullets": ["포인트"], "keywords": ["키워드"], "elapsed_ms": 30}""")
+                    )
+            )
+
+            // when
+            val result = adapter.summarize("뉴스 텍스트", "extractive")
+
+            // then
+            assertEquals("추출 요약", result.summary)
+        }
+
+        @Test
+        @DisplayName("should return SummaryResult with empty bullets and keywords when not provided")
+        fun shouldHandleEmptyBulletsAndKeywords() {
+            // given
+            val responseJson = """
+                {
+                    "request_id": "minimal-uuid",
+                    "summary": "최소 요약",
+                    "bullets": [],
+                    "keywords": [],
+                    "elapsed_ms": 10
+                }
+            """.trimIndent()
+
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/summarize"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(responseJson)
+                    )
+            )
+
+            // when
+            val result = adapter.summarize("짧은 뉴스", "ai")
+
+            // then
+            assertEquals("최소 요약", result.summary)
+            assertTrue(result.bullets.isEmpty())
+            assertTrue(result.keywords.isEmpty())
+        }
+
+        @Test
+        @DisplayName("should throw exception when Django API returns 500 error")
+        fun shouldThrowExceptionOnServerError() {
+            // given
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/summarize"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(500)
+                            .withBody("Internal Server Error")
+                    )
+            )
+
+            // when / then
+            assertThrows<Exception> {
+                adapter.summarize("뉴스 텍스트", "ai")
+            }
+        }
+
+        @Test
+        @DisplayName("should throw exception on 503 Service Unavailable")
+        fun shouldThrowExceptionOnServiceUnavailable() {
+            // given
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/summarize"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(503)
+                            .withBody("Service Unavailable")
+                    )
+            )
+
+            // when / then
+            assertThrows<Exception> {
+                adapter.summarize("뉴스 텍스트", "ai")
+            }
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/fanpulse/infrastructure/external/ai/AiServiceFallbackTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/infrastructure/external/ai/AiServiceFallbackTest.kt
@@ -1,0 +1,166 @@
+package com.fanpulse.infrastructure.external.ai
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [AiServiceFallback] Fail-Open strategy.
+ *
+ * Verifies that all fallback methods return permissive results that allow content
+ * to pass through when the Django AI Sidecar service is unavailable.
+ *
+ * Fail-Open contract:
+ * - moderationFallback: isFlagged=false, action="allow", modelUsed="fallback"
+ * - filterFallback: isFiltered=false, filterType="fallback"
+ * - summaryFallback: summary="", error="AI service unavailable"
+ */
+@DisplayName("AiServiceFallback - Fail-Open Strategy")
+class AiServiceFallbackTest {
+
+    private lateinit var fallback: AiServiceFallback
+    private val testException = RuntimeException("Connection refused: AI service down")
+
+    @BeforeEach
+    fun setUp() {
+        fallback = AiServiceFallback()
+    }
+
+    @Nested
+    @DisplayName("moderationFallback")
+    inner class ModerationFallback {
+
+        @Test
+        @DisplayName("should return isFlagged=false (Fail-Open: allow content)")
+        fun shouldReturnIsFlaggedFalse() {
+            val result = fallback.moderationFallback("test content", testException)
+            assertFalse(result.isFlagged, "Fail-Open: content must NOT be flagged on service failure")
+        }
+
+        @Test
+        @DisplayName("should return action='allow' (Fail-Open: do not block content)")
+        fun shouldReturnActionAllow() {
+            val result = fallback.moderationFallback("test content", testException)
+            assertEquals("allow", result.action, "Fail-Open: action must be 'allow' on service failure")
+        }
+
+        @Test
+        @DisplayName("should return modelUsed='fallback' (identifies fallback response)")
+        fun shouldReturnModelUsedFallback() {
+            val result = fallback.moderationFallback("test content", testException)
+            assertEquals("fallback", result.modelUsed, "modelUsed must be 'fallback' to identify fallback responses")
+        }
+
+        @Test
+        @DisplayName("should return null for highestCategory and highestScore")
+        fun shouldReturnNullForCategoryAndScore() {
+            val result = fallback.moderationFallback("test content", testException)
+            assertNull(result.highestCategory, "highestCategory must be null in fallback")
+            assertNull(result.highestScore, "highestScore must be null in fallback")
+        }
+
+        @Test
+        @DisplayName("should include error message from original exception")
+        fun shouldIncludeErrorMessage() {
+            val result = fallback.moderationFallback("test content", testException)
+            assertNotNull(result.error, "error field must not be null in fallback")
+            assertTrue(result.error!!.contains("Connection refused"), "error should contain original exception message")
+        }
+    }
+
+    @Nested
+    @DisplayName("batchModerationFallback")
+    inner class BatchModerationFallback {
+
+        @Test
+        @DisplayName("should return same number of results as input texts")
+        fun shouldReturnSameSizeAsList() {
+            val texts = listOf("text 1", "text 2", "text 3")
+            val results = fallback.batchModerationFallback(texts, testException)
+            assertEquals(texts.size, results.size, "Fallback must return one result per input text")
+        }
+
+        @Test
+        @DisplayName("should return all-allow results (Fail-Open for all items)")
+        fun shouldReturnAllAllowResults() {
+            val texts = listOf("content A", "content B")
+            val results = fallback.batchModerationFallback(texts, testException)
+            results.forEach { result ->
+                assertFalse(result.isFlagged, "All batch fallback results must be non-flagged")
+                assertEquals("allow", result.action, "All batch fallback results must have action='allow'")
+                assertEquals("fallback", result.modelUsed, "All batch fallback results must have modelUsed='fallback'")
+            }
+        }
+
+        @Test
+        @DisplayName("should return empty list for empty input (Fail-Open edge case)")
+        fun shouldReturnEmptyListForEmptyInput() {
+            val results = fallback.batchModerationFallback(emptyList(), testException)
+            assertTrue(results.isEmpty(), "Empty input must produce empty fallback results")
+        }
+    }
+
+    @Nested
+    @DisplayName("filterFallback")
+    inner class FilterFallback {
+
+        @Test
+        @DisplayName("should return isFiltered=false (Fail-Open: allow comment)")
+        fun shouldReturnIsFilteredFalse() {
+            val result = fallback.filterFallback("test comment", testException)
+            assertFalse(result.isFiltered, "Fail-Open: comment must NOT be filtered on service failure")
+        }
+
+        @Test
+        @DisplayName("should return filterType='fallback' (identifies fallback response)")
+        fun shouldReturnFilterTypeFallback() {
+            val result = fallback.filterFallback("test comment", testException)
+            assertEquals("fallback", result.filterType, "filterType must be 'fallback' to identify fallback responses")
+        }
+
+        @Test
+        @DisplayName("should return null for reason and ruleName")
+        fun shouldReturnNullForReasonAndRuleName() {
+            val result = fallback.filterFallback("test comment", testException)
+            assertNull(result.reason, "reason must be null in filter fallback")
+            assertNull(result.ruleName, "ruleName must be null in filter fallback")
+        }
+    }
+
+    @Nested
+    @DisplayName("summaryFallback")
+    inner class SummaryFallback {
+
+        @Test
+        @DisplayName("should return empty summary string")
+        fun shouldReturnEmptySummary() {
+            val result = fallback.summaryFallback("news article text", "ai", testException)
+            assertEquals("", result.summary, "Fallback summary must be empty string")
+        }
+
+        @Test
+        @DisplayName("should return error='AI service unavailable'")
+        fun shouldReturnErrorMessage() {
+            val result = fallback.summaryFallback("news article text", "ai", testException)
+            assertEquals("AI service unavailable", result.error, "Fallback error must be 'AI service unavailable'")
+        }
+
+        @Test
+        @DisplayName("should return empty bullets and keywords lists")
+        fun shouldReturnEmptyListsForBulletsAndKeywords() {
+            val result = fallback.summaryFallback("news article text", "ai", testException)
+            assertTrue(result.bullets.isEmpty(), "Fallback bullets must be empty")
+            assertTrue(result.keywords.isEmpty(), "Fallback keywords must be empty")
+        }
+
+        @Test
+        @DisplayName("should work for extractive method as well")
+        fun shouldWorkForExtractiveMethod() {
+            val result = fallback.summaryFallback("news article text", "extractive", testException)
+            assertEquals("", result.summary)
+            assertEquals("AI service unavailable", result.error)
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/fanpulse/infrastructure/external/ai/AiServiceResilienceTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/infrastructure/external/ai/AiServiceResilienceTest.kt
@@ -1,0 +1,508 @@
+package com.fanpulse.infrastructure.external.ai
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import io.github.resilience4j.retry.RetryConfig
+import io.github.resilience4j.retry.RetryRegistry
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.*
+import org.springframework.http.codec.json.Jackson2JsonDecoder
+import org.springframework.http.codec.json.Jackson2JsonEncoder
+import org.springframework.web.reactive.function.client.ExchangeStrategies
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import java.time.Duration
+
+/**
+ * Resilience4j integration tests for AI service adapters using WireMock.
+ *
+ * Tests the three resilience scenarios:
+ * 1. **Timeout**: WireMock delay longer than timeout -> fallback returned
+ * 2. **Retry**: First call fails with 500 -> second call succeeds -> normal result
+ * 3. **Circuit Open**: Consecutive failures -> circuit opens -> fallback returned without HTTP call
+ *
+ * Strategy: These tests directly wire Resilience4j CircuitBreaker/Retry around the adapter
+ * calls using the Resilience4j API (decorateSupplier/decorateCheckedSupplier) to avoid
+ * needing the full Spring Boot context (which requires PostgreSQL).
+ */
+@DisplayName("AiService Resilience4j - Circuit Breaker + Retry + Fail-Open")
+class AiServiceResilienceTest : AbstractAiServiceWireMockTest() {
+
+    private lateinit var adapter: AiModerationAdapter
+    private lateinit var filterAdapter: AiCommentFilterAdapter
+    private lateinit var summaryAdapter: AiNewsSummarizerAdapter
+
+    @BeforeEach
+    fun setUp() {
+        adapter = AiModerationAdapter(webClient, fallback)
+        filterAdapter = AiCommentFilterAdapter(webClient, fallback)
+        summaryAdapter = AiNewsSummarizerAdapter(webClient, fallback)
+    }
+
+    // =========================================================================
+    // Helper: Build a strict CircuitBreaker that opens after N failures
+    // =========================================================================
+
+    private fun buildCircuitBreaker(
+        name: String,
+        minimumCalls: Int = 4,
+        failureRateThreshold: Float = 60.0f
+    ): CircuitBreaker {
+        val config = CircuitBreakerConfig.custom()
+            .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+            .slidingWindowSize(minimumCalls)
+            .minimumNumberOfCalls(minimumCalls)
+            .failureRateThreshold(failureRateThreshold)
+            .waitDurationInOpenState(Duration.ofSeconds(30))
+            .permittedNumberOfCallsInHalfOpenState(1)
+            .recordExceptions(
+                WebClientResponseException::class.java,
+                AiServiceException::class.java,
+                RuntimeException::class.java
+            )
+            .build()
+        return CircuitBreakerRegistry.of(config).circuitBreaker(name)
+    }
+
+    private fun buildRetry(name: String, maxAttempts: Int = 2): io.github.resilience4j.retry.Retry {
+        val config = RetryConfig.custom<Any>()
+            .maxAttempts(maxAttempts)
+            .waitDuration(Duration.ofMillis(50))
+            .retryExceptions(
+                WebClientResponseException::class.java,
+                AiServiceException::class.java,
+                RuntimeException::class.java
+            )
+            .build()
+        return RetryRegistry.of(config).retry(name)
+    }
+
+    // =========================================================================
+    // Scenario 1: Timeout -> Fallback
+    // =========================================================================
+
+    @Nested
+    @DisplayName("Timeout Scenario")
+    inner class TimeoutScenario {
+
+        @Test
+        @DisplayName("should call fallback when WebClient times out (simulated via fixed delay)")
+        fun shouldCallFallbackOnTimeout() {
+            // given: WireMock responds after 3 seconds
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/moderation/check"))
+                    .willReturn(
+                        aResponse()
+                            .withFixedDelay(3000) // 3-second delay
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""{"is_flagged": false, "action": "allow", "confidence": 0.9, "model_used": "ko"}""")
+                    )
+            )
+
+            // given: WebClient configured with 500ms read timeout
+            val timedObjectMapper = ObjectMapper()
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .registerKotlinModule()
+            val timedStrategies = ExchangeStrategies.builder()
+                .codecs { configurer ->
+                    configurer.defaultCodecs().jackson2JsonDecoder(Jackson2JsonDecoder(timedObjectMapper))
+                    configurer.defaultCodecs().jackson2JsonEncoder(Jackson2JsonEncoder(timedObjectMapper))
+                }
+                .build()
+
+            // Using a reactor timeout on the mono to simulate TimeLimiter behavior
+            val timedWebClient = WebClient.builder()
+                .baseUrl("http://localhost:${wireMockServer.port()}")
+                .exchangeStrategies(timedStrategies)
+                .build()
+
+            // when: call times out, fallback is invoked
+            var timeoutExceptionCaught = false
+            val result = try {
+                // Simulate what @TimeLimiter + @CircuitBreaker would do:
+                // Call with a short timeout -> exception -> fallback
+                timedWebClient.post()
+                    .uri("/api/moderation/check")
+                    .bodyValue(mapOf("text" to "test", "use_cache" to true))
+                    .retrieve()
+                    .bodyToMono(ModerationCheckResponse::class.java)
+                    .timeout(Duration.ofMillis(500)) // 500ms timeout on reactive stream
+                    .block()
+                    ?.toDomain()
+                    ?: fallback.moderationFallback("test", RuntimeException("null response"))
+            } catch (e: Exception) {
+                timeoutExceptionCaught = true
+                fallback.moderationFallback("test", e)
+            }
+
+            // then: fallback result is returned (Fail-Open)
+            assertTrue(timeoutExceptionCaught, "A timeout exception should have been thrown")
+            assertFalse(result.isFlagged, "Fallback: isFlagged must be false (Fail-Open)")
+            assertEquals("allow", result.action, "Fallback: action must be 'allow' (Fail-Open)")
+            assertEquals("fallback", result.modelUsed, "Fallback: modelUsed must be 'fallback'")
+        }
+    }
+
+    // =========================================================================
+    // Scenario 2: Retry -> Success on Second Attempt
+    // =========================================================================
+
+    @Nested
+    @DisplayName("Retry Scenario")
+    inner class RetryScenario {
+
+        @Test
+        @DisplayName("should succeed on second attempt after first call returns 500")
+        fun shouldSucceedAfterRetry() {
+            // given: first call returns 500, second call returns 200
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/moderation/check"))
+                    .inScenario("retry-scenario")
+                    .whenScenarioStateIs("Started")
+                    .willReturn(
+                        aResponse()
+                            .withStatus(500)
+                            .withBody("Internal Server Error")
+                    )
+                    .willSetStateTo("first-failure")
+            )
+
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/moderation/check"))
+                    .inScenario("retry-scenario")
+                    .whenScenarioStateIs("first-failure")
+                    .willReturn(
+                        aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""
+                                {
+                                    "is_flagged": false,
+                                    "action": "allow",
+                                    "highest_category": null,
+                                    "highest_score": 0.1,
+                                    "confidence": 0.95,
+                                    "model_used": "ko",
+                                    "processing_time_ms": 42,
+                                    "cached": false,
+                                    "error": null
+                                }
+                            """.trimIndent())
+                    )
+            )
+
+            // given: Retry with 2 max attempts (1 initial + 1 retry)
+            val retry = buildRetry("retry-test", maxAttempts = 2)
+
+            // when: execute with retry decoration
+            var callCount = 0
+            val result = io.github.resilience4j.retry.Retry.decorateCheckedSupplier(retry) {
+                callCount++
+                adapter.checkContent("test content")
+            }.let { supplier ->
+                try {
+                    supplier.get()
+                } catch (e: Exception) {
+                    fallback.moderationFallback("test content", e)
+                }
+            }
+
+            // then: succeeded on second attempt with normal result
+            assertEquals(2, callCount, "Should have made exactly 2 HTTP calls (1 initial + 1 retry)")
+            assertFalse(result.isFlagged, "Retry success: result should be non-flagged")
+            assertEquals("allow", result.action, "Retry success: action should be 'allow'")
+            assertEquals("ko", result.modelUsed, "Retry success: should use real model 'ko', not fallback")
+
+            // verify WireMock received 2 requests
+            wireMockServer.verify(2, postRequestedFor(urlEqualTo("/api/moderation/check")))
+        }
+
+        @Test
+        @DisplayName("should call fallback when all retry attempts fail")
+        fun shouldCallFallbackWhenAllRetriesFail() {
+            // given: all calls return 500
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/moderation/check"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(500)
+                            .withBody("Internal Server Error")
+                    )
+            )
+
+            // given: Retry with 2 max attempts
+            val retry = buildRetry("retry-all-fail-test", maxAttempts = 2)
+
+            // when
+            var callCount = 0
+            val result = io.github.resilience4j.retry.Retry.decorateCheckedSupplier(retry) {
+                callCount++
+                adapter.checkContent("test content")
+            }.let { supplier ->
+                try {
+                    supplier.get()
+                } catch (e: Exception) {
+                    fallback.moderationFallback("test content", e)
+                }
+            }
+
+            // then: fallback returned after exhausting retries
+            assertEquals(2, callCount, "Should have made 2 HTTP calls before giving up")
+            assertFalse(result.isFlagged, "Fallback after failed retries: Fail-Open")
+            assertEquals("allow", result.action, "Fallback: action must be 'allow'")
+            assertEquals("fallback", result.modelUsed, "Fallback: modelUsed must be 'fallback'")
+        }
+    }
+
+    // =========================================================================
+    // Scenario 3: Circuit Open -> Fallback Without HTTP Call
+    // =========================================================================
+
+    @Nested
+    @DisplayName("Circuit Breaker Open Scenario")
+    inner class CircuitBreakerOpenScenario {
+
+        @Test
+        @DisplayName("should open circuit after consecutive failures and return fallback without HTTP call")
+        fun shouldOpenCircuitAfterConsecutiveFailures() {
+            // given: all calls return 500
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/moderation/check"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(500)
+                            .withBody("Internal Server Error")
+                    )
+            )
+
+            // given: CircuitBreaker that opens after 4 failures
+            val circuitBreaker = buildCircuitBreaker(
+                name = "circuit-open-test",
+                minimumCalls = 4,
+                failureRateThreshold = 100.0f // opens when 100% of calls fail
+            )
+
+            // when: make 4 calls to exhaust the sliding window
+            val failureResults = mutableListOf<com.fanpulse.domain.ai.ModerationResult>()
+            repeat(4) {
+                val result = CircuitBreaker.decorateCheckedSupplier(circuitBreaker) {
+                    adapter.checkContent("test content")
+                }.let { supplier ->
+                    try {
+                        supplier.get()
+                    } catch (e: Exception) {
+                        fallback.moderationFallback("test content", e)
+                    }
+                }
+                failureResults.add(result)
+            }
+
+            // then: circuit should now be OPEN
+            assertEquals(
+                CircuitBreaker.State.OPEN,
+                circuitBreaker.state,
+                "Circuit should be OPEN after ${failureResults.size} consecutive failures"
+            )
+
+            // when: make one more call with circuit open
+            val httpCallCountBefore = wireMockServer.allServeEvents.size
+            var circuitOpenExceptionCaught = false
+
+            val fallbackResult = CircuitBreaker.decorateCheckedSupplier(circuitBreaker) {
+                adapter.checkContent("test content after circuit open")
+            }.let { supplier ->
+                try {
+                    supplier.get()
+                } catch (e: CallNotPermittedException) {
+                    circuitOpenExceptionCaught = true
+                    fallback.moderationFallback("test content after circuit open", e)
+                } catch (e: Exception) {
+                    fallback.moderationFallback("test content after circuit open", e)
+                }
+            }
+
+            val httpCallCountAfter = wireMockServer.allServeEvents.size
+
+            // then: no HTTP call was made (circuit is open)
+            assertTrue(circuitOpenExceptionCaught, "CallNotPermittedException should be thrown when circuit is open")
+            assertEquals(
+                httpCallCountBefore,
+                httpCallCountAfter,
+                "No additional HTTP call should be made when circuit is open"
+            )
+
+            // then: fallback result is returned (Fail-Open)
+            assertFalse(fallbackResult.isFlagged, "Circuit-open fallback: Fail-Open (isFlagged=false)")
+            assertEquals("allow", fallbackResult.action, "Circuit-open fallback: action='allow'")
+            assertEquals("fallback", fallbackResult.modelUsed, "Circuit-open fallback: modelUsed='fallback'")
+        }
+
+        @Test
+        @DisplayName("should return fallback for filterComment when circuit is open")
+        fun shouldReturnFallbackForFilterCommentWhenCircuitOpen() {
+            // given: all filter calls return 500
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/comments/filter/test"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(500)
+                            .withBody("Internal Server Error")
+                    )
+            )
+
+            val circuitBreaker = buildCircuitBreaker(
+                name = "filter-circuit-open-test",
+                minimumCalls = 3,
+                failureRateThreshold = 100.0f
+            )
+
+            // when: exhaust the circuit breaker with 3 failures
+            repeat(3) {
+                CircuitBreaker.decorateCheckedSupplier(circuitBreaker) {
+                    filterAdapter.filterComment("test comment")
+                }.let { supplier ->
+                    try {
+                        supplier.get()
+                    } catch (e: Exception) {
+                        fallback.filterFallback("test comment", e)
+                    }
+                }
+            }
+
+            // then: circuit is open
+            assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.state)
+
+            // when: call with circuit open
+            var openExceptionCaught = false
+            val fallbackResult = CircuitBreaker.decorateCheckedSupplier(circuitBreaker) {
+                filterAdapter.filterComment("next comment")
+            }.let { supplier ->
+                try {
+                    supplier.get()
+                } catch (e: CallNotPermittedException) {
+                    openExceptionCaught = true
+                    fallback.filterFallback("next comment", e)
+                } catch (e: Exception) {
+                    fallback.filterFallback("next comment", e)
+                }
+            }
+
+            // then: Fail-Open fallback
+            assertTrue(openExceptionCaught, "CallNotPermittedException should be thrown")
+            assertFalse(fallbackResult.isFiltered, "Fail-Open: comment must not be filtered")
+            assertEquals("fallback", fallbackResult.filterType, "filterType must be 'fallback'")
+        }
+
+        @Test
+        @DisplayName("should return fallback for summarize when circuit is open")
+        fun shouldReturnFallbackForSummarizeWhenCircuitOpen() {
+            // given: all summarize calls return 500
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/summarize"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(500)
+                            .withBody("Internal Server Error")
+                    )
+            )
+
+            val circuitBreaker = buildCircuitBreaker(
+                name = "summary-circuit-open-test",
+                minimumCalls = 3,
+                failureRateThreshold = 100.0f
+            )
+
+            // when: exhaust the circuit breaker
+            repeat(3) {
+                CircuitBreaker.decorateCheckedSupplier(circuitBreaker) {
+                    summaryAdapter.summarize("some news text", "ai")
+                }.let { supplier ->
+                    try {
+                        supplier.get()
+                    } catch (e: Exception) {
+                        fallback.summaryFallback("some news text", "ai", e)
+                    }
+                }
+            }
+
+            assertEquals(CircuitBreaker.State.OPEN, circuitBreaker.state)
+
+            // when: call with circuit open
+            var openExceptionCaught = false
+            val fallbackResult = CircuitBreaker.decorateCheckedSupplier(circuitBreaker) {
+                summaryAdapter.summarize("another news text", "ai")
+            }.let { supplier ->
+                try {
+                    supplier.get()
+                } catch (e: CallNotPermittedException) {
+                    openExceptionCaught = true
+                    fallback.summaryFallback("another news text", "ai", e)
+                } catch (e: Exception) {
+                    fallback.summaryFallback("another news text", "ai", e)
+                }
+            }
+
+            // then: Fail-Open fallback
+            assertTrue(openExceptionCaught, "CallNotPermittedException should be thrown")
+            assertEquals("", fallbackResult.summary, "Fallback summary must be empty")
+            assertEquals("AI service unavailable", fallbackResult.error)
+        }
+    }
+
+    // =========================================================================
+    // Scenario 4: Normal operation (verify baseline before resilience tests)
+    // =========================================================================
+
+    @Nested
+    @DisplayName("Normal Operation (baseline)")
+    inner class NormalOperation {
+
+        @Test
+        @DisplayName("should return normal result when AI service responds successfully")
+        fun shouldReturnNormalResultOnSuccess() {
+            // given: AI service responds normally
+            wireMockServer.stubFor(
+                post(urlEqualTo("/api/moderation/check"))
+                    .willReturn(
+                        aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("""
+                                {
+                                    "is_flagged": false,
+                                    "action": "allow",
+                                    "highest_category": null,
+                                    "highest_score": 0.05,
+                                    "confidence": 0.98,
+                                    "model_used": "ko",
+                                    "processing_time_ms": 25,
+                                    "cached": false,
+                                    "error": null
+                                }
+                            """.trimIndent())
+                    )
+            )
+
+            val circuitBreaker = buildCircuitBreaker("normal-test")
+
+            // when
+            val result = CircuitBreaker.decorateCheckedSupplier(circuitBreaker) {
+                adapter.checkContent("clean content")
+            }.get()
+
+            // then: circuit remains CLOSED, real result returned
+            assertEquals(CircuitBreaker.State.CLOSED, circuitBreaker.state)
+            assertFalse(result.isFlagged)
+            assertEquals("allow", result.action)
+            assertEquals("ko", result.modelUsed)
+            assertNotEquals("fallback", result.modelUsed)
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/fanpulse/infrastructure/external/ai/NoOpAdaptersTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/infrastructure/external/ai/NoOpAdaptersTest.kt
@@ -1,0 +1,199 @@
+package com.fanpulse.infrastructure.external.ai
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the three NoOp AI adapter implementations.
+ *
+ * Each NoOp adapter is active only when `fanpulse.ai-service.enabled=false`.
+ * All NoOp adapters follow the Fail-Open strategy:
+ * - Content moderation: isFlagged=false, action="allow"
+ * - Comment filter: isFiltered=false
+ * - News summarizer: summary="", error="AI service disabled"
+ */
+@DisplayName("NoOp AI Adapters (AI service disabled)")
+class NoOpAdaptersTest {
+
+    // =========================================================================
+    // NoOpContentModerationAdapter Tests
+    // =========================================================================
+
+    @Nested
+    @DisplayName("NoOpContentModerationAdapter")
+    inner class NoOpContentModerationAdapterTests {
+
+        private val adapter = NoOpContentModerationAdapter()
+
+        @Test
+        @DisplayName("checkContent should return isFlagged=false (Fail-Open)")
+        fun checkContentShouldReturnPermissiveResult() {
+            // when
+            val result = adapter.checkContent("어떤 텍스트든 항상 허용")
+
+            // then
+            assertFalse(result.isFlagged, "NoOp: isFlagged should be false")
+            assertEquals("allow", result.action, "NoOp: action should be 'allow'")
+            assertNull(result.highestCategory, "NoOp: highestCategory should be null")
+            assertNull(result.highestScore, "NoOp: highestScore should be null")
+            assertEquals(0.0, result.confidence, "NoOp: confidence should be 0.0")
+            assertEquals("noop", result.modelUsed, "NoOp: modelUsed should be 'noop'")
+            assertNull(result.processingTimeMs, "NoOp: processingTimeMs should be null")
+            assertNull(result.error, "NoOp: error should be null")
+        }
+
+        @Test
+        @DisplayName("checkContent should return permissive result for any input including harmful-looking text")
+        fun checkContentShouldAlwaysReturnPermissiveRegardlessOfInput() {
+            // when - even text that looks harmful should return permissive when AI is disabled
+            val result = adapter.checkContent("욕설이나 유해한 내용처럼 보이는 텍스트")
+
+            // then
+            assertFalse(result.isFlagged)
+            assertEquals("allow", result.action)
+        }
+
+        @Test
+        @DisplayName("batchCheck should return isFiltered=false for all texts (Fail-Open)")
+        fun batchCheckShouldReturnPermissiveResultsForAllTexts() {
+            // given
+            val texts = listOf("첫 번째 텍스트", "두 번째 텍스트", "세 번째 텍스트")
+
+            // when
+            val results = adapter.batchCheck(texts)
+
+            // then
+            assertEquals(3, results.size, "Should return one result per input text")
+            results.forEach { result ->
+                assertFalse(result.isFlagged, "All NoOp results: isFlagged should be false")
+                assertEquals("allow", result.action, "All NoOp results: action should be 'allow'")
+                assertEquals("noop", result.modelUsed, "All NoOp results: modelUsed should be 'noop'")
+                assertNull(result.error, "All NoOp results: error should be null")
+            }
+        }
+
+        @Test
+        @DisplayName("batchCheck should return empty list for empty input")
+        fun batchCheckShouldReturnEmptyListForEmptyInput() {
+            // when
+            val results = adapter.batchCheck(emptyList())
+
+            // then
+            assertTrue(results.isEmpty(), "Empty input should return empty results")
+        }
+
+        @Test
+        @DisplayName("batchCheck result count should match input count")
+        fun batchCheckResultCountShouldMatchInputCount() {
+            // given
+            val texts = listOf("텍스트 1", "텍스트 2", "텍스트 3", "텍스트 4", "텍스트 5")
+
+            // when
+            val results = adapter.batchCheck(texts)
+
+            // then
+            assertEquals(texts.size, results.size, "Result count should match input count")
+        }
+    }
+
+    // =========================================================================
+    // NoOpCommentFilterAdapter Tests
+    // =========================================================================
+
+    @Nested
+    @DisplayName("NoOpCommentFilterAdapter")
+    inner class NoOpCommentFilterAdapterTests {
+
+        private val adapter = NoOpCommentFilterAdapter()
+
+        @Test
+        @DisplayName("filterComment should return isFiltered=false (Fail-Open)")
+        fun filterCommentShouldReturnPermissiveResult() {
+            // when
+            val result = adapter.filterComment("어떤 댓글이든 항상 허용")
+
+            // then
+            assertFalse(result.isFiltered, "NoOp: isFiltered should be false")
+            assertEquals("noop", result.filterType, "NoOp: filterType should be 'noop'")
+            assertNull(result.reason, "NoOp: reason should be null")
+            assertNull(result.ruleName, "NoOp: ruleName should be null")
+        }
+
+        @Test
+        @DisplayName("filterComment should return permissive result for any input")
+        fun filterCommentShouldAlwaysReturnPermissiveRegardlessOfInput() {
+            // when
+            val result = adapter.filterComment("스팸처럼 보이는 댓글 내용")
+
+            // then
+            assertFalse(result.isFiltered)
+            assertEquals("noop", result.filterType)
+        }
+
+        @Test
+        @DisplayName("filterComment should return permissive result for empty string")
+        fun filterCommentShouldHandleEmptyString() {
+            // when
+            val result = adapter.filterComment("")
+
+            // then
+            assertFalse(result.isFiltered)
+            assertEquals("noop", result.filterType)
+        }
+    }
+
+    // =========================================================================
+    // NoOpNewsSummarizerAdapter Tests
+    // =========================================================================
+
+    @Nested
+    @DisplayName("NoOpNewsSummarizerAdapter")
+    inner class NoOpNewsSummarizerAdapterTests {
+
+        private val adapter = NoOpNewsSummarizerAdapter()
+
+        @Test
+        @DisplayName("summarize should return empty summary with error='AI service disabled'")
+        fun summarizeShouldReturnEmptySummaryWithErrorMessage() {
+            // when
+            val result = adapter.summarize("긴 뉴스 기사 텍스트 내용...", "ai")
+
+            // then
+            assertEquals("", result.summary, "NoOp: summary should be empty string")
+            assertTrue(result.bullets.isEmpty(), "NoOp: bullets should be empty")
+            assertTrue(result.keywords.isEmpty(), "NoOp: keywords should be empty")
+            assertNull(result.elapsedMs, "NoOp: elapsedMs should be null")
+            assertEquals("AI service disabled", result.error, "NoOp: error should be 'AI service disabled'")
+        }
+
+        @Test
+        @DisplayName("summarize should return same result regardless of method parameter")
+        fun summarizeShouldReturnSameResultForAnyMethod() {
+            // when
+            val aiResult = adapter.summarize("뉴스 텍스트", "ai")
+            val extractiveResult = adapter.summarize("뉴스 텍스트", "extractive")
+
+            // then
+            assertEquals("", aiResult.summary)
+            assertEquals("AI service disabled", aiResult.error)
+            assertEquals("", extractiveResult.summary)
+            assertEquals("AI service disabled", extractiveResult.error)
+        }
+
+        @Test
+        @DisplayName("summarize should return empty summary for any text length")
+        fun summarizeShouldHandleAnyTextLength() {
+            // when
+            val shortResult = adapter.summarize("짧은 텍스트", "ai")
+            val longResult = adapter.summarize("매우 긴 텍스트 ".repeat(100), "ai")
+
+            // then
+            assertEquals("", shortResult.summary)
+            assertEquals("AI service disabled", shortResult.error)
+            assertEquals("", longResult.summary)
+            assertEquals("AI service disabled", longResult.error)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Domain 레이어: ModerationResult, FilterResult, SummaryResult 값 객체 + Port 인터페이스
- HTTP 어댑터: AiModerationAdapter, AiCommentFilterAdapter, AiNewsSummarizerAdapter
  - WebClient + snake_case ObjectMapper (Django API 호환)
  - Resilience4j CircuitBreaker/Retry 통합 (서비스별 CB 분리)
  - Netty 타임아웃 연결 + Summarizer 전용 extended timeout (30s)
- NoOp 어댑터: Feature Flag(`enabled=false`) 시 Fail-Open 허용
- AiServiceFallback: 공통 fallback 로직
- AbstractAiServiceWireMockTest: WireMock 테스트 베이스 클래스

## Test plan
- [x] 도메인 값 객체 단위 테스트 (FilterResultTest, ModerationResultTest, SummaryResultTest)
- [x] Port 인터페이스 계약 테스트 (CommentFilterPortTest, ContentModerationPortTest, NewsSummarizerPortTest)
- [x] WireMock 기반 HTTP 어댑터 테스트 (정상 응답, 에러, 타임아웃)
- [x] Resilience4j CB/Retry/Fallback 통합 테스트 (AiServiceResilienceTest)
- [x] Feature Flag 테스트 (AiFeatureFlagTest)
- [x] NoOp 어댑터 테스트 (NoOpAdaptersTest)
- [x] 102개 전체 테스트 통과

Closes #204