### PR TITLE
feat(web): 검색 페이지 API 연동 및 UI 구현 (H018)

### DIFF
--- a/web/src/app/search/page.tsx
+++ b/web/src/app/search/page.tsx
@@ -1,307 +1,302 @@
 "use client";
 
-import PageWrapper from "@/components/layout/PageWrapper";
+import { useState, useCallback } from "react";
+import { useTranslation } from "react-i18next";
 import Link from "next/link";
-import { useState } from "react";
+import PageWrapper from "@/components/layout/PageWrapper";
+import LiveCard from "@/app/components/home/LiveCard";
+import NewsCard from "@/app/components/home/NewsCard";
+import SkeletonCard from "@/components/ui/SkeletonCard";
+import { useSearch } from "@/hooks/useSearch";
+
+const RECENT_SEARCHES_KEY = "fanpulse_recent_searches";
+const MAX_RECENT_SEARCHES = 10;
+
+function loadRecentSearches(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(RECENT_SEARCHES_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveRecentSearches(searches: string[]) {
+  try {
+    localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(searches));
+  } catch {
+    // localStorage 용량 초과 등 무시
+  }
+}
+
+function addRecentSearch(term: string, current: string[]): string[] {
+  const filtered = current.filter((s) => s !== term);
+  const updated = [term, ...filtered].slice(0, MAX_RECENT_SEARCHES);
+  saveRecentSearches(updated);
+  return updated;
+}
 
 export default function SearchPage() {
-  const [searchQuery, setSearchQuery] = useState('');
-  const [activeTab, setActiveTab] = useState('all');
+  const { t } = useTranslation();
+  const { query, setQuery, lives, news, state, error } = useSearch();
+  const [recentSearches, setRecentSearches] = useState<string[]>(loadRecentSearches);
 
-  const recentSearches = ['BTS', 'BLACKPINK', '콘서트', 'NewJeans'];
-  const popularSearches = ['BTS 새 앨범', 'BLACKPINK 투어', 'SEVENTEEN', 'NewJeans 뮤비'];
+  const handleSearch = useCallback(
+    (term: string) => {
+      setQuery(term);
+      if (term.trim()) {
+        setRecentSearches((prev) => addRecentSearch(term.trim(), prev));
+      }
+    },
+    [setQuery]
+  );
 
-  const searchResults = {
-    artists: [
-      {
-        id: 1,
-        name: 'BTS',
-        image: 'https://readdy.ai/api/search-image?query=BTS%20K-pop%20group%20professional%20photo%2C%20seven%20members%2C%20modern%20style%2C%20high%20quality%20photography%2C%20purple%20theme%2C%20elegant%20composition&width=200&height=200&seq=search001&orientation=squarish',
-        followers: '1.2M'
-      },
-      {
-        id: 2,
-        name: 'BLACKPINK',
-        image: 'https://readdy.ai/api/search-image?query=BLACKPINK%20K-pop%20girl%20group%20professional%20photo%2C%20four%20members%2C%20glamorous%20style%2C%20high%20quality%20photography%2C%20pink%20and%20black%20theme&width=200&height=200&seq=search002&orientation=squarish',
-        followers: '980K'
-      }
-    ],
-    posts: [
-      {
-        id: 1,
-        author: 'ARMY_Forever',
-        content: 'BTS 새 앨범 티저 영상 보셨나요? 진짜 너무 기대돼요! 💜',
-        image: 'https://readdy.ai/api/search-image?query=BTS%20comeback%20teaser%20concept%2C%20professional%20photography%2C%20purple%20theme%2C%20modern%20aesthetic%2C%20high%20quality%2C%20artistic%20composition&width=300&height=200&seq=search003&orientation=landscape',
-        likes: 1234,
-        time: '2시간 전'
-      },
-      {
-        id: 2,
-        author: 'Blink_Girl',
-        content: 'BLACKPINK 월드투어 티켓 예매 성공했어요! 너무 설레요 ㅠㅠ',
-        image: 'https://readdy.ai/api/search-image?query=BLACKPINK%20world%20tour%20concert%20stage%2C%20spectacular%20lighting%2C%20pink%20and%20black%20theme%2C%20professional%20concert%20photography&width=300&height=200&seq=search004&orientation=landscape',
-        likes: 856,
-        time: '5시간 전'
-      }
-    ],
-    news: [
-      {
-        id: 1,
-        title: 'BTS 새 앨범 발매 예정',
-        category: '뉴스',
-        date: '2024.12.10',
-        image: 'https://readdy.ai/api/search-image?query=BTS%20new%20album%20announcement%2C%20professional%20press%20photo%2C%20modern%20studio%20setting%2C%20album%20cover%20concept%2C%20high%20quality%20photography%2C%20purple%20theme&width=300&height=200&seq=search005&orientation=landscape'
-      },
-      {
-        id: 2,
-        title: 'BLACKPINK 월드투어 추가 공연',
-        category: '공연',
-        date: '2024.12.09',
-        image: 'https://readdy.ai/api/search-image?query=BLACKPINK%20world%20tour%20concert%20announcement%2C%20glamorous%20stage%20setup%2C%20pink%20and%20black%20theme%2C%20professional%20concert%20photography&width=300&height=200&seq=search006&orientation=landscape'
-      }
-    ],
-    concerts: [
-      {
-        id: 1,
-        title: 'BTS World Tour 2025',
-        date: '2025.03.15',
-        venue: '잠실 올림픽 주경기장',
-        image: 'https://readdy.ai/api/search-image?query=BTS%20world%20tour%20concert%20poster%20design%2C%20professional%20layout%2C%20purple%20and%20blue%20gradient%2C%20modern%20typography%2C%20high%20quality%20graphics&width=300&height=400&seq=search007&orientation=portrait'
-      },
-      {
-        id: 2,
-        title: 'BLACKPINK BORN PINK TOUR',
-        date: '2025.04.20',
-        venue: '고척 스카이돔',
-        image: 'https://readdy.ai/api/search-image?query=BLACKPINK%20concert%20poster%20design%2C%20glamorous%20style%2C%20pink%20and%20black%20gradient%2C%20modern%20typography%2C%20high%20quality%20graphics&width=300&height=400&seq=search008&orientation=portrait'
-      }
-    ]
-  };
+  const handleInputChange = useCallback(
+    (value: string) => {
+      setQuery(value);
+    },
+    [setQuery]
+  );
 
-  const hasSearchQuery = searchQuery.length > 0;
+  const handleInputKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter" && query.trim()) {
+        setRecentSearches((prev) => addRecentSearch(query.trim(), prev));
+      }
+    },
+    [query]
+  );
+
+  const handleClearInput = useCallback(() => {
+    setQuery("");
+  }, [setQuery]);
+
+  const handleClearRecentSearches = useCallback(() => {
+    setRecentSearches([]);
+    saveRecentSearches([]);
+  }, []);
+
+  const handleRemoveRecentSearch = useCallback((term: string) => {
+    setRecentSearches((prev) => {
+      const updated = prev.filter((s) => s !== term);
+      saveRecentSearches(updated);
+      return updated;
+    });
+  }, []);
+
+  const hasQuery = query.trim().length > 0;
+  const hasResults = lives.length > 0 || news.length > 0;
 
   return (
     <>
+      {/* 검색 헤더 */}
       <header className="fixed top-0 left-0 right-0 bg-white border-b border-gray-200 z-50 lg:static lg:z-auto lg:border-none lg:bg-transparent lg:pt-8 lg:pb-4">
         <div className="px-4 py-3 lg:px-0 lg:max-w-4xl lg:mx-auto">
           <div className="flex items-center gap-2">
-            <Link href="/" className="w-9 h-9 flex items-center justify-center lg:hidden">
-              <i className="ri-arrow-left-line text-xl text-gray-900"></i>
+            <Link
+              href="/"
+              className="w-9 h-9 flex items-center justify-center lg:hidden"
+            >
+              <i className="ri-arrow-left-line text-xl text-gray-900" />
             </Link>
             <div className="flex-1 relative">
-              <input 
+              <input
                 type="text"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder="아티스트, 게시글, 뉴스 검색..."
+                value={query}
+                onChange={(e) => handleInputChange(e.target.value)}
+                onKeyDown={handleInputKeyDown}
+                placeholder={t("search.placeholder")}
                 className="w-full bg-gray-100 rounded-full pl-10 pr-10 py-2.5 text-sm border-none focus:outline-none focus:ring-2 focus:ring-purple-600 lg:py-3 lg:text-base"
               />
-              <i className="ri-search-line absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 lg:left-4"></i>
-              {searchQuery && (
-                <button 
-                  onClick={() => setSearchQuery('')}
+              <i className="ri-search-line absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 lg:left-4" />
+              {query && (
+                <button
+                  onClick={handleClearInput}
                   className="absolute right-3 top-1/2 -translate-y-1/2"
+                  aria-label="Clear search"
                 >
-                  <i className="ri-close-circle-fill text-gray-400"></i>
+                  <i className="ri-close-circle-fill text-gray-400" />
                 </button>
               )}
             </div>
           </div>
         </div>
-
-        {/* Tabs */}
-        {hasSearchQuery && (
-          <div className="px-4 pb-2 flex gap-2 overflow-x-auto scrollbar-hide lg:max-w-4xl lg:mx-auto lg:px-0 lg:pt-4">
-            {['all', 'artists', 'posts', 'news', 'concerts'].map(tab => (
-              <button
-                key={tab}
-                onClick={() => setActiveTab(tab)}
-                className={`px-4 py-1.5 rounded-full text-sm font-medium whitespace-nowrap transition-colors ${
-                  activeTab === tab
-                    ? 'bg-purple-600 text-white'
-                    : 'bg-gray-100 text-gray-600'
-                }`}
-              >
-                {tab === 'all' && '전체'}
-                {tab === 'artists' && '아티스트'}
-                {tab === 'posts' && '게시글'}
-                {tab === 'news' && '뉴스'}
-                {tab === 'concerts' && '콘서트'}
-              </button>
-            ))}
-          </div>
-        )}
       </header>
 
-      <PageWrapper className={hasSearchQuery ? 'pt-32' : 'pt-16'}>
-        {!hasSearchQuery ? (
-          <>
-            {/* Recent Searches */}
-            <div className="px-4 py-4">
-              <div className="flex items-center justify-between mb-3">
-                <h2 className="text-sm font-bold text-gray-900">최근 검색어</h2>
-                <button className="text-xs text-gray-500 hover:text-purple-600">전체 삭제</button>
-              </div>
-              <div className="flex flex-wrap gap-2">
-                {recentSearches.map((term, index) => (
-                  <button
-                    key={index}
-                    onClick={() => setSearchQuery(term)}
-                    className="flex items-center gap-2 bg-gray-100 px-3 py-2 rounded-full text-sm text-gray-700 hover:bg-gray-200 transition-colors"
-                  >
-                    <i className="ri-time-line text-gray-400"></i>
-                    {term}
-                    <i className="ri-close-line text-gray-400"></i>
-                  </button>
-                ))}
-              </div>
+      <PageWrapper className="pt-16">
+        {/* 검색어 없을 때: 최근 검색어 */}
+        {!hasQuery && (
+          <RecentSearchesSection
+            searches={recentSearches}
+            onSelect={handleSearch}
+            onRemove={handleRemoveRecentSearch}
+            onClearAll={handleClearRecentSearches}
+          />
+        )}
+
+        {/* 로딩 상태 */}
+        {hasQuery && state === "loading" && <SearchSkeleton />}
+
+        {/* 에러 상태 */}
+        {hasQuery && state === "error" && (
+          <div className="text-center py-16 px-4">
+            <div className="w-16 h-16 mx-auto mb-4 bg-red-50 rounded-full flex items-center justify-center">
+              <i className="ri-error-warning-line text-2xl text-red-400" />
             </div>
+            <p className="text-gray-500 mb-4">{error}</p>
+            <button
+              onClick={() => handleSearch(query)}
+              className="px-6 py-2 bg-purple-600 text-white rounded-full text-sm font-medium hover:bg-purple-700 transition-colors"
+            >
+              {t("search.errorRetry")}
+            </button>
+          </div>
+        )}
 
-            {/* Popular Searches */}
-            <div className="px-4 py-4 bg-gray-50">
-              <h2 className="text-sm font-bold text-gray-900 mb-3">인기 검색어</h2>
-              <div className="space-y-2">
-                {popularSearches.map((term, index) => (
-                  <button
-                    key={index}
-                    onClick={() => setSearchQuery(term)}
-                    className="flex items-center gap-3 w-full text-left py-2 hover:bg-gray-100 rounded-lg px-2 transition-colors"
-                  >
-                    <span className="text-purple-600 font-bold text-sm w-5">{index + 1}</span>
-                    <span className="text-sm text-gray-900">{term}</span>
-                  </button>
-                ))}
-              </div>
+        {/* 결과 없음 */}
+        {hasQuery && state === "success" && !hasResults && (
+          <div className="text-center py-16 px-4">
+            <div className="w-16 h-16 mx-auto mb-4 bg-gray-100 rounded-full flex items-center justify-center">
+              <i className="ri-search-line text-2xl text-gray-400" />
             </div>
-          </>
-        ) : (
-          <>
-            {/* Artists Results */}
-            {(activeTab === 'all' || activeTab === 'artists') && (
-              <div className="px-4 py-4">
-                <h2 className="text-sm font-bold text-gray-900 mb-3">아티스트</h2>
-                <div className="space-y-3">
-                  {searchResults.artists.map(artist => (
-                    <Link
-                      key={artist.id}
-                      href={`/artist-detail?id=${artist.id}`}
-                      className="flex items-center gap-3 hover:bg-gray-50 p-2 rounded-xl transition-colors"
-                    >
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img
-                        src={artist.image}
-                        alt={artist.name}
-                        className="w-14 h-14 rounded-full object-cover"
-                      />
-                      <div className="flex-1">
-                        <h3 className="font-bold text-gray-900">{artist.name}</h3>
-                        <p className="text-xs text-gray-500">팔로워 {artist.followers}</p>
-                      </div>
-                      <button className="px-4 py-1.5 border-2 border-purple-600 text-purple-600 rounded-full text-sm font-medium hover:bg-purple-50 transition-colors">
-                        팔로우
-                      </button>
-                    </Link>
+            <p className="text-gray-500">
+              {t("search.noResults", { query: query.trim() })}
+            </p>
+            <p className="text-sm text-gray-400 mt-1">
+              {t("search.noResultsHint")}
+            </p>
+          </div>
+        )}
+
+        {/* 검색 결과 */}
+        {hasQuery && state === "success" && hasResults && (
+          <div className="space-y-6 pb-4">
+            {/* Live 결과 */}
+            {lives.length > 0 && (
+              <section aria-label={t("search.liveResults")}>
+                <div className="flex items-center justify-between px-4 py-3">
+                  <h2 className="text-lg font-bold text-gray-900">
+                    {t("search.liveResults")}
+                  </h2>
+                </div>
+                <div className="flex overflow-x-auto gap-4 px-4 pb-2 scrollbar-hide">
+                  {lives.map((live) => (
+                    <LiveCard key={live.id} live={live} />
                   ))}
                 </div>
-              </div>
+              </section>
             )}
 
-            {/* Posts Results */}
-            {(activeTab === 'all' || activeTab === 'posts') && (
-              <div className="px-4 py-4 bg-gray-50">
-                <h2 className="text-sm font-bold text-gray-900 mb-3">게시글</h2>
-                <div className="space-y-3">
-                  {searchResults.posts.map(post => (
-                    <Link
-                      key={post.id}
-                      href={`/post-detail?id=${post.id}`}
-                      className="flex gap-3 bg-white rounded-xl p-3 shadow-sm hover:shadow-md transition-shadow"
-                    >
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img
-                        src={post.image}
-                        alt={post.content}
-                        className="w-24 h-20 rounded-lg object-cover object-top flex-shrink-0"
-                      />
-                      <div className="flex-1 min-w-0">
-                        <p className="text-xs text-purple-600 font-medium mb-1">{post.author}</p>
-                        <p className="text-sm text-gray-900 line-clamp-2 mb-2">{post.content}</p>
-                        <div className="flex items-center gap-3 text-xs text-gray-500">
-                          <span className="flex items-center gap-1">
-                            <i className="ri-heart-line"></i>
-                            {post.likes}
-                          </span>
-                          <span>{post.time}</span>
-                        </div>
-                      </div>
-                    </Link>
+            {/* News 결과 */}
+            {news.length > 0 && (
+              <section aria-label={t("search.newsResults")}>
+                <div className="flex items-center justify-between px-4 py-3">
+                  <h2 className="text-lg font-bold text-gray-900">
+                    {t("search.newsResults")}
+                  </h2>
+                </div>
+                <div className="space-y-1 px-4">
+                  {news.map((item) => (
+                    <NewsCard key={item.id} news={item} />
                   ))}
                 </div>
-              </div>
+              </section>
             )}
-
-            {/* News Results */}
-            {(activeTab === 'all' || activeTab === 'news') && (
-              <div className="px-4 py-4">
-                <h2 className="text-sm font-bold text-gray-900 mb-3">뉴스</h2>
-                <div className="space-y-3">
-                  {searchResults.news.map(news => (
-                    <Link
-                      key={news.id}
-                      href={`/news-detail?id=${news.id}`}
-                      className="flex gap-3 hover:bg-gray-50 p-2 rounded-xl transition-colors"
-                    >
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img
-                        src={news.image}
-                        alt={news.title}
-                        className="w-24 h-20 rounded-lg object-cover object-top flex-shrink-0"
-                      />
-                      <div className="flex-1">
-                        <span className="text-xs text-purple-600 font-medium">{news.category}</span>
-                        <h3 className="text-sm font-medium text-gray-900 mt-1 line-clamp-2">
-                          {news.title}
-                        </h3>
-                        <p className="text-xs text-gray-500 mt-1">{news.date}</p>
-                      </div>
-                    </Link>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Concerts Results */}
-            {(activeTab === 'all' || activeTab === 'concerts') && (
-              <div className="px-4 py-4 bg-gray-50">
-                <h2 className="text-sm font-bold text-gray-900 mb-3">콘서트</h2>
-                <div className="grid grid-cols-2 gap-3">
-                  {searchResults.concerts.map(concert => (
-                    <Link
-                      key={concert.id}
-                      href={`/concert-detail?id=${concert.id}`}
-                      className="bg-white rounded-xl overflow-hidden shadow-sm hover:shadow-md transition-shadow"
-                    >
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img
-                        src={concert.image}
-                        alt={concert.title}
-                        className="w-full h-48 object-cover object-top"
-                      />
-                      <div className="p-3">
-                        <h3 className="text-sm font-bold text-gray-900 line-clamp-1 mb-1">
-                          {concert.title}
-                        </h3>
-                        <p className="text-xs text-gray-600 mb-1">{concert.date}</p>
-                        <p className="text-xs text-gray-500 line-clamp-1">{concert.venue}</p>
-                      </div>
-                    </Link>
-                  ))}
-                </div>
-              </div>
-            )}
-          </>
+          </div>
         )}
       </PageWrapper>
     </>
+  );
+}
+
+/* ─── 최근 검색어 ─── */
+
+interface RecentSearchesSectionProps {
+  searches: string[];
+  onSelect: (term: string) => void;
+  onRemove: (term: string) => void;
+  onClearAll: () => void;
+}
+
+function RecentSearchesSection({
+  searches,
+  onSelect,
+  onRemove,
+  onClearAll,
+}: RecentSearchesSectionProps) {
+  const { t } = useTranslation();
+
+  if (searches.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="px-4 py-4">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-sm font-bold text-gray-900">
+          {t("search.recentSearches")}
+        </h2>
+        <button
+          onClick={onClearAll}
+          className="text-xs text-gray-500 hover:text-purple-600 transition-colors"
+        >
+          {t("search.clearAll")}
+        </button>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {searches.map((term) => (
+          <div
+            key={term}
+            className="flex items-center gap-1.5 bg-gray-100 rounded-full text-sm text-gray-700 hover:bg-gray-200 transition-colors"
+          >
+            <button
+              onClick={() => onSelect(term)}
+              className="flex items-center gap-2 pl-3 py-2"
+            >
+              <i className="ri-time-line text-gray-400" />
+              {term}
+            </button>
+            <button
+              onClick={() => onRemove(term)}
+              className="pr-3 py-2"
+              aria-label={t("search.removeRecent")}
+            >
+              <i className="ri-close-line text-gray-400 hover:text-gray-600" />
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ─── 로딩 스켈레톤 ─── */
+
+function SearchSkeleton() {
+  return (
+    <div className="space-y-6 px-4 py-4">
+      {/* Live 스켈레톤 */}
+      <div>
+        <div className="h-5 w-20 bg-gray-200 rounded animate-pulse mb-3" />
+        <div className="flex overflow-x-auto gap-4 scrollbar-hide">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <SkeletonCard key={`live-${i}`} />
+          ))}
+        </div>
+      </div>
+
+      {/* News 스켈레톤 */}
+      <div>
+        <div className="h-5 w-16 bg-gray-200 rounded animate-pulse mb-3" />
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <SkeletonCard key={`news-${i}`} layout="horizontal" />
+          ))}
+        </div>
+      </div>
+    </div>
   );
 }

--- a/web/src/hooks/useSearch.ts
+++ b/web/src/hooks/useSearch.ts
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import axios from 'axios';
+import { searchAll, type SearchResultItem } from '@/lib/api/search';
+import type { Live } from '@/types/live';
+import type { News } from '@/types/news';
+import type { AsyncState } from '@/types/common';
+
+const DEBOUNCE_MS = 300;
+
+function getErrorMessage(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    if (error.code === 'ECONNABORTED') return '요청 시간이 초과되었습니다';
+    if (error.request && !error.response) return '네트워크 연결을 확인해주세요';
+    if (error.response && error.response.status >= 500) return '서버에 문제가 발생했습니다';
+  }
+  return '검색 결과를 불러올 수 없습니다';
+}
+
+function splitResults(items: SearchResultItem[]): { lives: Live[]; news: News[] } {
+  const lives: Live[] = [];
+  const news: News[] = [];
+
+  for (const item of items) {
+    if (item.type === 'LIVE' && item.live) {
+      lives.push(item.live);
+    } else if (item.type === 'NEWS' && item.news) {
+      news.push(item.news);
+    }
+  }
+
+  return { lives, news };
+}
+
+interface UseSearchReturn {
+  query: string;
+  setQuery: (q: string) => void;
+  lives: Live[];
+  news: News[];
+  state: AsyncState;
+  error: string | null;
+}
+
+export function useSearch(): UseSearchReturn {
+  const [query, setQuery] = useState('');
+  const [lives, setLives] = useState<Live[]>([]);
+  const [news, setNews] = useState<News[]>([]);
+  const [state, setState] = useState<AsyncState>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const abortRef = useRef<AbortController | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const executeSearch = useCallback(async (q: string) => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setState('loading');
+    setError(null);
+
+    try {
+      const result = await searchAll(q, 20, controller.signal);
+
+      if (controller.signal.aborted) return;
+
+      const { lives: liveItems, news: newsItems } = splitResults(result.items);
+      setLives(liveItems);
+      setNews(newsItems);
+      setState('success');
+    } catch (err) {
+      if (axios.isCancel(err) || (err instanceof DOMException && err.name === 'AbortError')) {
+        return;
+      }
+      setError(getErrorMessage(err));
+      setState('error');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+
+    const trimmed = query.trim();
+
+    if (!trimmed) {
+      abortRef.current?.abort();
+      timerRef.current = setTimeout(() => {
+        setLives([]);
+        setNews([]);
+        setState('idle');
+        setError(null);
+      }, 0);
+      return;
+    }
+
+    timerRef.current = setTimeout(() => {
+      executeSearch(trimmed);
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [query, executeSearch]);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  return { query, setQuery, lives, news, state, error };
+}

--- a/web/src/i18n/local/en.ts
+++ b/web/src/i18n/local/en.ts
@@ -1,6 +1,15 @@
 const enTranslations = {
   "app.title": "FanPulse",
-  "welcome": "Welcome to FanPulse"
+  "welcome": "Welcome to FanPulse",
+  "search.placeholder": "Search lives, news...",
+  "search.recentSearches": "Recent Searches",
+  "search.clearAll": "Clear All",
+  "search.liveResults": "Live",
+  "search.newsResults": "News",
+  "search.noResults": "No results found for \"{{query}}\"",
+  "search.noResultsHint": "Try a different keyword",
+  "search.errorRetry": "Retry",
+  "search.removeRecent": "Remove"
 };
 
 export default enTranslations;

--- a/web/src/lib/api/search.ts
+++ b/web/src/lib/api/search.ts
@@ -1,0 +1,27 @@
+import type { Live } from '@/types/live';
+import type { News } from '@/types/news';
+import { apiClient } from '@/lib/api-client';
+
+export interface SearchResultItem {
+  type: 'LIVE' | 'NEWS';
+  live?: Live;
+  news?: News;
+}
+
+export interface SearchResponse {
+  items: SearchResultItem[];
+  hasMore: boolean;
+  nextCursor?: string;
+}
+
+export async function searchAll(
+  query: string,
+  limit = 20,
+  signal?: AbortSignal
+): Promise<SearchResponse> {
+  const { data } = await apiClient.get('/search', {
+    params: { q: query, limit },
+    signal,
+  });
+  return data.data;
+}


### PR DESCRIPTION
## Summary
- 백엔드 `GET /api/search` 연동하여 Live/News 통합 검색 구현
- 디바운스(300ms) + AbortController 기반 검색 훅 추가
- 최근 검색어 localStorage 저장/삭제 (최대 10개)
- 검색 결과를 Live/News 섹션으로 분리하여 기존 LiveCard, NewsCard 재사용
- 로딩 스켈레톤, 에러 상태, 빈 결과 상태 처리
- i18n 번역키 적용

## 변경 파일
- `web/src/lib/api/search.ts` — 검색 API 모듈 (신규)
- `web/src/hooks/useSearch.ts` — 검색 커스텀 훅 (신규)
- `web/src/app/search/page.tsx` — 검색 페이지 전면 재구현
- `web/src/i18n/local/en.ts` — 검색 관련 번역키 추가

## 관련 이슈
Closes #256

## Test plan
- [ ] 검색어 입력 후 300ms 후 자동 검색 실행 확인
- [ ] Live/News 결과가 각각 섹션으로 분리되어 표시되는지 확인
- [ ] 최근 검색어 저장/개별 삭제/전체 삭제 동작 확인
- [ ] 검색 결과 클릭 시 `/live/[id]` 또는 `/news/[id]`로 이동 확인
- [ ] 빈 결과/에러/로딩 상태 UI 확인