### PR TITLE
refactor(api): REST API 응답 포맷 통일

### DIFF
--- a/backend/src/main/kotlin/com/fanpulse/interfaces/rest/common/ApiResponse.kt
+++ b/backend/src/main/kotlin/com/fanpulse/interfaces/rest/common/ApiResponse.kt
@@ -1,0 +1,21 @@
+package com.fanpulse.interfaces.rest.common
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 모든 REST API 엔드포인트에서 사용하는 공통 응답 래퍼.
+ * `{ success: true, data: T }` 형태로 일관된 응답 포맷을 보장한다.
+ */
+@Schema(description = "Standard API response wrapper")
+data class ApiResponse<T>(
+    @Schema(description = "Request success status")
+    val success: Boolean,
+
+    @Schema(description = "Response data")
+    val data: T? = null
+) {
+    companion object {
+        fun <T> success(data: T): ApiResponse<T> = ApiResponse(success = true, data = data)
+        fun <T> error(): ApiResponse<T> = ApiResponse(success = false, data = null)
+    }
+}

--- a/backend/src/main/kotlin/com/fanpulse/interfaces/rest/content/ArtistController.kt
+++ b/backend/src/main/kotlin/com/fanpulse/interfaces/rest/content/ArtistController.kt
@@ -3,11 +3,12 @@ package com.fanpulse.interfaces.rest.content
 import com.fanpulse.application.dto.content.ArtistListResponse
 import com.fanpulse.application.dto.content.ArtistResponse
 import com.fanpulse.application.service.content.ArtistQueryService
