### PR TITLE
docs(kdoc): 전체 백엔드 Kotlin 소스 KDoc 한국어 주석 추가

### DIFF
--- a/backend/src/main/kotlin/com/fanpulse/FanPulseApplication.kt
+++ b/backend/src/main/kotlin/com/fanpulse/FanPulseApplication.kt
@@ -4,6 +4,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.scheduling.annotation.EnableScheduling
 
+/**
+ * K-Pop 팬 커뮤니티 라이브 스트리밍 플랫폼.
+ */
 @SpringBootApplication
 @EnableScheduling
 class FanPulseApplication

--- a/backend/src/main/kotlin/com/fanpulse/application/dto/comment/CommentDtos.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/dto/comment/CommentDtos.kt
@@ -6,6 +6,9 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 import java.util.*
 
+/**
+ * 컨트롤러에서 전달받는 댓글 생성 요청 모델.
+ */
 @Schema(description = "댓글 생성 요청 (Controller)")
 data class CreateCommentRequest(
     @Schema(description = "게시글 ID (MongoDB ObjectId)")
@@ -18,6 +21,9 @@ data class CreateCommentRequest(
     val parentCommentId: UUID? = null
 )
 
+/**
+ * 페이지네이션이 적용된 댓글 목록 응답 모델.
+ */
 @Schema(description = "댓글 목록 응답")
 data class CommentListResponse(
     @Schema(description = "댓글 목록")
@@ -36,6 +42,9 @@ data class CommentListResponse(
     val totalPages: Int
 )
 
+/**
+ * 서비스 레이어에서 사용하는 댓글 생성 커맨드 (userId 포함).
+ */
 @Schema(description = "댓글 생성 커맨드 (Service)")
 data class CreateCommentCommand(
     @Schema(description = "게시글 ID (MongoDB ObjectId)")
@@ -51,6 +60,9 @@ data class CreateCommentCommand(
     val parentCommentId: UUID? = null
 )
 
+/**
+ * 도메인 엔티티를 API 응답으로 변환하는 댓글 응답 모델.
+ */
 @Schema(description = "댓글 응답")
 data class CommentResponse(
     @Schema(description = "댓글 ID")

--- a/backend/src/main/kotlin/com/fanpulse/application/dto/content/ArtistDtos.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/dto/content/ArtistDtos.kt
@@ -8,6 +8,9 @@ import java.util.*
 
 // === Response DTOs ===
 
+/**
+ * 아티스트 상세 정보를 포함하는 응답 모델.
+ */
 @Schema(description = "Artist detail response")
 data class ArtistResponse(
     @Schema(description = "Artist ID")
@@ -60,6 +63,9 @@ data class ArtistResponse(
     }
 }
 
+/**
+ * 목록 화면에 사용하는 간략한 아티스트 정보.
+ */
 @Schema(description = "Artist summary for list views")
 data class ArtistSummary(
     @Schema(description = "Artist ID")
@@ -92,6 +98,9 @@ data class ArtistSummary(
     }
 }
 
+/**
+ * 페이지네이션이 적용된 아티스트 목록 응답.
+ */
 @Schema(description = "Paginated list of artists")
 data class ArtistListResponse(
     @Schema(description = "List of artists")

--- a/backend/src/main/kotlin/com/fanpulse/application/dto/content/ChartDtos.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/dto/content/ChartDtos.kt
@@ -9,6 +9,9 @@ import java.util.*
 
 // === Response DTOs ===
 
+/**
+ * 차트 순위 엔트리를 포함하는 상세 응답 모델.
+ */
 @Schema(description = "Chart detail response")
 data class ChartResponse(
     @Schema(description = "Chart ID")
@@ -37,6 +40,9 @@ data class ChartResponse(
     }
 }
 
+/**
+ * 차트 내 개별 순위 항목 (트랙, 아티스트, 순위 변동 포함).
+ */
 @Schema(description = "Chart entry response")
 data class ChartEntryResponse(
     @Schema(description = "Entry ID")
@@ -89,6 +95,9 @@ data class ChartEntryResponse(
     }
 }
 
+/**
+ * 목록 화면에 사용하는 간략한 차트 정보.
+ */
 @Schema(description = "Chart summary for list views")
 data class ChartSummary(
     @Schema(description = "Chart ID")
@@ -113,6 +122,9 @@ data class ChartSummary(
     }
 }
 
+/**
+ * 차트 목록 응답 모델.
+ */
 @Schema(description = "List of charts")
 data class ChartListResponse(
     @Schema(description = "List of chart summaries")

--- a/backend/src/main/kotlin/com/fanpulse/application/dto/content/NewsDtos.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/dto/content/NewsDtos.kt
@@ -8,6 +8,9 @@ import java.util.*
 
 // === Response DTOs ===
 
+/**
+ * 뉴스 기사 상세 정보를 포함하는 응답 모델.
+ */
 @Schema(description = "News detail response")
 data class NewsResponse(
     @Schema(description = "News ID")
@@ -60,6 +63,9 @@ data class NewsResponse(
     }
 }
 
+/**
+ * 목록 화면에 사용하는 간략한 뉴스 정보.
+ */
 @Schema(description = "News summary for list views")
 data class NewsSummary(
     @Schema(description = "News ID")
@@ -96,6 +102,9 @@ data class NewsSummary(
     }
 }
 
+/**
+ * 페이지네이션이 적용된 뉴스 목록 응답.
+ */
 @Schema(description = "Paginated list of news")
 data class NewsListResponse(
     @Schema(description = "List of news")
@@ -116,6 +125,9 @@ data class NewsListResponse(
 
 // === Filter ===
 
+/**
+ * 뉴스 조회 시 사용하는 필터 조건.
+ */
 @Schema(description = "Filter criteria for news")
 data class NewsFilter(
     @Schema(description = "Filter by artist ID")

--- a/backend/src/main/kotlin/com/fanpulse/application/dto/discovery/ArtistChannelDtos.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/dto/discovery/ArtistChannelDtos.kt
@@ -10,6 +10,9 @@ import java.util.UUID
 
 // === Response DTOs ===
 
+/**
+ * 아티스트 채널 상세 정보 응답 모델.
+ */
 @Schema(description = "Artist channel response")
 data class ArtistChannelResponse(
     @Schema(description = "Channel ID")
@@ -58,6 +61,9 @@ data class ArtistChannelResponse(
     }
 }
 
+/**
+ * 아티스트 채널 목록 응답 모델.
+ */
 @Schema(description = "List of artist channels")
 data class ArtistChannelListResponse(
     @Schema(description = "List of channels")
@@ -69,6 +75,9 @@ data class ArtistChannelListResponse(
 
 // === Request DTOs (Admin) ===
 
+/**
+ * 관리자가 새 아티스트 채널을 크롤링 대상으로 등록하는 요청 모델.
+ */
 @Schema(description = "Create artist channel request")
 data class CreateArtistChannelRequest(
     @field:NotNull(message = "Artist ID is required")
@@ -95,6 +104,9 @@ data class CreateArtistChannelRequest(
     val isActive: Boolean = true
 )
 
+/**
+ * 기존 아티스트 채널 정보를 부분 수정하는 요청 모델. null 필드는 변경하지 않는다.
+ */
 @Schema(description = "Update artist channel request")
 data class UpdateArtistChannelRequest(
     @Schema(description = "Channel handle")

--- a/backend/src/main/kotlin/com/fanpulse/application/dto/identity/AuthDtos.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/dto/identity/AuthDtos.kt
@@ -7,6 +7,9 @@ import jakarta.validation.constraints.Size
 
 // === Request DTOs ===
 
+/**
+ * 이메일/비밀번호 기반 회원가입 요청 모델.
+ */
 @Schema(description = "Email/password signup request")
 data class SignupRequest(
     @field:NotBlank(message = "Email is required")
@@ -25,6 +28,9 @@ data class SignupRequest(
     val password: String
 )
 
+/**
+ * 이메일/비밀번호 기반 로그인 요청 모델.
+ */
 @Schema(description = "Email/password login request")
 data class LoginRequest(
     @field:NotBlank(message = "Email is required")
@@ -37,6 +43,9 @@ data class LoginRequest(
     val password: String
 )
 
+/**
+ * Google OAuth 로그인 시 클라이언트 SDK에서 받은 ID 토큰을 전달하는 요청 모델.
+ */
 @Schema(description = "Google OAuth login request")
 data class GoogleLoginRequest(
     @field:NotBlank(message = "ID token is required")
@@ -44,6 +53,9 @@ data class GoogleLoginRequest(
     val idToken: String
 )
 
+/**
+ * 만료된 액세스 토큰을 갱신하기 위한 리프레시 토큰 요청 모델.
+ */
 @Schema(description = "Token refresh request")
 data class RefreshTokenRequest(
     @field:NotBlank(message = "Refresh token is required")
@@ -51,6 +63,9 @@ data class RefreshTokenRequest(
     val refreshToken: String
 )
 
+/**
+ * 현재 비밀번호 확인 후 새 비밀번호로 변경하는 요청 모델.
+ */
 @Schema(description = "Password change request")
 data class ChangePasswordRequest(
     @field:NotBlank(message = "Current password is required")
@@ -65,6 +80,9 @@ data class ChangePasswordRequest(
 
 // === Response DTOs ===
 
+/**
+ * 인증 성공 시 반환하는 JWT 토큰 응답 모델.
+ */
 @Schema(description = "Authentication token response")
 data class TokenResponse(
     @Schema(description = "JWT access token")
@@ -83,6 +101,9 @@ data class TokenResponse(
     val refreshExpiresIn: Long? = null
 )
 
+/**
+ * 별도 반환 데이터가 없는 작업의 결과 메시지 응답.
+ */
 @Schema(description = "Simple message response")
 data class MessageResponse(
     @Schema(description = "Response message")

--- a/backend/src/main/kotlin/com/fanpulse/application/dto/identity/UserDtos.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/dto/identity/UserDtos.kt
@@ -11,6 +11,9 @@ import java.util.UUID
 
 // === Response DTOs ===
 
+/**
+ * 사용자 프로필 기본 정보 응답 모델.
+ */
 @Schema(description = "User profile response")
 data class UserResponse(
     @Schema(description = "User ID")
@@ -39,6 +42,9 @@ data class UserResponse(
     }
 }
 
+/**
+ * 사용자 설정(테마, 언어, 알림) 응답 모델.
+ */
 @Schema(description = "User settings response")
 data class UserSettingsResponse(
     @Schema(description = "Theme (LIGHT/DARK)")
@@ -65,6 +71,9 @@ data class UserSettingsResponse(
 
 // === Request DTOs ===
 
+/**
+ * 사용자 프로필 부분 수정 요청 모델. null 필드는 변경하지 않는다.
+ */
 @Schema(description = "Profile update request")
 data class UpdateProfileRequest(
     @field:Size(min = 2, max = 50, message = "Username must be 2-50 characters")
@@ -72,6 +81,9 @@ data class UpdateProfileRequest(
     val username: String? = null
 )
 
+/**
+ * 사용자 설정 부분 수정 요청 모델. null 필드는 변경하지 않는다.
+ */
 @Schema(description = "Settings update request")
 data class UpdateSettingsRequest(
     @Schema(description = "Theme (light/dark)", example = "dark")

--- a/backend/src/main/kotlin/com/fanpulse/application/dto/search/SearchDtos.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/dto/search/SearchDtos.kt
@@ -4,6 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
 import java.util.UUID
 
+/**
+ * 라이브 이벤트와 뉴스 검색 결과를 통합한 응답 모델.
+ */
 @Schema(description = "Unified search response")
 data class SearchResponse(
     @Schema(description = "Live (streaming events) search result")
@@ -13,6 +16,9 @@ data class SearchResponse(
     val news: SearchCategoryResponse<SearchNewsItem>
 )
 
+/**
+ * 검색 결과의 카테고리별 항목 리스트와 전체 개수를 담는 제네릭 모델.
+ */
 @Schema(description = "Search result category")
 data class SearchCategoryResponse<T>(
     @Schema(description = "Items in this category")
@@ -22,6 +28,9 @@ data class SearchCategoryResponse<T>(
     val totalCount: Long
 )
 
+/**
+ * 통합 검색 결과에 포함되는 라이브 스트리밍 이벤트 항목.
+ */
 @Schema(description = "Live search item")
 data class SearchLiveItem(
     @Schema(description = "Streaming event ID")
@@ -46,6 +55,9 @@ data class SearchLiveItem(
     val scheduledAt: Instant
 )
 
+/**
+ * 통합 검색 결과에 포함되는 뉴스 기사 항목.
+ */
 @Schema(description = "News search item")
 data class SearchNewsItem(
     @Schema(description = "News ID")

--- a/backend/src/main/kotlin/com/fanpulse/application/dto/streaming/StreamingEventDtos.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/dto/streaming/StreamingEventDtos.kt
@@ -9,6 +9,9 @@ import java.util.UUID
 
 // === Response DTOs ===
 
+/**
+ * 스트리밍 이벤트 전체 상세 정보 응답 모델.
+ */
 @Schema(description = "Streaming event detail response")
 data class StreamingEventResponse(
     @Schema(description = "Event ID")
@@ -77,6 +80,9 @@ data class StreamingEventResponse(
     }
 }
 
+/**
+ * 목록 화면에 사용하는 간략한 스트리밍 이벤트 정보.
+ */
 @Schema(description = "Streaming event summary for list views")
 data class StreamingEventSummary(
     @Schema(description = "Event ID")
@@ -117,6 +123,9 @@ data class StreamingEventSummary(
     }
 }
 
+/**
+ * 페이지네이션이 적용된 스트리밍 이벤트 목록 응답.
+ */
 @Schema(description = "Paginated list of streaming events")
 data class StreamingEventListResponse(
     @Schema(description = "List of events")
@@ -137,6 +146,9 @@ data class StreamingEventListResponse(
 
 // === Cursor-based Pagination DTOs (for MVP API spec) ===
 
+/**
+ * API 성공/실패 플래그를 포함하는 표준 응답 래퍼.
+ */
 @Schema(description = "Standard API response wrapper")
 data class ApiResponse<T>(
     @Schema(description = "Request success status")
@@ -150,6 +162,9 @@ data class ApiResponse<T>(
     }
 }
 
+/**
+ * 무한 스크롤을 위한 커서 기반 페이지네이션 응답 모델.
+ */
 @Schema(description = "Cursor-based pagination response")
 data class CursorPageResponse<T>(
     @Schema(description = "List of items")
@@ -162,6 +177,9 @@ data class CursorPageResponse<T>(
     val hasMore: Boolean
 )
 
+/**
+ * 아티스트 이름이 조인된 스트리밍 이벤트 목록 항목.
+ */
 @Schema(description = "Streaming event item for list views (with artist name)")
 data class StreamingEventListItem(
     @Schema(description = "Event ID")
@@ -192,6 +210,9 @@ data class StreamingEventListItem(
     val viewerCount: Int
 )
 
+/**
+ * 아티스트 이름이 조인된 스트리밍 이벤트 상세 응답.
+ */
 @Schema(description = "Streaming event detail (with artist name)")
 data class StreamingEventDetailResponse(
     @Schema(description = "Event ID")
@@ -236,6 +257,9 @@ data class StreamingEventDetailResponse(
 
 // === Query Parameters ===
 
+/**
+ * 스트리밍 이벤트 조회 시 사용하는 필터 조건.
+ */
 @Schema(description = "Filter criteria for streaming events")
 data class StreamingEventFilter(
     @Schema(description = "Filter by status", example = "LIVE")

--- a/backend/src/main/kotlin/com/fanpulse/application/service/LiveDiscoveryService.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/service/LiveDiscoveryService.kt
@@ -1,5 +1,13 @@
 package com.fanpulse.application.service
 
+/**
+ * 라이브 스트리밍 자동 탐색 실행 결과
+ *
+ * @property total total channels processed
+ * @property upserted successfully created or updated events
+ * @property failed channels that failed during discovery
+ * @property errors error messages for failed channels
+ */
 data class LiveDiscoveryResult(
     val total: Int,
     val upserted: Int,
@@ -7,6 +15,14 @@ data class LiveDiscoveryResult(
     val errors: List<String> = emptyList()
 )
 
+/**
+ * 등록된 아티스트 채널에서 라이브 스트리밍을 자동 탐색한다.
+ */
 interface LiveDiscoveryService {
+
+    /**
+     * 모든 활성 아티스트 채널에서 라이브 스트림을 탐색한다.
+     * 모든 활성 채널을 순회하며 라이브 스트리밍 이벤트를 upsert한다.
+     */
     suspend fun discoverAllChannels(): LiveDiscoveryResult
 }

--- a/backend/src/main/kotlin/com/fanpulse/application/service/LiveDiscoveryServiceImpl.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/service/LiveDiscoveryServiceImpl.kt
@@ -26,6 +26,16 @@ import java.util.concurrent.atomic.AtomicInteger
 
 private val logger = KotlinLogging.logger {}
 
+/**
+ * 코루틴 기반 병렬 라이브 스트리밍 발견 서비스 구현체.
+ * Semaphore로 동시 처리 수를 제한하고, Batch DB 작업으로 I/O를 최적화한다.
+ *
+ * @property channelPort 아티스트 채널 조회/저장 포트
+ * @property discoveryPort 외부 플랫폼 스트림 발견 포트 (yt-dlp)
+ * @property eventPort 스트리밍 이벤트 저장/조회 포트
+ * @property channelDelayMs 채널 간 처리 지연 시간 (밀리초, rate limiting 용도)
+ * @property maxConcurrency 동시 처리 가능한 최대 채널 수
+ */
 class LiveDiscoveryServiceImpl(
     private val channelPort: ArtistChannelPort,
     private val discoveryPort: StreamDiscoveryPort,

--- a/backend/src/main/kotlin/com/fanpulse/application/service/comment/CommentCommandService.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/service/comment/CommentCommandService.kt
@@ -3,7 +3,20 @@ package com.fanpulse.application.service.comment
 import com.fanpulse.application.dto.comment.CommentResponse
 import java.util.*
 
+/**
+ * AI 필터링을 포함한 댓글 생성/수정 작업을 정의한다.
+ */
 interface CommentCommandService {
 
+    /**
+     * AI 콘텐츠 필터링을 적용하여 새 댓글을 생성한다.
+     * Fail-Pending 전략: AI 필터 장애 시 PENDING 상태로 저장한다.
+     *
+     * @param postId target post identifier
+     * @param userId author's user ID
+     * @param content comment text content
+     * @param parentCommentId parent comment ID for replies (null for top-level)
+     * @return created comment with resolved status (APPROVED / BLOCKED / PENDING)
+     */
     fun createComment(postId: String, userId: UUID, content: String, parentCommentId: UUID? = null): CommentResponse
 }

--- a/backend/src/main/kotlin/com/fanpulse/application/service/comment/CommentCommandServiceImpl.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/service/comment/CommentCommandServiceImpl.kt
@@ -16,6 +16,14 @@ import java.util.*
 
 private val logger = KotlinLogging.logger {}
 
+/**
+ * AI 댓글 필터링 → 상태 결정 → 저장 → 로그 기록 → 메트릭 발행 파이프라인을 수행한다.
+ *
+ * @property commentFilterPort AI Sidecar 댓글 필터 포트 (Fail-Pending fallback 포함)
+ * @property commentPort 댓글 영속성 포트
+ * @property filterLogPort 필터 로그 영속성 포트
+ * @property meterRegistry Micrometer 메트릭 레지스트리
+ */
 @Service
 class CommentCommandServiceImpl(
     private val commentFilterPort: CommentFilterPort,

--- a/backend/src/main/kotlin/com/fanpulse/application/service/comment/CommentQueryService.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/service/comment/CommentQueryService.kt
@@ -3,7 +3,17 @@ package com.fanpulse.application.service.comment
 import com.fanpulse.application.dto.comment.CommentListResponse
 import org.springframework.data.domain.Pageable
 
+/**
+ * 승인된(APPROVED) 댓글만 조회하는 읽기 전용 서비스를 정의한다.
+ */
 interface CommentQueryService {
 
+    /**
+     * 게시글의 승인된 댓글을 페이지네이션하여 조회한다.
+     * APPROVED 상태 댓글만 반환한다 (BLOCKED, PENDING 제외).
+     *
+     * @param postId target post identifier
+     * @param pageable pagination parameters
+     */
     fun getComments(postId: String, pageable: Pageable): CommentListResponse
 }

--- a/backend/src/main/kotlin/com/fanpulse/application/service/comment/CommentQueryServiceImpl.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/service/comment/CommentQueryServiceImpl.kt
@@ -12,6 +12,9 @@ import org.springframework.transaction.annotation.Transactional
 
 private val logger = KotlinLogging.logger {}
 
+/**
+ * 도메인 포트를 통해 APPROVED 댓글을 페이징 조회한다.
+ */
 @Service
 @Transactional(readOnly = true)
 class CommentQueryServiceImpl(

--- a/backend/src/main/kotlin/com/fanpulse/application/service/search/SearchQueryService.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/service/search/SearchQueryService.kt
@@ -2,6 +2,17 @@ package com.fanpulse.application.service.search
 
 import com.fanpulse.application.dto.search.SearchResponse
 
+/**
+ * 통합 검색 쿼리 서비스.
+ * 라이브 스트리밍, 뉴스 등 여러 도메인을 통합 검색한다.
+ */
 interface SearchQueryService {
+
+    /**
+     * 코루틴 병렬 처리로 LIVE/SCHEDULED/ENDED 스트리밍과 뉴스를 동시 검색한다.
+     *
+     * @param query 검색 키워드
+     * @param limit 카테고리별 최대 결과 수
+     */
     fun search(query: String, limit: Int): SearchResponse
 }

--- a/backend/src/main/kotlin/com/fanpulse/application/service/search/SearchQueryServiceImpl.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/service/search/SearchQueryServiceImpl.kt
@@ -18,6 +18,14 @@ import org.springframework.transaction.annotation.Transactional
 
 private val logger = KotlinLogging.logger {}
 
+/**
+ * [SearchQueryService] 구현체.
+ * Kotlin 코루틴으로 스트리밍/뉴스 검색을 병렬 수행하고, N+1 방지를 위해 아티스트를 배치 로딩한다.
+ *
+ * @property streamingEventPort 스트리밍 이벤트 조회 포트
+ * @property newsPort 뉴스 조회 포트
+ * @property artistPort 아티스트 조회 포트 (배치 로딩용)
+ */
 @Service
 @Transactional(readOnly = true)
 class SearchQueryServiceImpl(

--- a/backend/src/main/kotlin/com/fanpulse/domain/comment/Comment.kt
+++ b/backend/src/main/kotlin/com/fanpulse/domain/comment/Comment.kt
@@ -4,6 +4,18 @@ import jakarta.persistence.*
 import java.time.Instant
 import java.util.*
 
+/**
+ * AI 필터링 결과에 따라 PENDING → APPROVED / BLOCKED 상태가 결정되는 댓글 엔티티.
+ *
+ * @property id unique comment identifier
+ * @property postId target post identifier (MongoDB ObjectId)
+ * @property userId comment author's user ID
+ * @property content comment text content
+ * @property status current moderation status (PENDING, APPROVED, BLOCKED)
+ * @property parentCommentId parent comment ID for threaded replies (null for top-level)
+ * @property createdAt creation timestamp
+ * @property updatedAt last modification timestamp
+ */
 @Entity
 @Table(name = "comments")
 class Comment private constructor(
@@ -38,6 +50,10 @@ class Comment private constructor(
         private set
 
     companion object {
+        /**
+         * Factory method to create a new comment in PENDING status.
+         * 새 댓글을 PENDING 상태로 생성한다. AI 필터링 후 상태가 결정된다.
+         */
         fun create(
             postId: String,
             userId: UUID,
@@ -60,11 +76,13 @@ class Comment private constructor(
         }
     }
 
+    /** Transitions the comment to APPROVED status. AI 필터 통과 시 호출된다. */
     fun approve() {
         this.status = CommentStatus.APPROVED
         this.updatedAt = Instant.now()
     }
 
+    /** Transitions the comment to BLOCKED status with a reason. AI 필터 차단 시 호출된다. */
     fun block(reason: String) {
         require(reason.isNotBlank()) { "Block reason cannot be blank" }
         this.status = CommentStatus.BLOCKED

--- a/backend/src/main/kotlin/com/fanpulse/domain/comment/CommentStatus.kt
+++ b/backend/src/main/kotlin/com/fanpulse/domain/comment/CommentStatus.kt
@@ -1,5 +1,12 @@
 package com.fanpulse.domain.comment
 
+/**
+ * AI 필터링 결과에 따른 댓글 상태를 나타낸다.
+ *
+ * - PENDING: 필터링 대기 중 또는 AI 장애 시 Fail-Pending 상태
+ * - APPROVED: AI 필터 통과, 노출 허용
+ * - BLOCKED: AI 필터에 의해 차단됨
+ */
 enum class CommentStatus {
     APPROVED,
     BLOCKED,

--- a/backend/src/main/kotlin/com/fanpulse/domain/comment/port/CommentPort.kt
+++ b/backend/src/main/kotlin/com/fanpulse/domain/comment/port/CommentPort.kt
@@ -6,8 +6,17 @@ import com.fanpulse.domain.common.PageRequest
 import com.fanpulse.domain.common.PageResult
 import java.util.*
 
+/**
+ * 댓글 저장/조회를 위한 도메인 포트 (헥사고날 아키텍처 outbound).
+ */
 interface CommentPort {
+
+    /** Saves or updates a comment entity. */
     fun save(comment: Comment): Comment
+
+    /** Finds a comment by its unique ID, or null if not found. */
     fun findById(id: UUID): Comment?
+
+    /** Finds comments by post and status with pagination. */
     fun findByPostIdAndStatus(postId: String, status: CommentStatus, pageRequest: PageRequest): PageResult<Comment>
 }

--- a/backend/src/main/kotlin/com/fanpulse/domain/discovery/ArtistChannel.kt
+++ b/backend/src/main/kotlin/com/fanpulse/domain/discovery/ArtistChannel.kt
@@ -5,6 +5,21 @@ import jakarta.persistence.*
 import java.time.Instant
 import java.util.UUID
 
+/**
+ * 아티스트의 스트리밍 플랫폼 채널 정보를 관리하는 엔티티.
+ * 라이브 탐색 스케줄러가 이 채널을 크롤링하여 새로운 라이브 이벤트를 발견한다.
+ *
+ * @property id channel unique identifier
+ * @property artistId associated artist ID
+ * @property platform streaming platform (e.g., YOUTUBE)
+ * @property channelHandle platform-specific handle (e.g., @NewJeans_official)
+ * @property channelId platform-specific channel ID
+ * @property channelUrl full channel URL
+ * @property isOfficial whether this is an official artist channel
+ * @property isActive whether crawling is enabled for this channel
+ * @property lastCrawledAt last successful crawl timestamp
+ * @property createdAt channel registration timestamp
+ */
 @Entity
 @Table(
     name = "artist_channels",
@@ -48,6 +63,7 @@ class ArtistChannel(
     @Column(name = "created_at", nullable = false, updatable = false)
     val createdAt: Instant = Instant.now()
 ) {
+    /** Updates the last crawled timestamp. 크롤링 완료 시 호출된다. */
     fun markCrawled(now: Instant = Instant.now()) {
         lastCrawledAt = now
     }

--- a/backend/src/main/kotlin/com/fanpulse/domain/discovery/port/StreamDiscoveryPort.kt
+++ b/backend/src/main/kotlin/com/fanpulse/domain/discovery/port/StreamDiscoveryPort.kt
@@ -4,6 +4,15 @@ import com.fanpulse.domain.streaming.StreamingPlatform
 import com.fanpulse.domain.streaming.StreamingStatus
 import java.time.Instant
 
+/**
+ * 외부 플랫폼에서 탐색된 라이브 스트리밍 정보를 담는 DTO.
+ *
+ * @property platform streaming platform
+ * @property externalId platform-specific video/stream ID
+ * @property title stream title
+ * @property streamUrl embeddable stream URL
+ * @property status discovered stream status
+ */
 data class DiscoveredStream(
     val platform: StreamingPlatform,
     val externalId: String,
@@ -19,6 +28,10 @@ data class DiscoveredStream(
     val viewerCount: Int? = null
 )
 
+/**
+ * 외부 플랫폼(YouTube 등)에서 라이브 스트리밍을 탐색하는 도메인 포트.
+ */
 interface StreamDiscoveryPort {
+    /** Discovers live/upcoming streams from the given channel handle. */
     fun discoverChannelStreams(channelHandle: String): List<DiscoveredStream>
 }

--- a/backend/src/main/kotlin/com/fanpulse/domain/streaming/StreamingEvent.kt
+++ b/backend/src/main/kotlin/com/fanpulse/domain/streaming/StreamingEvent.kt
@@ -4,6 +4,15 @@ import jakarta.persistence.*
 import java.time.Instant
 import java.util.*
 
+/**
+ * 스트리밍 이벤트 도메인 엔티티. SCHEDULED → LIVE → ENDED 상태 전이를 관리한다.
+ * 외부 소스(yt-dlp)에서 발견된 데이터로 메타데이터를 업데이트하는 메서드를 제공한다.
+ *
+ * @property id 이벤트 고유 식별자
+ * @property streamUrl 임베드 가능한 스트리밍 URL
+ * @property artistId 연결된 아티스트 ID
+ * @property createdAt 이벤트 생성 시각
+ */
 @Entity
 @Table(name = "streaming_events")
 class StreamingEvent(
@@ -205,8 +214,15 @@ class StreamingEvent(
     }
 }
 
+/**
+ * 스트리밍 이벤트의 생명주기 상태를 나타내는 열거형.
+ * SCHEDULED(예정) → LIVE(실시간 방송 중) → ENDED(종료) 순서로 전이한다.
+ */
 enum class StreamingStatus {
+    /** 방송 예정 상태. 아직 시작되지 않은 스트리밍. */
     SCHEDULED,
+    /** 실시간 방송 중. 시청자가 실시간으로 시청 가능한 상태. */
     LIVE,
+    /** 방송 종료. 다시보기로 전환될 수 있는 상태. */
     ENDED
 }

--- a/backend/src/main/kotlin/com/fanpulse/domain/streaming/StreamingPlatform.kt
+++ b/backend/src/main/kotlin/com/fanpulse/domain/streaming/StreamingPlatform.kt
@@ -1,5 +1,8 @@
 package com.fanpulse.domain.streaming
 
+/**
+ * 라이브 이벤트 탐색이 지원되는 스트리밍 플랫폼 목록.
+ */
 enum class StreamingPlatform {
     YOUTUBE
 }

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/config/LiveDiscoveryConfig.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/config/LiveDiscoveryConfig.kt
@@ -11,6 +11,9 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
+/**
+ * 아티스트 채널에서 라이브 스트리밍을 탐색하기 위한 yt-dlp 설정 및 서비스 빈을 구성한다.
+ */
 @Configuration
 class LiveDiscoveryConfig {
     @Value("\${fanpulse.discovery.ytdlp.command:yt-dlp}")

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/config/MetadataRefreshConfig.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/config/MetadataRefreshConfig.kt
@@ -9,6 +9,9 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
+/**
+ * 스트리밍 이벤트 메타데이터(제목, 썸네일 등) 주기적 갱신 설정.
+ */
 @Configuration
 class MetadataRefreshConfig {
 

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/config/OpenApiConfig.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/config/OpenApiConfig.kt
@@ -10,6 +10,9 @@ import io.swagger.v3.oas.models.tags.Tag
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
+/**
+ * API 문서 메타데이터, 서버 목록, JWT 인증 스키마를 정의한다.
+ */
 @Configuration
 class OpenApiConfig {
 

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/config/YouTubeConfig.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/config/YouTubeConfig.kt
@@ -8,6 +8,9 @@ import org.springframework.http.codec.json.Jackson2JsonDecoder
 import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
 
+/**
+ * YouTube 영상 메타데이터 조회를 위한 snake_case WebClient를 구성한다.
+ */
 @Configuration
 class YouTubeConfig {
 

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/external/youtube/YtDlpConfig.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/external/youtube/YtDlpConfig.kt
@@ -1,5 +1,13 @@
 package com.fanpulse.infrastructure.external.youtube
 
+/**
+ * 라이브 스트리밍 탐색에 사용하는 yt-dlp 실행 옵션.
+ *
+ * @property command yt-dlp executable path or name
+ * @property timeoutMs process execution timeout in milliseconds
+ * @property playlistLimit max entries to extract from a playlist
+ * @property extractFlat if true, only extract metadata without downloading
+ */
 data class YtDlpConfig(
     val command: String,
     val timeoutMs: Long,

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/external/youtube/YtDlpOutputParser.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/external/youtube/YtDlpOutputParser.kt
@@ -6,6 +6,10 @@ import org.springframework.stereotype.Component
 
 private val logger = KotlinLogging.logger {}
 
+/**
+ * yt-dlp 실행 결과(JSON)를 파싱하여 [YtDlpEntry] 리스트로 변환한다.
+ * 플레이리스트 형식과 개별 엔트리 라인 형식을 모두 지원한다.
+ */
 @Component
 class YtDlpOutputParser(
     private val objectMapper: ObjectMapper
@@ -47,10 +51,21 @@ class YtDlpOutputParser(
     }
 }
 
+/**
+ * yt-dlp playlist output model.
+ * yt-dlp의 플레이리스트 JSON 출력을 역직렬화하기 위한 모델.
+ */
 data class YtDlpPlaylist(
     val entries: List<YtDlpEntry?>? = emptyList()
 )
 
+/**
+ * yt-dlp가 추출한 개별 영상/스트리밍 메타데이터.
+ *
+ * @property id YouTube video ID
+ * @property live_status live broadcast status (e.g., "is_live", "is_upcoming", "was_live")
+ * @property concurrent_view_count current viewer count for live streams
+ */
 data class YtDlpEntry(
     val id: String? = null,
     val title: String? = null,

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/external/youtube/YtDlpStreamDiscoveryAdapter.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/external/youtube/YtDlpStreamDiscoveryAdapter.kt
@@ -17,6 +17,14 @@ import java.util.concurrent.TimeUnit
 
 private val logger = KotlinLogging.logger {}
 
+/**
+ * yt-dlp CLI를 사용하여 YouTube 채널에서 라이브/예정/종료된 스트리밍을 발견하는 어댑터.
+ * CircuitBreaker와 Retry 패턴으로 외부 프로세스 호출의 안정성을 보장한다.
+ *
+ * @property config yt-dlp CLI 실행 설정 (커맨드 경로, 타임아웃, 재생목록 제한 등)
+ * @property outputParser yt-dlp JSON 출력 파서
+ * @property videoIdExtractor YouTube 비디오 ID 추출기
+ */
 @Component
 class YtDlpStreamDiscoveryAdapter(
     private val config: YtDlpConfig,

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/persistence/comment/CommentAdapter.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/persistence/comment/CommentAdapter.kt
@@ -10,6 +10,10 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
 
+/**
+ * JPA adapter for [CommentPort].
+ * 댓글 도메인 포트를 Spring Data JPA로 구현한다.
+ */
 @Component
 class CommentAdapter(
     private val repository: CommentJpaRepository

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/persistence/comment/CommentFilterLog.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/persistence/comment/CommentFilterLog.kt
@@ -5,6 +5,16 @@ import jakarta.persistence.*
 import java.time.Instant
 import java.util.*
 
+/**
+ * JPA entity for AI comment filter audit logs.
+ * 댓글 AI 필터링 결과를 기록하는 감사 로그 엔티티.
+ *
+ * @property commentId 필터링 대상 댓글 ID
+ * @property isFiltered AI가 유해하다고 판단했는지 여부
+ * @property filterType 필터 유형 (ai / fallback 등)
+ * @property reason 차단 사유 (nullable)
+ * @property ruleName 적용된 규칙명 (nullable)
+ */
 @Entity
 @Table(name = "comment_filter_logs")
 class CommentFilterLog private constructor(

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/persistence/comment/CommentFilterLogAdapter.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/persistence/comment/CommentFilterLogAdapter.kt
@@ -4,6 +4,10 @@ import com.fanpulse.application.port.out.CommentFilterLogPort
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
+/**
+ * JPA adapter for [CommentFilterLogPort].
+ * 댓글 필터 로그 영속성을 Spring Data JPA로 구현한다.
+ */
 @Component
 class CommentFilterLogAdapter(
     private val repository: CommentFilterLogJpaRepository

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/persistence/comment/CommentFilterLogJpaRepository.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/persistence/comment/CommentFilterLogJpaRepository.kt
@@ -3,4 +3,7 @@ package com.fanpulse.infrastructure.persistence.comment
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.*
 
+/**
+ * AI 댓글 필터 감사 로그 테이블 접근을 위한 JPA 리포지토리.
+ */
 interface CommentFilterLogJpaRepository : JpaRepository<CommentFilterLog, UUID>

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/persistence/comment/CommentJpaRepository.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/persistence/comment/CommentJpaRepository.kt
@@ -7,7 +7,13 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.*
 
+/**
+ * 댓글 테이블 접근을 위한 JPA 리포지토리.
+ */
 interface CommentJpaRepository : JpaRepository<Comment, UUID> {
 
+    /**
+     * Finds comments by post ID and status with pagination.
+     */
     fun findByPostIdAndStatus(postId: String, status: CommentStatus, pageable: Pageable): Page<Comment>
 }

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/scheduler/LiveDiscoveryScheduler.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/scheduler/LiveDiscoveryScheduler.kt
@@ -11,6 +11,11 @@ import java.time.Instant
 
 private val logger = KotlinLogging.logger {}
 
+/**
+ * 주기적으로 아티스트 채널의 라이브 스트리밍을 발견하는 스케줄러.
+ * ShedLock으로 다중 인스턴스 환경에서 동시 실행을 방지한다.
+ * `fanpulse.scheduler.live-discovery.enabled=true` 설정 시에만 활성화된다.
+ */
 @Component
 @ConditionalOnProperty(
     name = ["fanpulse.scheduler.live-discovery.enabled"],

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/seed/SeedLoaderRunner.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/seed/SeedLoaderRunner.kt
@@ -23,6 +23,16 @@ import kotlin.system.exitProcess
 
 private val logger = KotlinLogging.logger {}
 
+/**
+ * 애플리케이션 시작 시 JSON 시드 파일에서 아티스트, 라이브 이벤트, 뉴스 데이터를 로드한다.
+ * `fanpulse.seed.enabled=true`일 때만 실행되며 완료 후 프로세스를 종료한다.
+ *
+ * @property objectMapper JSON 역직렬화에 사용하는 Jackson ObjectMapper
+ * @property txManager 시드 데이터 삽입의 트랜잭션 관리자
+ * @property artistPort 아티스트 도메인 포트
+ * @property streamingEventPort 스트리밍 이벤트 도메인 포트
+ * @property newsPort 뉴스 도메인 포트
+ */
 @Component
 class SeedLoaderRunner(
     private val objectMapper: ObjectMapper,
@@ -348,6 +358,15 @@ class SeedLoaderRunner(
     }
 }
 
+/**
+ * 시드 데이터 로딩 작업의 결과를 요약하는 데이터 클래스.
+ *
+ * @property processed total number of seed entries processed
+ * @property inserted number of newly created records
+ * @property updated number of existing records updated (upsert)
+ * @property failed number of entries that failed to process
+ * @property skippedReason reason for skipping (e.g., file not found), null if executed
+ */
 private data class SeedResult(
     val processed: Int,
     val inserted: Int,

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/seed/SeedModels.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/seed/SeedModels.kt
@@ -5,6 +5,9 @@ import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
+/**
+ * JSON 시드 파일에서 아티스트 데이터를 역직렬화하기 위한 모델.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class SeedArtist(
     val name: String,
@@ -18,6 +21,9 @@ data class SeedArtist(
     val members: List<String>? = null
 )
 
+/**
+ * JSON 시드 파일에서 라이브 이벤트 데이터를 역직렬화하기 위한 모델.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class SeedLiveEvent(
     val title: String,
@@ -36,6 +42,9 @@ data class SeedLiveEvent(
     val externalId: String? = null
 )
 
+/**
+ * JSON 시드 파일에서 뉴스 데이터를 역직렬화하기 위한 모델.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class SeedNews(
     val title: String,

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/web/discovery/ArtistChannelController.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/web/discovery/ArtistChannelController.kt
@@ -20,6 +20,9 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import java.util.UUID
 
+/**
+ * 아티스트 채널 CRUD 및 라이브 스트리밍 수동 탐색 트리거를 제공한다.
+ */
 @RestController
 @RequestMapping("/admin/artist-channels")
 @Tag(name = "Artist Channels (Admin)", description = "Artist channel management for live stream discovery")

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/web/streaming/StreamingEventController.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/web/streaming/StreamingEventController.kt
@@ -18,6 +18,10 @@ import org.springframework.web.bind.annotation.*
 import java.time.Instant
 import java.util.UUID
 
+/**
+ * 라이브 스트리밍 이벤트 조회 API 엔드포인트를 제공한다.
+ * MVP 커서 기반 페이지네이션과 레거시 오프셋 기반 페이지네이션을 모두 지원한다.
+ */
 @RestController
 @RequestMapping("/api/v1/streaming-events")
 @Tag(name = "Streaming Events", description = "Live streaming event discovery and information")

--- a/backend/src/main/kotlin/com/fanpulse/interfaces/rest/comment/CommentController.kt
+++ b/backend/src/main/kotlin/com/fanpulse/interfaces/rest/comment/CommentController.kt
@@ -23,6 +23,9 @@ import java.util.*
 
 private val logger = KotlinLogging.logger {}
 
+/**
+ * 댓글 생성(AI 필터링 포함) 및 게시글별 댓글 조회 API를 제공한다.
+ */
 @RestController
 @RequestMapping("/api/v1/comments")
 @Tag(name = "Comments", description = "댓글 생성 및 조회 (AI 필터링 적용)")

--- a/backend/src/main/kotlin/com/fanpulse/interfaces/rest/content/ArtistController.kt
+++ b/backend/src/main/kotlin/com/fanpulse/interfaces/rest/content/ArtistController.kt
@@ -19,6 +19,10 @@ import java.util.*
 
 private val logger = KotlinLogging.logger {}
 
+/**
+ * REST controller for artist information.
+ * 아티스트 목록 조회 및 상세 정보 API를 제공한다.
+ */
 @RestController
 @RequestMapping("/api/v1/artists")
 @Tag(name = "Artists", description = "K-POP artist information")

--- a/backend/src/main/kotlin/com/fanpulse/interfaces/rest/content/ChartController.kt
+++ b/backend/src/main/kotlin/com/fanpulse/interfaces/rest/content/ChartController.kt
@@ -20,6 +20,10 @@ import java.util.*
 
 private val logger = KotlinLogging.logger {}
 
+/**
+ * REST controller for music chart rankings.
+ * 음원 차트 목록 조회 및 날짜별 차트 데이터 API를 제공한다.
+ */
 @RestController
 @RequestMapping("/api/v1/charts")
 @Tag(name = "Charts", description = "Music chart rankings")

--- a/backend/src/main/kotlin/com/fanpulse/interfaces/rest/content/NewsController.kt
+++ b/backend/src/main/kotlin/com/fanpulse/interfaces/rest/content/NewsController.kt
@@ -21,6 +21,10 @@ import java.util.*
 
 private val logger = KotlinLogging.logger {}
 
+/**
+ * REST controller for K-POP news articles.
+ * 뉴스 기사 목록 조회 및 상세 조회 API를 제공한다.
+ */
 @RestController
 @RequestMapping("/api/v1/news")
 @Tag(name = "News", description = "K-POP news articles")

--- a/backend/src/main/kotlin/com/fanpulse/interfaces/rest/search/SearchController.kt
+++ b/backend/src/main/kotlin/com/fanpulse/interfaces/rest/search/SearchController.kt
@@ -18,6 +18,9 @@ import org.springframework.web.bind.annotation.RestController
 
 private val logger = KotlinLogging.logger {}
 
+/**
+ * 라이브 스트리밍과 뉴스를 통합 검색하는 API 엔드포인트를 제공한다.
+ */
 @RestController
 @RequestMapping("/api/v1/search")
 @Tag(name = "Search", description = "Unified search across live streaming events and news")


### PR DESCRIPTION
## Summary
- 백엔드 Kotlin 소스 파일 47개에 KDoc 컨벤션 기반 한국어 주석 추가
- domain, application, infrastructure, interfaces 전 레이어 대상
- `@property`, `@param`, `@return`, `@throws` 태그 포함
- 코드 참조/프레임워크명 외 모든 설명은 한국어로 작성

## 변경 범위
- **domain**: 엔티티(`StreamingEvent`, `Comment`, `ArtistChannel`), 포트, enum
- **application**: 서비스 인터페이스/구현체, DTO
- **infrastructure**: 어댑터, 컨트롤러, 설정 클래스, 스케줄러
- **interfaces**: REST 컨트롤러

## Test plan
- [ ] 빌드 성공 확인 (`./gradlew build`)
- [ ] 기존 테스트 통과 확인
- [ ] KDoc 렌더링 확인 (IDE에서 hover 시 한국어 문서 표시)