### PR TITLE
fix(web): 검색 API 응답 파싱 오류 수정

### DIFF
--- a/web/src/hooks/useSearch.ts
+++ b/web/src/hooks/useSearch.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import axios from 'axios';
-import { searchAll, type SearchResultItem } from '@/lib/api/search';
+import { searchAll } from '@/lib/api/search';
 import type { Live } from '@/types/live';
 import type { News } from '@/types/news';
 import type { AsyncState } from '@/types/common';
@@ -18,20 +18,6 @@ function getErrorMessage(error: unknown): string {
   return '검색 결과를 불러올 수 없습니다';
 }
 
-function splitResults(items: SearchResultItem[]): { lives: Live[]; news: News[] } {
-  const lives: Live[] = [];
-  const news: News[] = [];
-
-  for (const item of items) {
-    if (item.type === 'LIVE' && item.live) {
-      lives.push(item.live);
-    } else if (item.type === 'NEWS' && item.news) {
-      news.push(item.news);
-    }
-  }
-
-  return { lives, news };
-}
 
 interface UseSearchReturn {
   query: string;
@@ -65,9 +51,8 @@ export function useSearch(): UseSearchReturn {
 
       if (controller.signal.aborted) return;
 
-      const { lives: liveItems, news: newsItems } = splitResults(result.items);
-      setLives(liveItems);
-      setNews(newsItems);
+      setLives(result.live?.items ?? []);
+      setNews(result.news?.items ?? []);
       setState('success');
     } catch (err) {
       if (axios.isCancel(err) || (err instanceof DOMException && err.name === 'AbortError')) {

--- a/web/src/lib/api/search.ts
+++ b/web/src/lib/api/search.ts
@@ -2,16 +2,9 @@ import type { Live } from '@/types/live';
 import type { News } from '@/types/news';
 import { apiClient } from '@/lib/api-client';
 
-export interface SearchResultItem {
-  type: 'LIVE' | 'NEWS';
-  live?: Live;
-  news?: News;
-}
-
 export interface SearchResponse {
-  items: SearchResultItem[];
-  hasMore: boolean;
-  nextCursor?: string;
+  live: { items: Live[]; totalCount: number };
+  news: { items: News[]; totalCount: number };
 }
 
 export async function searchAll(
@@ -23,5 +16,5 @@ export async function searchAll(
     params: { q: query, limit },
     signal,
   });
-  return data.data;
+  return data;
 }


### PR DESCRIPTION
## Summary
- `search.ts`: `data.data` 제거 — 백엔드 응답에 `.data` 래퍼 없음
- `search.ts`: 인터페이스를 실제 응답 구조 `{ live: { items, totalCount }, news: { items, totalCount } }`로 변경
- `useSearch.ts`: 불필요한 `splitResults` 함수 제거, 응답에서 직접 live/news items 추출

Closes #263

## Test plan
- [ ] 검색 페이지에서 키워드 입력 시 결과 정상 표시 확인
- [ ] Live/News 결과 분리 렌더링 확인
- [ ] 결과 없는 검색어 입력 시 "결과 없음" UI 정상 표시 확인