+import com.fanpulse.interfaces.rest.common.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
-import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import mu.KotlinLogging
@@ -36,7 +37,7 @@ class ArtistController(
         description = "Returns a paginated list of artists"
     )
     @ApiResponses(
-        ApiResponse(
+        SwaggerApiResponse(
             responseCode = "200",
             description = "Artists retrieved successfully",
             content = [Content(schema = Schema(implementation = ArtistListResponse::class))]
@@ -57,7 +58,7 @@ class ArtistController(
 
         @Parameter(description = "Sort direction")
         @RequestParam(defaultValue = "asc") sortDir: String
-    ): ResponseEntity<ArtistListResponse> {
+    ): ResponseEntity<ApiResponse<ArtistListResponse>> {
         logger.debug { "Getting artists, activeOnly=$activeOnly" }
         val sort = Sort.by(
             if (sortDir.equals("desc", ignoreCase = true)) Sort.Direction.DESC else Sort.Direction.ASC,
@@ -70,7 +71,7 @@ class ArtistController(
         } else {
             queryService.getAll(pageable)
         }
-        return ResponseEntity.ok(response)
+        return ResponseEntity.ok(ApiResponse.success(response))
     }
 
     @GetMapping("/{id}")
@@ -79,20 +80,20 @@ class ArtistController(
         description = "Returns detailed information about a specific artist"
     )
     @ApiResponses(
-        ApiResponse(
+        SwaggerApiResponse(
             responseCode = "200",
             description = "Artist retrieved successfully",
             content = [Content(schema = Schema(implementation = ArtistResponse::class))]
         ),
-        ApiResponse(responseCode = "404", description = "Artist not found")
+        SwaggerApiResponse(responseCode = "404", description = "Artist not found")
     )
     fun getArtist(
         @Parameter(description = "Artist ID")
         @PathVariable id: UUID
-    ): ResponseEntity<ArtistResponse> {
+    ): ResponseEntity<ApiResponse<ArtistResponse>> {
         logger.debug { "Getting artist by ID: $id" }
         val response = queryService.getById(id)
-        return ResponseEntity.ok(response)
+        return ResponseEntity.ok(ApiResponse.success(response))
     }
 
     @GetMapping("/search")
@@ -109,10 +110,10 @@ class ArtistController(
 
         @Parameter(description = "Page size")
         @RequestParam(defaultValue = "20") size: Int
-    ): ResponseEntity<ArtistListResponse> {
+    ): ResponseEntity<ApiResponse<ArtistListResponse>> {
         logger.debug { "Searching artists with query: $q" }
         val pageable = PageRequest.of(page, size.coerceIn(1, 100))
         val response = queryService.search(q, pageable)
-        return ResponseEntity.ok(response)
+        return ResponseEntity.ok(ApiResponse.success(response))
     }
 }

--- a/backend/src/main/kotlin/com/fanpulse/interfaces/rest/content/ChartController.kt
+++ b/backend/src/main/kotlin/com/fanpulse/interfaces/rest/content/ChartController.kt
@@ -3,12 +3,13 @@ package com.fanpulse.interfaces.rest.content
 import com.fanpulse.application.dto.content.ChartListResponse
 import com.fanpulse.application.dto.content.ChartResponse
 import com.fanpulse.application.service.content.ChartQueryService
+import com.fanpulse.interfaces.rest.common.ApiResponse
 import com.fanpulse.domain.content.ChartType
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
-import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import mu.KotlinLogging
@@ -37,20 +38,20 @@ class ChartController(
         description = "Returns detailed chart information with all entries"
     )
     @ApiResponses(
-        ApiResponse(
+        SwaggerApiResponse(
             responseCode = "200",
             description = "Chart retrieved successfully",
             content = [Content(schema = Schema(implementation = ChartResponse::class))]
         ),
-        ApiResponse(responseCode = "404", description = "Chart not found")
+        SwaggerApiResponse(responseCode = "404", description = "Chart not found")
     )
     fun getChartById(
         @Parameter(description = "Chart ID")
         @PathVariable id: UUID
-    ): ResponseEntity<ChartResponse> {
+    ): ResponseEntity<ApiResponse<ChartResponse>> {
         logger.debug { "Getting chart by ID: $id" }
         val response = queryService.getById(id)
-        return ResponseEntity.ok(response)
+        return ResponseEntity.ok(ApiResponse.success(response))
     }
 
     @GetMapping("/{chartType}/latest")
@@ -59,20 +60,20 @@ class ChartController(
         description = "Returns the most recent chart for a specific type"
     )
     @ApiResponses(
-        ApiResponse(
+        SwaggerApiResponse(
             responseCode = "200",
             description = "Chart retrieved successfully",
             content = [Content(schema = Schema(implementation = ChartResponse::class))]
         ),
-        ApiResponse(responseCode = "404", description = "Chart not found")
+        SwaggerApiResponse(responseCode = "404", description = "Chart not found")
     )
     fun getLatestChart(
         @Parameter(description = "Chart type")
         @PathVariable chartType: ChartType
-    ): ResponseEntity<ChartResponse> {
+    ): ResponseEntity<ApiResponse<ChartResponse>> {
         logger.debug { "Getting latest chart for type: $chartType" }
         val response = queryService.getLatestByType(chartType)
-        return ResponseEntity.ok(response)
+        return ResponseEntity.ok(ApiResponse.success(response))
     }
 
     @GetMapping("/{chartType}/date/{date}")
@@ -81,12 +82,12 @@ class ChartController(
         description = "Returns chart for a specific type and date"
     )
     @ApiResponses(
-        ApiResponse(
+        SwaggerApiResponse(
             responseCode = "200",
             description = "Chart retrieved successfully",
             content = [Content(schema = Schema(implementation = ChartResponse::class))]
         ),
-        ApiResponse(responseCode = "404", description = "Chart not found")
+        SwaggerApiResponse(responseCode = "404", description = "Chart not found")
     )
     fun getChartByDate(
         @Parameter(description = "Chart type")
@@ -94,10 +95,10 @@ class ChartController(
 
         @Parameter(description = "Chart date (YYYY-MM-DD)")
         @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate
-    ): ResponseEntity<ChartResponse> {
+    ): ResponseEntity<ApiResponse<ChartResponse>> {
         logger.debug { "Getting chart for type: $chartType and date: $date" }
         val response = queryService.getByTypeAndDate(chartType, date)
-        return ResponseEntity.ok(response)
+        return ResponseEntity.ok(ApiResponse.success(response))
     }
 
     @GetMapping("/{chartType}/history")
@@ -114,9 +115,9 @@ class ChartController(
 
         @Parameter(description = "End date (YYYY-MM-DD)")
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate
-    ): ResponseEntity<ChartListResponse> {
+    ): ResponseEntity<ApiResponse<ChartListResponse>> {
         logger.debug { "Getting chart history for type: $chartType from $startDate to $endDate" }
         val response = queryService.getByDateRange(chartType, startDate, endDate)
-        return ResponseEntity.ok(response)
+        return ResponseEntity.ok(ApiResponse.success(response))
     }
 }

--- a/backend/src/main/kotlin/com/fanpulse/interfaces/rest/content/NewsController.kt
+++ b/backend/src/main/kotlin/com/fanpulse/interfaces/rest/content/NewsController.kt
@@ -5,11 +5,12 @@ import com.fanpulse.application.dto.content.NewsListResponse
 import com.fanpulse.application.dto.content.NewsResponse
 import com.fanpulse.application.service.content.NewsQueryService
 import com.fanpulse.domain.content.NewsCategory
+import com.fanpulse.interfaces.rest.common.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
-import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import mu.KotlinLogging
@@ -38,7 +39,7 @@ class NewsController(
         description = "Returns a paginated list of news articles"
     )
     @ApiResponses(
-        ApiResponse(
+        SwaggerApiResponse(
             responseCode = "200",
             description = "News retrieved successfully",
             content = [Content(schema = Schema(implementation = NewsListResponse::class))]
@@ -62,7 +63,7 @@ class NewsController(
 
         @Parameter(description = "Sort direction")
         @RequestParam(defaultValue = "desc") sortDir: String
-    ): ResponseEntity<NewsListResponse> {
+    ): ResponseEntity<ApiResponse<NewsListResponse>> {
         logger.debug { "Getting news with artistId=$artistId, category=$category" }
         val sort = Sort.by(
             if (sortDir.equals("asc", ignoreCase = true)) Sort.Direction.ASC else Sort.Direction.DESC,
@@ -72,7 +73,7 @@ class NewsController(
         val filter = NewsFilter(artistId = artistId, category = category)
 
         val response = queryService.getAll(filter, pageable)
-        return ResponseEntity.ok(response)
+        return ResponseEntity.ok(ApiResponse.success(response))
     }
 
     @GetMapping("/{id}")
@@ -81,20 +82,20 @@ class NewsController(
         description = "Returns detailed information about a specific news article"
     )
     @ApiResponses(
-        ApiResponse(
+        SwaggerApiResponse(
             responseCode = "200",
             description = "News retrieved successfully",
             content = [Content(schema = Schema(implementation = NewsResponse::class))]
         ),
-        ApiResponse(responseCode = "404", description = "News not found")
+        SwaggerApiResponse(responseCode = "404", description = "News not found")
     )
     fun getNewsById(
         @Parameter(description = "News ID")
         @PathVariable id: UUID
-    ): ResponseEntity<NewsResponse> {
+    ): ResponseEntity<ApiResponse<NewsResponse>> {
         logger.debug { "Getting news by ID: $id" }
         val response = queryService.getById(id)
-        return ResponseEntity.ok(response)
+        return ResponseEntity.ok(ApiResponse.success(response))
     }
 
     @GetMapping("/latest")
@@ -105,10 +106,10 @@ class NewsController(
     fun getLatestNews(
         @Parameter(description = "Number of articles to return")
         @RequestParam(defaultValue = "10") limit: Int
-    ): ResponseEntity<List<NewsResponse>> {
+    ): ResponseEntity<ApiResponse<List<NewsResponse>>> {
         logger.debug { "Getting latest $limit news" }
         val response = queryService.getLatest(limit.coerceIn(1, 50))
-        return ResponseEntity.ok(response)
+        return ResponseEntity.ok(ApiResponse.success(response))
     }
 
     @GetMapping("/search")
@@ -125,10 +126,10 @@ class NewsController(
 
         @Parameter(description = "Page size")
         @RequestParam(defaultValue = "20") size: Int
-    ): ResponseEntity<NewsListResponse> {
+    ): ResponseEntity<ApiResponse<NewsListResponse>> {
         logger.debug { "Searching news with query: $q" }
         val pageable = PageRequest.of(page, size.coerceIn(1, 100))
         val response = queryService.search(q, pageable)
-        return ResponseEntity.ok(response)
+        return ResponseEntity.ok(ApiResponse.success(response))
     }
 }

--- a/backend/src/test/kotlin/com/fanpulse/interfaces/rest/content/ArtistControllerTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/interfaces/rest/content/ArtistControllerTest.kt
@@ -58,10 +58,11 @@ class ArtistControllerTest {
             // When & Then
             mockMvc.get("/api/v1/artists").andExpect {
                 status { isOk() }
-                jsonPath("$.content") { isArray() }
-                jsonPath("$.content[0].id") { value(artistId.toString()) }
-                jsonPath("$.content[0].name") { value("BTS") }
-                jsonPath("$.totalElements") { value(1) }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data.content") { isArray() }
+                jsonPath("$.data.content[0].id") { value(artistId.toString()) }
+                jsonPath("$.data.content[0].name") { value("BTS") }
+                jsonPath("$.data.totalElements") { value(1) }
             }
         }
     }
@@ -80,9 +81,10 @@ class ArtistControllerTest {
             // When & Then
             mockMvc.get("/api/v1/artists/{id}", artistId).andExpect {
                 status { isOk() }
-                jsonPath("$.id") { value(artistId.toString()) }
-                jsonPath("$.name") { value("BTS") }
-                jsonPath("$.agency") { value("HYBE") }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data.id") { value(artistId.toString()) }
+                jsonPath("$.data.name") { value("BTS") }
+                jsonPath("$.data.agency") { value("HYBE") }
             }
         }
 
@@ -123,7 +125,8 @@ class ArtistControllerTest {
                 param("q", "BTS")
             }.andExpect {
                 status { isOk() }
-                jsonPath("$.content[0].name") { value("BTS") }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data.content[0].name") { value("BTS") }
             }
         }
     }


### PR DESCRIPTION
Closes #246 - 모든 REST API 엔드포인트 응답을 ApiResponse 래퍼로 통일