### PR TITLE
fix(docker): .env.docker 파일 자동 로드 설정 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+env_file:
+  - .env.docker
+
 services:
   postgres:
     image: postgres:14


### PR DESCRIPTION
## Summary
- Docker Compose `env_file` 디렉티브를 추가하여 `.env.docker` 파일이 자동으로 로드되도록 수정
- Docker Compose는 기본적으로 `.env` 파일만 자동 로드하므로, `.env.docker`의 환경변수(`GOOGLE_CLIENT_ID`, `AI_API_KEY` 등)가 서비스에 주입되지 않는 문제 해결

## Test plan
- [ ] `docker compose up` 실행 후 `docker exec fanpulse-spring env | grep GOOGLE_CLIENT_ID`로 환경변수 주입 확인
- [ ] Google 로그인 정상 동작 확인