### PR TITLE
feat(web): 마이페이지/설정 MVP API 연동 (H016, H010)

### DIFF
--- a/web/src/app/mypage/page.tsx
+++ b/web/src/app/mypage/page.tsx
@@ -4,41 +4,22 @@ import PageHeader from "@/components/layout/PageHeader";
 import PageWrapper from "@/components/layout/PageWrapper";
 import ProtectedRoute from "@/components/auth/ProtectedRoute";
 import { useAuth } from "@/contexts/AuthContext";
+import { useMyProfile } from "@/hooks/useMyProfile";
 import Link from "next/link";
 
 export default function MyPage() {
   const { logout, user: authUser } = useAuth();
+  const { profile, state } = useMyProfile();
 
-  // AuthContext에서 가져온 사용자 정보와 추가 프로필 정보 결합
-  const user = {
-    name: authUser?.username || authUser?.email?.split('@')[0] || '사용자',
-    email: authUser?.email || '',
-    avatar: 'https://readdy.ai/api/search-image?query=young%20asian%20woman%20profile%20photo%2C%20friendly%20smile%2C%20casual%20style%2C%20professional%20portrait%20photography%2C%20natural%20lighting%2C%20clean%20background&width=300&height=300&seq=mypage001&orientation=squarish',
-    // TODO: 아래 정보는 추후 프로필 API에서 가져오도록 수정
-    membership: 'VIP',
-    points: 12450,
-    level: 15
-  };
-
-  const stats = [
-    { label: '투표 참여', value: '247', icon: 'ri-trophy-line' },
-    { label: '게시물', value: '89', icon: 'ri-file-text-line' },
-    { label: '팔로워', value: '1.2K', icon: 'ri-user-follow-line' }
-  ];
-
-  const pointHistory = [
-    { id: 1, type: '적립', desc: '광고 시청', points: '+500', date: '2024.12.15' },
-    { id: 2, type: '사용', desc: '굿즈 구매', points: '-2000', date: '2024.12.14' },
-    { id: 3, type: '적립', desc: '투표 참여', points: '+100', date: '2024.12.13' },
-    { id: 4, type: '적립', desc: '출석 체크', points: '+50', date: '2024.12.12' }
-  ];
+  const displayName =
+    profile?.username ??
+    authUser?.username ??
+    authUser?.email?.split("@")[0] ??
+    "사용자";
+  const displayEmail = profile?.email ?? authUser?.email ?? "";
 
   const menuItems = [
-    { icon: 'ri-heart-line', label: '좋아요한 아티스트', link: '/favorites' },
-    { icon: 'ri-bookmark-line', label: '저장한 게시물', link: '/saved' },
-    { icon: 'ri-ticket-line', label: '예매 내역', link: '/tickets' },
-    { icon: 'ri-settings-3-line', label: '설정', link: '/settings' },
-    { icon: 'ri-customer-service-line', label: '고객센터', link: '/support' }
+    { icon: "ri-settings-3-line", label: "설정", link: "/settings" },
   ];
 
   return (
@@ -47,98 +28,49 @@ export default function MyPage() {
         title="마이페이지"
         showBack={false}
         rightAction={
-          <div className="flex items-center gap-2">
-            <Link href="/notifications" className="w-9 h-9 flex items-center justify-center relative rounded-full hover:bg-gray-100">
-              <i className="ri-notification-line text-xl text-gray-700"></i>
-              <span className="absolute top-1.5 right-1.5 w-2 h-2 bg-red-500 rounded-full"></span>
-            </Link>
-            <Link href="/settings" className="w-9 h-9 flex items-center justify-center rounded-full hover:bg-gray-100">
-              <i className="ri-settings-3-line text-xl text-gray-700"></i>
-            </Link>
-          </div>
+          <Link
+            href="/settings"
+            className="w-9 h-9 flex items-center justify-center rounded-full hover:bg-gray-100"
+          >
+            <i className="ri-settings-3-line text-xl text-gray-700"></i>
+          </Link>
         }
       />
       <PageWrapper>
         {/* Profile Section */}
         <div className="bg-gradient-to-r from-purple-600 to-pink-600 px-4 pt-6 pb-6 lg:rounded-b-3xl">
           <div className="max-w-4xl mx-auto">
-            <div className="flex items-center gap-4 mb-4">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={user.avatar}
-                alt={user.name}
-                className="w-20 h-20 rounded-full object-cover border-4 border-white shadow-md"
-              />
-              <div className="flex-1">
-                <div className="flex items-center gap-2 mb-1">
-                  <h2 className="text-white text-xl font-bold">{user.name}</h2>
-                  <span className="bg-gradient-to-r from-yellow-400 to-orange-500 text-white text-xs px-2 py-1 rounded-full font-medium shadow-sm">
-                    {user.membership}
-                  </span>
-                </div>
-                <p className="text-white/90 text-sm mb-2">{user.email}</p>
-                <div className="flex items-center gap-2">
-                  <div className="flex-1 bg-white/20 rounded-full h-2">
-                    <div className="bg-white rounded-full h-2" style={{ width: '60%' }}></div>
-                  </div>
-                  <span className="text-white text-xs font-medium">Lv.{user.level}</span>
-                </div>
+            <div className="flex items-center gap-4 mb-2">
+              {/* 아바타 플레이스홀더 */}
+              <div className="w-20 h-20 rounded-full border-4 border-white shadow-md bg-white/20 backdrop-blur-sm flex items-center justify-center">
+                {state === "loading" ? (
+                  <div className="w-8 h-8 rounded-full border-2 border-white/60 border-t-transparent animate-spin" />
+                ) : (
+                  <i className="ri-user-3-fill text-3xl text-white/80"></i>
+                )}
               </div>
-            </div>
-
-            {/* Stats */}
-            <div className="grid grid-cols-3 gap-3">
-              {stats.map((stat, index) => (
-                <div key={index} className="bg-white/20 backdrop-blur-sm rounded-2xl p-3 text-center border border-white/10">
-                  <i className={`${stat.icon} text-2xl text-white mb-1`}></i>
-                  <p className="text-white text-lg font-bold">{stat.value}</p>
-                  <p className="text-white/90 text-xs">{stat.label}</p>
-                </div>
-              ))}
+              <div className="flex-1">
+                {state === "loading" ? (
+                  <>
+                    <div className="h-6 w-24 bg-white/20 rounded mb-2 animate-pulse" />
+                    <div className="h-4 w-36 bg-white/20 rounded animate-pulse" />
+                  </>
+                ) : (
+                  <>
+                    <h2 className="text-white text-xl font-bold">
+                      {displayName}
+                    </h2>
+                    <p className="text-white/90 text-sm mt-1">
+                      {displayEmail}
+                    </p>
+                  </>
+                )}
+              </div>
             </div>
           </div>
         </div>
 
-        <div className="max-w-4xl mx-auto px-4 -mt-3">
-          {/* Points Card */}
-          <div className="bg-white rounded-2xl p-4 shadow-lg mb-4">
-            <div className="flex items-center justify-between mb-3">
-              <div>
-                <p className="text-gray-600 text-sm mb-1">보유 포인트</p>
-                <p className="text-2xl font-bold text-purple-600">{user.points.toLocaleString()}P</p>
-              </div>
-              <Link
-                href="/ads"
-                className="bg-gradient-to-r from-purple-600 to-pink-600 text-white px-4 py-2 rounded-full text-sm font-medium hover:shadow-md transition-shadow"
-              >
-                포인트 적립
-              </Link>
-            </div>
-            <div className="border-t border-gray-100 pt-3">
-              <p className="text-xs text-gray-500 mb-2 font-medium">최근 포인트 내역</p>
-              <div className="space-y-2">
-                {pointHistory.slice(0, 3).map(item => (
-                  <div key={item.id} className="flex items-center justify-between text-sm">
-                    <div className="flex items-center gap-2">
-                      <span className={`w-1.5 h-1.5 rounded-full ${
-                        item.type === '적립' ? 'bg-green-500' : 'bg-red-500'
-                      }`}></span>
-                      <span className="text-gray-700">{item.desc}</span>
-                    </div>
-                    <span className={`font-medium ${
-                      item.type === '적립' ? 'text-green-600' : 'text-red-600'
-                    }`}>
-                      {item.points}
-                    </span>
-                  </div>
-                ))}
-              </div>
-              <button className="w-full mt-3 text-purple-600 text-sm font-medium hover:bg-purple-50 py-2 rounded-lg transition-colors">
-                전체 내역 보기 <i className="ri-arrow-right-s-line"></i>
-              </button>
-            </div>
-          </div>
-
+        <div className="max-w-4xl mx-auto px-4 mt-4">
           {/* Menu List */}
           <div className="bg-white rounded-2xl overflow-hidden shadow-sm mb-4 border border-gray-100">
             {menuItems.map((item, index) => (
@@ -146,14 +78,18 @@ export default function MyPage() {
                 key={index}
                 href={item.link}
                 className={`flex items-center justify-between px-4 py-4 hover:bg-gray-50 transition-colors ${
-                  index !== menuItems.length - 1 ? 'border-b border-gray-100' : ''
+                  index !== menuItems.length - 1
+                    ? "border-b border-gray-100"
+                    : ""
                 }`}
               >
                 <div className="flex items-center gap-3">
                   <div className="w-10 h-10 bg-purple-50 rounded-full flex items-center justify-center text-purple-600">
                     <i className={`${item.icon} text-xl`}></i>
                   </div>
-                  <span className="text-gray-900 font-medium">{item.label}</span>
+                  <span className="text-gray-900 font-medium">
+                    {item.label}
+                  </span>
                 </div>
                 <i className="ri-arrow-right-s-line text-xl text-gray-400"></i>
               </Link>

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -4,13 +4,11 @@ import PageHeader from "@/components/layout/PageHeader";
 import PageWrapper from "@/components/layout/PageWrapper";
 import ProtectedRoute from "@/components/auth/ProtectedRoute";
 import { useAuth } from "@/contexts/AuthContext";
-import Link from "next/link";
-import { useState } from "react";
+
+const APP_VERSION = "1.0.0";
 
 export default function SettingsPage() {
   const { logout } = useAuth();
-  const [pushEnabled, setPushEnabled] = useState(true);
-  const [darkMode, setDarkMode] = useState(false);
 
   return (
     <ProtectedRoute>
@@ -20,174 +18,56 @@ export default function SettingsPage() {
           {/* Account Section */}
           <div className="py-4">
             <h2 className="text-sm font-bold text-gray-500 mb-3 px-1">계정</h2>
-            
+
             <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden shadow-sm">
-              <Link href="/mypage" className="flex items-center justify-between px-4 py-4 border-b border-gray-100 hover:bg-gray-50 transition-colors">
-                <div className="flex items-center gap-3">
-                  <div className="w-9 h-9 bg-purple-100 rounded-full flex items-center justify-center">
-                    <i className="ri-user-line text-purple-600"></i>
-                  </div>
-                  <span className="text-sm text-gray-900 font-medium">프로필 수정</span>
-                </div>
-                <i className="ri-arrow-right-s-line text-gray-400 text-lg"></i>
-              </Link>
-
-              <button className="w-full flex items-center justify-between px-4 py-4 border-b border-gray-100 hover:bg-gray-50 transition-colors">
-                <div className="flex items-center gap-3">
-                  <div className="w-9 h-9 bg-blue-100 rounded-full flex items-center justify-center">
-                    <i className="ri-lock-line text-blue-600"></i>
-                  </div>
-                  <span className="text-sm text-gray-900 font-medium">비밀번호 변경</span>
-                </div>
-                <i className="ri-arrow-right-s-line text-gray-400 text-lg"></i>
-              </button>
-
-              <button className="w-full flex items-center justify-between px-4 py-4 hover:bg-gray-50 transition-colors">
-                <div className="flex items-center gap-3">
-                  <div className="w-9 h-9 bg-green-100 rounded-full flex items-center justify-center">
-                    <i className="ri-shield-check-line text-green-600"></i>
-                  </div>
-                  <span className="text-sm text-gray-900 font-medium">개인정보 보호</span>
-                </div>
-                <i className="ri-arrow-right-s-line text-gray-400 text-lg"></i>
-              </button>
-            </div>
-          </div>
-
-          {/* Notification Section */}
-          <div className="py-4">
-            <h2 className="text-sm font-bold text-gray-500 mb-3 px-1">알림</h2>
-            
-            <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden shadow-sm">
-              <div className="flex items-center justify-between px-4 py-4 border-b border-gray-100">
-                <div className="flex items-center gap-3">
-                  <div className="w-9 h-9 bg-pink-100 rounded-full flex items-center justify-center">
-                    <i className="ri-notification-line text-pink-600"></i>
-                  </div>
-                  <span className="text-sm text-gray-900 font-medium">푸시 알림</span>
-                </div>
-                <button 
-                  onClick={() => setPushEnabled(!pushEnabled)}
-                  className={`relative w-12 h-7 rounded-full transition-colors ${
-                    pushEnabled ? 'bg-purple-600' : 'bg-gray-200'
-                  }`}
-                >
-                  <div className={`absolute top-1 left-1 w-5 h-5 bg-white rounded-full transition-transform shadow-sm ${
-                    pushEnabled ? 'translate-x-5' : 'translate-x-0'
-                  }`}></div>
-                </button>
-              </div>
-
-              <Link href="/notifications" className="flex items-center justify-between px-4 py-4 hover:bg-gray-50 transition-colors">
-                <div className="flex items-center gap-3">
-                  <div className="w-9 h-9 bg-orange-100 rounded-full flex items-center justify-center">
-                    <i className="ri-settings-3-line text-orange-600"></i>
-                  </div>
-                  <span className="text-sm text-gray-900 font-medium">알림 설정</span>
-                </div>
-                <i className="ri-arrow-right-s-line text-gray-400 text-lg"></i>
-              </Link>
-            </div>
-          </div>
-
-          {/* Display Section */}
-          <div className="py-4">
-            <h2 className="text-sm font-bold text-gray-500 mb-3 px-1">화면</h2>
-            
-            <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden shadow-sm">
-              <div className="flex items-center justify-between px-4 py-4 border-b border-gray-100">
-                <div className="flex items-center gap-3">
-                  <div className="w-9 h-9 bg-indigo-100 rounded-full flex items-center justify-center">
-                    <i className="ri-moon-line text-indigo-600"></i>
-                  </div>
-                  <span className="text-sm text-gray-900 font-medium">다크 모드</span>
-                </div>
-                <button 
-                  onClick={() => setDarkMode(!darkMode)}
-                  className={`relative w-12 h-7 rounded-full transition-colors ${
-                    darkMode ? 'bg-purple-600' : 'bg-gray-200'
-                  }`}
-                >
-                  <div className={`absolute top-1 left-1 w-5 h-5 bg-white rounded-full transition-transform shadow-sm ${
-                    darkMode ? 'translate-x-5' : 'translate-x-0'
-                  }`}></div>
-                </button>
-              </div>
-
-              <button className="w-full flex items-center justify-between px-4 py-4 hover:bg-gray-50 transition-colors">
-                <div className="flex items-center gap-3">
-                  <div className="w-9 h-9 bg-teal-100 rounded-full flex items-center justify-center">
-                    <i className="ri-global-line text-teal-600"></i>
-                  </div>
-                  <div className="flex-1 text-left">
-                    <p className="text-sm text-gray-900 font-medium">언어</p>
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
-                  <span className="text-xs text-gray-500">한국어</span>
-                  <i className="ri-arrow-right-s-line text-gray-400 text-lg"></i>
-                </div>
-              </button>
-            </div>
-          </div>
-
-          {/* Support Section */}
-          <div className="py-4">
-            <h2 className="text-sm font-bold text-gray-500 mb-3 px-1">지원</h2>
-            
-            <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden shadow-sm">
-              <button className="w-full flex items-center justify-between px-4 py-4 border-b border-gray-100 hover:bg-gray-50 transition-colors">
-                <div className="flex items-center gap-3">
-                  <div className="w-9 h-9 bg-yellow-100 rounded-full flex items-center justify-center">
-                    <i className="ri-question-line text-yellow-600"></i>
-                  </div>
-                  <span className="text-sm text-gray-900 font-medium">도움말</span>
-                </div>
-                <i className="ri-arrow-right-s-line text-gray-400 text-lg"></i>
-              </button>
-
-              <Link href="/support" className="w-full flex items-center justify-between px-4 py-4 border-b border-gray-100 hover:bg-gray-50 transition-colors">
+              <button
+                onClick={logout}
+                className="w-full flex items-center justify-between px-4 py-4 hover:bg-gray-50 transition-colors"
+              >
                 <div className="flex items-center gap-3">
                   <div className="w-9 h-9 bg-red-100 rounded-full flex items-center justify-center">
-                    <i className="ri-customer-service-line text-red-600"></i>
+                    <i className="ri-logout-box-r-line text-red-600"></i>
                   </div>
-                  <span className="text-sm text-gray-900 font-medium">고객센터</span>
+                  <span className="text-sm text-gray-900 font-medium">
+                    로그아웃
+                  </span>
                 </div>
                 <i className="ri-arrow-right-s-line text-gray-400 text-lg"></i>
-              </Link>
+              </button>
+            </div>
+          </div>
 
-              <button className="w-full flex items-center justify-between px-4 py-4 hover:bg-gray-50 transition-colors">
+          {/* App Info Section */}
+          <div className="py-4">
+            <h2 className="text-sm font-bold text-gray-500 mb-3 px-1">
+              앱 정보
+            </h2>
+
+            <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden shadow-sm">
+              <div className="flex items-center justify-between px-4 py-4 border-b border-gray-100">
                 <div className="flex items-center gap-3">
                   <div className="w-9 h-9 bg-gray-100 rounded-full flex items-center justify-center">
                     <i className="ri-information-line text-gray-600"></i>
                   </div>
-                  <div className="flex-1 text-left">
-                    <p className="text-sm text-gray-900 font-medium">앱 정보</p>
+                  <span className="text-sm text-gray-900 font-medium">
+                    버전
+                  </span>
+                </div>
+                <span className="text-xs text-gray-500">v{APP_VERSION}</span>
+              </div>
+
+              <div className="flex items-center justify-between px-4 py-4">
+                <div className="flex items-center gap-3">
+                  <div className="w-9 h-9 bg-purple-100 rounded-full flex items-center justify-center">
+                    <i className="ri-copyright-line text-purple-600"></i>
                   </div>
+                  <span className="text-sm text-gray-900 font-medium">
+                    서비스 정보
+                  </span>
                 </div>
-                <div className="flex items-center gap-2">
-                  <span className="text-xs text-gray-500">v1.0.0</span>
-                  <i className="ri-arrow-right-s-line text-gray-400 text-lg"></i>
-                </div>
-              </button>
+                <span className="text-xs text-gray-500">FanPulse</span>
+              </div>
             </div>
-          </div>
-
-          {/* Logout Button */}
-          <div className="py-4">
-            <button
-              onClick={logout}
-              className="w-full bg-white border border-gray-200 text-gray-700 py-3.5 rounded-2xl font-medium hover:bg-gray-50 transition-colors shadow-sm"
-            >
-              로그아웃
-            </button>
-          </div>
-
-          {/* Delete Account */}
-          <div className="pb-8 text-center">
-            <button className="text-red-500 text-sm underline hover:text-red-600 transition-colors">
-              회원 탈퇴
-            </button>
           </div>
         </div>
       </PageWrapper>

--- a/web/src/hooks/useMyProfile.ts
+++ b/web/src/hooks/useMyProfile.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState, useEffect, useCallback } from 'react';
+import { fetchMyProfile, type UserProfile } from '@/lib/api/user';
+import type { AsyncState } from '@/types/common';
+
+interface UseMyProfileReturn {
+  profile: UserProfile | null;
+  state: AsyncState;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+export function useMyProfile(): UseMyProfileReturn {
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [state, setState] = useState<AsyncState>('loading');
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchProfile = useCallback(async (signal?: AbortSignal) => {
+    setState('loading');
+    setError(null);
+
+    try {
+      const data = await fetchMyProfile(signal);
+      if (signal?.aborted) return;
+      setProfile(data);
+      setState('success');
+    } catch (err) {
+      if (signal?.aborted) return;
+      setError('프로필을 불러올 수 없습니다');
+      setState('error');
+    }
+  }, []);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    fetchProfile(abortController.signal);
+
+    return () => {
+      abortController.abort();
+    };
+  }, [fetchProfile]);
+
+  return {
+    profile,
+    state,
+    error,
+    refresh: fetchProfile,
+  };
+}

--- a/web/src/lib/api/user.ts
+++ b/web/src/lib/api/user.ts
@@ -1,0 +1,13 @@
+import { apiClient } from '@/lib/api-client';
+
+export interface UserProfile {
+  id: string;
+  email: string;
+  username?: string;
+  profileImageUrl?: string;
+}
+
+export async function fetchMyProfile(signal?: AbortSignal): Promise<UserProfile> {
+  const { data } = await apiClient.get('/users/me', { signal });
+  return data.data ?? data;
+}


### PR DESCRIPTION
## Summary
- 마이페이지: 프로필 카드(아바타, 이름, 이메일) + 설정 메뉴 + 로그아웃
- 설정: 앱 정보 + 로그아웃 + 뒤로가기
- `GET /api/users/me` 연동하여 실제 프로필 데이터 표시
- 기존 과도한 목업(VIP, 포인트, 통계 등) 제거 → MVP 범위로 축소
- ProtectedRoute로 인증 가드 적용

## 변경 파일
- `web/src/lib/api/user.ts` — fetchMyProfile API 모듈 (신규)
- `web/src/hooks/useMyProfile.ts` — 프로필 조회 훅 (신규)
- `web/src/app/mypage/page.tsx` — MVP 범위로 리팩토링
- `web/src/app/settings/page.tsx` — MVP 범위로 리팩토링

## 관련 이슈
Closes #141

## Test plan
- [ ] 비로그인 상태에서 `/mypage` 접근 시 로그인 리다이렉트 확인
- [ ] 로그인 후 프로필 정보(이름, 이메일) 표시 확인
- [ ] 설정 메뉴 클릭 → `/settings` 이동 확인
- [ ] 로그아웃 버튼 동작 확인
- [ ] 설정 페이지 뒤로가기 동작 확인