### PR TITLE
feat: 홈페이지 스트리밍/뉴스 UI 및 yt-dlp 안정화

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,6 +15,28 @@ RUN gradle bootJar -x test --no-daemon
 FROM eclipse-temurin:17-jre-jammy
 WORKDIR /app
 
+ARG YT_DLP_VERSION=2026.03.17
+ARG YT_DLP_SHA256=3bda0968a01cde70d26720653003b28553c71be14dcb2e5f4c24e9921fdad745
+# Deno: webhook-channel 서버 런타임 (GitHub PR 리뷰 자동화)
+ARG DENO_VERSION=v2.7.12
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3 ffmpeg curl unzip && \
+    curl -fsSL https://github.com/yt-dlp/yt-dlp/releases/download/${YT_DLP_VERSION}/yt-dlp -o /usr/local/bin/yt-dlp && \
+    echo "${YT_DLP_SHA256}  /usr/local/bin/yt-dlp" | sha256sum -c - && \
+    chmod a+rx /usr/local/bin/yt-dlp && \
+    ARCH=$(dpkg --print-architecture) && \
+    case "${ARCH}" in \
+      amd64) DENO_ARCH="x86_64-unknown-linux-gnu" DENO_SHA="4646ec32b4296fdf963a62a3df3d57e342a3c70376976e5690c34d42e23a3080" ;; \
+      arm64) DENO_ARCH="aarch64-unknown-linux-gnu" DENO_SHA="4116c1bb5fa2bba348a1f89c5392d5ecdbb505dd7166796870660556ea6c6c53" ;; \
+      *) echo "Unsupported arch: ${ARCH}" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/denoland/deno/releases/download/${DENO_VERSION}/deno-${DENO_ARCH}.zip" -o /tmp/deno.zip && \
+    echo "${DENO_SHA}  /tmp/deno.zip" | sha256sum -c - && \
+    unzip -o /tmp/deno.zip -d /usr/local/bin && \
+    chmod a+rx /usr/local/bin/deno && \
+    rm /tmp/deno.zip && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 RUN groupadd -r appgroup && useradd -r -g appgroup -s /bin/false appuser
 
 COPY --from=builder /app/build/libs/*.jar app.jar

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/external/youtube/YtDlpStreamDiscoveryAdapter.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/external/youtube/YtDlpStreamDiscoveryAdapter.kt
@@ -63,8 +63,8 @@ class YtDlpStreamDiscoveryAdapter(
             "Invalid channel handle format: $handle"
         }
         val normalized = if (handle.startsWith("@")) handle else "@$handle"
-        // /videos 탭에서 라이브 영상 포함하여 크롤링 (K-Pop 채널 지원)
-        return "https://www.youtube.com/$normalized/videos"
+        // /streams 탭에서 라이브/예정/종료 스트리밍만 크롤링
+        return "https://www.youtube.com/$normalized/streams"
     }
 
     private fun executeYtDlp(channelUrl: String): String {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -64,8 +64,8 @@ fanpulse:
   discovery:
     ytdlp:
       command: yt-dlp
-      timeout-ms: 30000   # 30초 타임아웃
-      playlist-limit: 30   # 채널당 30개
+      timeout-ms: 60000   # 60초 타임아웃
+      playlist-limit: 10   # 채널당 10개
       extract-flat: false
 
   scheduler:
@@ -192,12 +192,9 @@ resilience4j:
           - com.fanpulse.infrastructure.external.ai.AiServiceException
 
       ytdlp:
-        maxAttempts: 3
+        maxAttempts: 2
         waitDuration: 2s
-        enableExponentialBackoff: true
-        exponentialBackoffMultiplier: 2
         retryExceptions:
-          - java.lang.IllegalStateException
           - java.io.IOException
 
   # TimeLimiter 설정 (reactive WebClient에서는 .timeout() operator로 처리)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,8 +41,9 @@ services:
       AI_SERVICE_API_KEY: ${AI_API_KEY:-test-api-key}
       JWT_SECRET: ${JWT_SECRET:-default-dev-secret-key-256-bits-long-for-hs256-algorithm}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-test-google-client-id.apps.googleusercontent.com}
-      FANPULSE_SCHEDULER_LIVE_DISCOVERY_ENABLED: "false"
-      FANPULSE_SCHEDULER_METADATA_REFRESH_ENABLED: "false"
+      FANPULSE_SCHEDULER_LIVE_DISCOVERY_ENABLED: "${FANPULSE_SCHEDULER_LIVE_DISCOVERY_ENABLED:-false}"
+      FANPULSE_SCHEDULER_METADATA_REFRESH_ENABLED: "${FANPULSE_SCHEDULER_METADATA_REFRESH_ENABLED:-false}"
+      FANPULSE_SCHEDULER_LIVE_DISCOVERY_MAX_CONCURRENCY: "${FANPULSE_SCHEDULER_LIVE_DISCOVERY_MAX_CONCURRENCY:-2}"
       JAVA_TOOL_OPTIONS: "-Xmx512m -Xms256m"
     depends_on:
       postgres:
@@ -57,7 +58,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 768M
+          memory: 1536M
     networks:
       - fanpulse-net
 

--- a/readme.md
+++ b/readme.md
@@ -39,10 +39,10 @@ graph TB
     end
 
     subgraph AI["Django AI Sidecar"]
-        MOD["콘텐츠 모더레이션"]
-        FILTER["댓글 필터링"]
-        SUMMARY["뉴스 요약"]
-        CRAWL["뉴스 크롤링"]
+        MOD["콘텐츠 모더레이션<br/>(KcBERT, RoBERTa)"]
+        FILTER["댓글 필터링<br/>(Mistral-7B / Qwen2.5)"]
+        SUMMARY["뉴스 요약<br/>(T5, BART)"]
+        CRAWL["뉴스 크롤링<br/>(네이버 API)"]
     end
 
     DB[(PostgreSQL 14)]
@@ -150,6 +150,82 @@ sequenceDiagram
 - **CircuitBreaker 설정**: 실패율 60% 이상 -> 회로 개방, 30초 대기 후 Half-Open
 - **Retry**: 최대 2회, 500ms 간격, 지수 백오프
 - **TimeLimiter**: AI 응답 5초 제한 (요약은 30초)
+
+---
+
+## AI 서비스 상세
+
+Django AI Sidecar가 담당하는 AI 기능은 **3가지**입니다. 각 서비스는 독립적으로 동작하며, Spring Boot에서 HTTP로 호출합니다.
+
+### 1. 뉴스 요약 (News Summarizer)
+
+K-POP 뉴스 기사를 AI가 읽고 핵심 내용을 자동 요약합니다.
+
+- **방식**: 생성형 요약 (Abstractive Summarization) — 원문을 이해하고 새로운 문장으로 재구성
+- **사용 모델**
+  - 한국어: `eenzeenee/t5-base-korean-summarization`
+  - 영어: `facebook/bart-large-cnn`
+- **API 엔드포인트**
+  - `POST /api/ai/summarize` — 단건 요약
+  - `POST /api/news/batch-summarize` — 배치 요약 (다수 기사 한 번에 처리)
+  - `GET /api/news/summarized` — 요약 결과 조회
+- **장애 전략**: Fail-Open — AI 실패 시 원문 그대로 노출 (가용성 우선)
+- **Spring 어댑터**: `AiNewsSummarizerAdapter` / `NoOpNewsSummarizerAdapter` (fallback)
+
+### 2. 댓글 필터링 (Comment Filter)
+
+사용자 댓글을 LLM이 분석하여 맥락과 의도를 파악하고, 허용/차단 여부를 판단합니다.
+
+- **방식**: LLM 기반 추론 — 단순 키워드 매칭이 아니라 문맥을 이해하여 판단
+- **사용 모델**
+  - 우선: `mistralai/Mistral-7B-Instruct-v0.3`
+  - Fallback: `Qwen/Qwen2.5-3B-Instruct` (GPU VRAM 부족 시)
+- **API 엔드포인트**
+  - `POST /api/ai/filter` — 단건 필터링
+  - `POST /api/ai/filter/batch` — 배치 필터링
+- **장애 전략**: Fail-Pending — AI 실패 시 PENDING 상태로 저장, 관리자 검토 대기 (안전성 우선)
+- **댓글 상태 흐름**: `DRAFT` → AI 필터링 → `PUBLISHED` (허용) 또는 `FILTERED_BY_AI` (차단) 또는 `PENDING` (AI 장애)
+- **Spring 어댑터**: `AiCommentFilterAdapter` / `NoOpCommentFilterAdapter` (fallback)
+
+### 3. 콘텐츠 모더레이션 (Content Moderation)
+
+게시글/댓글에서 유해 콘텐츠를 카테고리별로 분류하고 점수를 매겨 자동 판정합니다.
+
+- **방식**: 분류 모델 기반 — 텍스트를 유해 카테고리별 확률 점수로 변환
+- **사용 모델**
+  - 한국어: `beomi/KcBERT-base` (한국어 악성 댓글 분류 특화)
+  - 다국어: `facebook/roberta-hate-speech-dynabench-r4-target`
+- **감지 카테고리** (6종)
+  - `profanity` — 욕설/비속어
+  - `spam` — 스팸 콘텐츠
+  - `adult` — 성인 콘텐츠
+  - `violence` — 폭력적 콘텐츠
+  - `hate` — 혐오 발언
+  - `harassment` — 괴롭힘/악성 댓글
+- **판정 수준** (4단계)
+  - `allow` — 허용
+  - `warning` — 경고 (사용자에게 경고 메시지 표시)
+  - `review` — 관리자 검토 대기
+  - `block` — 차단
+- **API 엔드포인트**
+  - `POST /api/ai/moderate` — 단건 모더레이션
+  - `POST /api/ai/moderate/batch` — 배치 모더레이션
+  - `GET /api/ai/moderate/status` — 모더레이션 서비스 상태 확인
+- **장애 전략**: Fail-Open — AI 실패 시 콘텐츠 허용 (가용성 우선)
+- **Spring 어댑터**: `AiModerationAdapter` / `NoOpContentModerationAdapter` (fallback)
+
+### 댓글 필터링 vs 콘텐츠 모더레이션
+
+두 서비스 모두 유해 콘텐츠를 감지하지만 접근 방식이 다르며, 이중 체크 구조로 운영됩니다.
+
+- **댓글 필터링**: LLM이 문맥과 의도를 추론 — "이 그룹 진짜 끝났다"가 팬 의견인지, 악의적 비하인지 판단
+- **콘텐츠 모더레이션**: 분류 모델이 카테고리별 확률 점수 산출 — "ㅅㅂ 꺼져" → profanity 0.95 → block
+
+```
+댓글 작성 → [댓글 필터링 (LLM)] → 허용/차단 판단
+              ↓
+         [콘텐츠 모더레이션 (분류)] → 카테고리별 점수 기록
+```
 
 ---
 

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -15,6 +15,14 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: '*.fanpulse.app',
       },
+      {
+        protocol: 'https',
+        hostname: 'i.ytimg.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'yt3.googleusercontent.com',
+      },
     ],
   },
   async rewrites() {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,7 +13,7 @@
         "i18next": "^25.7.3",
         "i18next-browser-languagedetector": "^8.2.0",
         "isomorphic-dompurify": "^3.0.0-rc.2",
-        "next": "16.1.1",
+        "next": "^16.2.2",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-i18next": "^16.5.1"
@@ -31,7 +31,7 @@
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^5.1.2",
         "eslint": "^9",
-        "eslint-config-next": "16.1.1",
+        "eslint-config-next": "^16.2.2",
         "jsdom": "^27.4.0",
         "tailwindcss": "^4",
         "typescript": "^5",
@@ -1755,15 +1755,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.1.tgz",
-      "integrity": "sha512-3oxyM97Sr2PqiVyMyrZUtrtM3jqqFxOQJVuKclDsgj/L728iZt/GyslkN4NwarledZATCenbk4Offjk1hQmaAA==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.2.tgz",
+      "integrity": "sha512-LqSGz5+xGk9EL/iBDr2yo/CgNQV6cFsNhRR2xhSXYh7B/hb4nePCxlmDvGEKG30NMHDFf0raqSyOZiQrO7BkHQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.1.tgz",
-      "integrity": "sha512-Ovb/6TuLKbE1UiPcg0p39Ke3puyTCIKN9hGbNItmpQsp+WX3qrjO3WaMVSi6JHr9X1NrmthqIguVHodMJbh/dw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.3.tgz",
+      "integrity": "sha512-nE/b9mht28XJxjTwKs/yk7w4XTaU3t40UHVAky6cjiijdP/SEy3hGsnQMPxmXPTpC7W4/97okm6fngKnvCqVaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1771,9 +1771,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.1.tgz",
-      "integrity": "sha512-JS3m42ifsVSJjSTzh27nW+Igfha3NdBOFScr9C80hHGrWx55pTrVL23RJbqir7k7/15SKlrLHhh/MQzqBBYrQA==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.2.tgz",
+      "integrity": "sha512-B92G3ulrwmkDSEJEp9+XzGLex5wC1knrmCSIylyVeiAtCIfvEJYiN3v5kXPlYt5R4RFlsfO/v++aKV63Acrugg==",
       "cpu": [
         "arm64"
       ],
@@ -1787,9 +1787,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.1.tgz",
-      "integrity": "sha512-hbyKtrDGUkgkyQi1m1IyD3q4I/3m9ngr+V93z4oKHrPcmxwNL5iMWORvLSGAf2YujL+6HxgVvZuCYZfLfb4bGw==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.2.tgz",
+      "integrity": "sha512-7ZwSgNKJNQiwW0CKhNm9B1WS2L1Olc4B2XY0hPYCAL3epFnugMhuw5TMWzMilQ3QCZcCHoYm9NGWTHbr5REFxw==",
       "cpu": [
         "x64"
       ],
@@ -1803,9 +1803,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.1.tgz",
-      "integrity": "sha512-/fvHet+EYckFvRLQ0jPHJCUI5/B56+2DpI1xDSvi80r/3Ez+Eaa2Yq4tJcRTaB1kqj/HrYKn8Yplm9bNoMJpwQ==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.2.tgz",
+      "integrity": "sha512-c3m8kBHMziMgo2fICOP/cd/5YlrxDU5YYjAJeQLyFsCqVF8xjOTH/QYG4a2u48CvvZZSj1eHQfBCbyh7kBr30Q==",
       "cpu": [
         "arm64"
       ],
@@ -1819,9 +1819,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.1.tgz",
-      "integrity": "sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.2.tgz",
+      "integrity": "sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==",
       "cpu": [
         "arm64"
       ],
@@ -1835,9 +1835,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.1.tgz",
-      "integrity": "sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.2.tgz",
+      "integrity": "sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g==",
       "cpu": [
         "x64"
       ],
@@ -1851,9 +1851,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.1.tgz",
-      "integrity": "sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.2.tgz",
+      "integrity": "sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==",
       "cpu": [
         "x64"
       ],
@@ -1867,9 +1867,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.1.tgz",
-      "integrity": "sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.2.tgz",
+      "integrity": "sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g==",
       "cpu": [
         "arm64"
       ],
@@ -1883,9 +1883,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.1.tgz",
-      "integrity": "sha512-Ncwbw2WJ57Al5OX0k4chM68DKhEPlrXBaSXDCi2kPi5f4d8b3ejr3RRJGfKBLrn2YJL5ezNS7w2TZLHSti8CMw==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.2.tgz",
+      "integrity": "sha512-aHaKceJgdySReT7qeck5oShucxWRiiEuwCGK8HHALe6yZga8uyFpLkPgaRw3kkF04U7ROogL/suYCNt/+CuXGA==",
       "cpu": [
         "x64"
       ],
@@ -2565,6 +2565,66 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",
@@ -3878,12 +3938,15 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.11",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
-      "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
+      "version": "2.10.16",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
+      "integrity": "sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==",
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bidi-js": {
@@ -4738,13 +4801,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.1.1.tgz",
-      "integrity": "sha512-55nTpVWm3qeuxoQKLOjQVciKZJUphKrNM0fCcQHAIOGl6VFXgaqeMfv0aKJhs7QtcnlAPhNVqsqRfRjeKBPIUA==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.3.tgz",
+      "integrity": "sha512-Dnkrylzjof/Az7iNoIQJqD18zTxQZcngir19KJaiRsMnnjpQSVoa6aEg/1Q4hQC+cW90uTlgQYadwL1CYNwFWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.1.1",
+        "@next/eslint-plugin-next": "16.2.3",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -4868,7 +4931,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6991,14 +7053,14 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.1.tgz",
-      "integrity": "sha512-QI+T7xrxt1pF6SQ/JYFz95ro/mg/1Znk5vBebsWwbpejj1T0A23hO7GYEaVac9QUOT2BIMiuzm0L99ooq7k0/w==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.2.tgz",
+      "integrity": "sha512-i6AJdyVa4oQjyvX/6GeER8dpY/xlIV+4NMv/svykcLtURJSy/WzDnnUk/TM4d0uewFHK7xSQz4TbIwPgjky+3A==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.1",
+        "@next/env": "16.2.2",
         "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.8.3",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -7010,15 +7072,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.1",
-        "@next/swc-darwin-x64": "16.1.1",
-        "@next/swc-linux-arm64-gnu": "16.1.1",
-        "@next/swc-linux-arm64-musl": "16.1.1",
-        "@next/swc-linux-x64-gnu": "16.1.1",
-        "@next/swc-linux-x64-musl": "16.1.1",
-        "@next/swc-win32-arm64-msvc": "16.1.1",
-        "@next/swc-win32-x64-msvc": "16.1.1",
-        "sharp": "^0.34.4"
+        "@next/swc-darwin-arm64": "16.2.2",
+        "@next/swc-darwin-x64": "16.2.2",
+        "@next/swc-linux-arm64-gnu": "16.2.2",
+        "@next/swc-linux-arm64-musl": "16.2.2",
+        "@next/swc-linux-x64-gnu": "16.2.2",
+        "@next/swc-linux-x64-musl": "16.2.2",
+        "@next/swc-win32-arm64-msvc": "16.2.2",
+        "@next/swc-win32-x64-msvc": "16.2.2",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -7346,9 +7408,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
     "i18next": "^25.7.3",
     "i18next-browser-languagedetector": "^8.2.0",
     "isomorphic-dompurify": "^3.0.0-rc.2",
-    "next": "16.1.1",
+    "next": "^16.2.2",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-i18next": "^16.5.1"
@@ -39,7 +39,7 @@
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^5.1.2",
     "eslint": "^9",
-    "eslint-config-next": "16.1.1",
+    "eslint-config-next": "^16.2.2",
     "jsdom": "^27.4.0",
     "tailwindcss": "^4",
     "typescript": "^5",

--- a/web/src/app/components/home/NewsCard.tsx
+++ b/web/src/app/components/home/NewsCard.tsx
@@ -17,13 +17,21 @@ export default function NewsCard({ news }: NewsCardProps) {
       href={`/news/${id}`}
       className="flex gap-3 hover:bg-gray-50 p-2 rounded-xl transition-colors"
     >
-      <Image
-        src={thumbnailUrl}
-        alt={title}
-        width={96}
-        height={80}
-        className="w-24 h-20 rounded-lg object-cover object-top flex-shrink-0"
-      />
+      {thumbnailUrl ? (
+        <Image
+          src={thumbnailUrl}
+          alt={title}
+          width={96}
+          height={80}
+          className="w-24 h-20 rounded-lg object-cover object-top flex-shrink-0"
+        />
+      ) : (
+        <div className="w-24 h-20 rounded-lg bg-gradient-to-br from-purple-100 to-pink-100 flex-shrink-0 flex items-center justify-center">
+          <svg className="w-8 h-8 text-purple-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 7.5h1.5m-1.5 3h1.5m-7.5 3h7.5m-7.5 3h7.5m3-9h3.375c.621 0 1.125.504 1.125 1.125V18a2.25 2.25 0 0 1-2.25 2.25M16.5 7.5V18a2.25 2.25 0 0 0 2.25 2.25M16.5 7.5V4.875c0-.621-.504-1.125-1.125-1.125H4.125C3.504 3.75 3 4.254 3 4.875V18a2.25 2.25 0 0 0 2.25 2.25h13.5" />
+          </svg>
+        </div>
+      )}
       <div className="flex-1 min-w-0">
         <h3 className="font-medium text-gray-900 line-clamp-1">{title}</h3>
         <p className="text-sm text-gray-600 line-clamp-2 mt-0.5">{summary}</p>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -6,11 +6,19 @@ import LatestNewsSection from './components/home/LatestNewsSection';
 import SkeletonCard from '@/components/ui/SkeletonCard';
 
 export default function Home() {
-  const { liveNow, upcoming, latestNews, state, error, refresh } = useHomeSections();
+  const { liveNow, upcoming, recentLives, latestNews, state, error, refresh } = useHomeSections();
 
   if (state === 'loading') {
     return (
       <main className="max-w-7xl mx-auto pb-20">
+        <section className="px-4 py-3">
+          <div className="h-6 w-24 bg-gray-200 rounded mb-3" />
+          <div className="flex gap-4 overflow-hidden">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <SkeletonCard key={i} />
+            ))}
+          </div>
+        </section>
         <section className="px-4 py-3">
           <div className="h-6 w-24 bg-gray-200 rounded mb-3" />
           <div className="flex gap-4 overflow-hidden">
@@ -67,6 +75,13 @@ export default function Home() {
       <LiveSection
         title="Upcoming"
         lives={upcoming}
+        state={state}
+        onRetry={refresh}
+      />
+
+      <LiveSection
+        title="Recent Lives"
+        lives={recentLives}
         state={state}
         onRetry={refresh}
       />

--- a/web/src/hooks/useHomeSections.ts
+++ b/web/src/hooks/useHomeSections.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import axios from 'axios';
-import { fetchLiveNow, fetchUpcoming, fetchLatestNews } from '@/lib/api/home';
+import { fetchLiveNow, fetchUpcoming, fetchRecentLives, fetchLatestNews } from '@/lib/api/home';
 import type { Live } from '@/types/live';
 import type { News } from '@/types/news';
 import type { AsyncState } from '@/types/common';
@@ -19,6 +19,7 @@ function getErrorMessage(error: unknown): string {
 interface UseHomeSectionsReturn {
   liveNow: Live[];
   upcoming: Live[];
+  recentLives: Live[];
   latestNews: News[];
   state: AsyncState;
   error: string | null;
@@ -28,6 +29,7 @@ interface UseHomeSectionsReturn {
 export function useHomeSections(): UseHomeSectionsReturn {
   const [liveNow, setLiveNow] = useState<Live[]>([]);
   const [upcoming, setUpcoming] = useState<Live[]>([]);
+  const [recentLives, setRecentLives] = useState<Live[]>([]);
   const [latestNews, setLatestNews] = useState<News[]>([]);
   const [state, setState] = useState<AsyncState>('loading');
   const [error, setError] = useState<string | null>(null);
@@ -36,23 +38,26 @@ export function useHomeSections(): UseHomeSectionsReturn {
     setState('loading');
     setError(null);
 
-    try {
-      const [liveRes, upcomingRes, newsRes] = await Promise.all([
-        fetchLiveNow(5, signal),
-        fetchUpcoming(5, signal),
-        fetchLatestNews(10, signal),
-      ]);
+    const [liveRes, upcomingRes, recentRes, newsRes] = await Promise.allSettled([
+      fetchLiveNow(5, signal),
+      fetchUpcoming(5, signal),
+      fetchRecentLives(10, signal),
+      fetchLatestNews(10, signal),
+    ]);
 
-      if (signal?.aborted) return;
+    if (signal?.aborted) return;
 
-      setLiveNow(liveRes.items);
-      setUpcoming(upcomingRes.items);
-      setLatestNews(newsRes);
-      setState('success');
-    } catch (err) {
-      if (signal?.aborted) return;
-      setError(getErrorMessage(err));
+    setLiveNow(liveRes.status === 'fulfilled' ? liveRes.value.items : []);
+    setUpcoming(upcomingRes.status === 'fulfilled' ? upcomingRes.value.items : []);
+    setRecentLives(recentRes.status === 'fulfilled' ? recentRes.value.items : []);
+    setLatestNews(newsRes.status === 'fulfilled' ? newsRes.value : []);
+
+    const coresFailed = liveRes.status === 'rejected' && upcomingRes.status === 'rejected';
+    if (coresFailed) {
+      setError(getErrorMessage(liveRes.reason));
       setState('error');
+    } else {
+      setState('success');
     }
   }, []);
 
@@ -68,6 +73,7 @@ export function useHomeSections(): UseHomeSectionsReturn {
   return {
     liveNow,
     upcoming,
+    recentLives,
     latestNews,
     state,
     error,

--- a/web/src/lib/api/home.ts
+++ b/web/src/lib/api/home.ts
@@ -19,6 +19,14 @@ export async function fetchUpcoming(limit = 5, signal?: AbortSignal): Promise<Pa
   return data.data;
 }
 
+export async function fetchRecentLives(limit = 10, signal?: AbortSignal): Promise<PaginatedResponse<Live>> {
+  const { data } = await apiClient.get('/streaming-events', {
+    params: { status: 'ENDED', limit },
+    signal,
+  });
+  return data.data;
+}
+
 export async function fetchLatestNews(limit = 10, signal?: AbortSignal): Promise<News[]> {
   const { data } = await apiClient.get('/news/latest', {
     params: { limit },


### PR DESCRIPTION
## Summary

- yt-dlp 크롤링을 `/videos` → `/streams` 탭으로 전환하여 속도 개선 및 OOM 해결
- Spring 컨테이너 메모리/동시성 튜닝 (768M→1536M, concurrency 2)
- 홈페이지에 Recent Lives 섹션 추가 (ENDED 상태 스트리밍 표시)
- Next.js Image 컴포넌트 YouTube 호스트 허용 및 NewsCard 빈 이미지 에러 수정
- README에 AI 서비스 상세 섹션 추가 (요약/필터링/모더레이션)

## Changes

### Backend
- `YtDlpStreamDiscoveryAdapter.kt`: `/videos` → `/streams` 탭 전환
- `application.yml`: timeout 30s→60s, playlist-limit 30→10, retry 3→1
- `docker-compose.yml`: 메모리 1536M, 동시성 2 제한
- `Dockerfile`: deno 런타임 추가 (yt-dlp 의존)

### Web Frontend
- `page.tsx` / `useHomeSections.ts` / `home.ts`: Recent Lives 섹션 추가
- `next.config.ts`: `i.ytimg.com`, `yt3.googleusercontent.com` 호스트 허용
- `NewsCard.tsx`: 빈 이미지 src → placeholder div 대체
- `package.json`: Next.js 16.2.2 업그레이드

### Docs
- `readme.md`: AI 서비스 상세 섹션 추가 (뉴스 요약, 댓글 필터링, 콘텐츠 모더레이션)

## Test plan

- [ ] `docker compose up -d --build` 후 Spring 컨테이너 OOM 없이 정상 기동 확인
- [ ] localhost:3000 홈페이지에서 Recent Lives / 최신 뉴스 섹션 정상 렌더링
- [ ] YouTube 썸네일 이미지 정상 로드 (i.ytimg.com)
- [ ] 뉴스 이미지 없는 경우 placeholder 정상 표시