### PR TITLE
fix(backend): StreamingEventController Swagger 응답 스키마 수정

### DIFF
--- a/backend/src/main/kotlin/com/fanpulse/interfaces/rest/streaming/StreamingEventController.kt
+++ b/backend/src/main/kotlin/com/fanpulse/interfaces/rest/streaming/StreamingEventController.kt
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
-import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.data.domain.PageRequest
@@ -67,12 +67,12 @@ class StreamingEventController(
         tags = ["Streaming Events"]
     )
     @ApiResponses(
-        ApiResponse(
+        SwaggerApiResponse(
             responseCode = "200",
             description = "Events retrieved successfully",
             content = [Content(schema = Schema(implementation = ApiResponse::class))]
         ),
-        ApiResponse(
+        SwaggerApiResponse(
             responseCode = "400",
             description = "Invalid request parameters (e.g., malformed cursor, invalid limit)"
         )
@@ -120,12 +120,12 @@ class StreamingEventController(
         tags = ["Streaming Events"]
     )
     @ApiResponses(
-        ApiResponse(
+        SwaggerApiResponse(
             responseCode = "200",
             description = "Event retrieved successfully",
             content = [Content(schema = Schema(implementation = ApiResponse::class))]
         ),
-        ApiResponse(
+        SwaggerApiResponse(
             responseCode = "404",
             description = "Event with given ID not found"
         )
@@ -146,7 +146,7 @@ class StreamingEventController(
         description = "Returns a paginated list of streaming events with optional filtering"
     )
     @ApiResponses(
-        ApiResponse(
+        SwaggerApiResponse(
             responseCode = "200",
             description = "Events retrieved successfully",
             content = [Content(schema = Schema(implementation = StreamingEventListResponse::class))]
@@ -204,7 +204,7 @@ class StreamingEventController(
         description = "Returns currently live streaming events, ordered by viewer count (highest first)"
     )
     @ApiResponses(
-        ApiResponse(
+        SwaggerApiResponse(
             responseCode = "200",
             description = "Live events retrieved successfully",
             content = [Content(schema = Schema(implementation = StreamingEventListResponse::class))]
@@ -228,7 +228,7 @@ class StreamingEventController(
         description = "Returns upcoming scheduled streaming events, ordered by scheduled time (soonest first)"
     )
     @ApiResponses(
-        ApiResponse(
+        SwaggerApiResponse(
             responseCode = "200",
             description = "Scheduled events retrieved successfully",
             content = [Content(schema = Schema(implementation = StreamingEventListResponse::class))]
@@ -252,7 +252,7 @@ class StreamingEventController(
         description = "Returns streaming events for a specific artist"
     )
     @ApiResponses(
-        ApiResponse(
+        SwaggerApiResponse(
             responseCode = "200",
             description = "Events retrieved successfully",
             content = [Content(schema = Schema(implementation = StreamingEventListResponse::class))]


### PR DESCRIPTION
## 문제

Swagger UI에서 `/api/v1/streaming-events` 및 `/api/v1/streaming-events/{id}` 엔드포인트의 200 응답 스키마가 에러 응답 형태처럼 보이는 문제가 있었다.

원인은 `StreamingEventController.kt`의 import 충돌:
- `io.swagger.v3.oas.annotations.responses.ApiResponse` (직접 import)
- `com.fanpulse.application.dto.streaming.*` (wildcard — 같은 이름의 래퍼 DTO 포함)

Kotlin은 직접 import를 우선하므로 `Schema(implementation = ApiResponse::class)`가 래퍼 DTO가 아니라 Swagger 어노테이션 클래스를 가리키게 되어 스키마가 잘못 렌더링되었다.

## 수정

`NewsController` / `ChartController`에서 이미 쓰는 `SwaggerApiResponse` 별칭 패턴을 동일하게 적용:

```kotlin
import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
```

- 어노테이션 site 8곳: `ApiResponse(...)` → `SwaggerApiResponse(...)`
- `Schema(implementation = ApiResponse::class)`는 이제 wildcard를 통해 올바른 `com.fanpulse.application.dto.streaming.ApiResponse<T>`로 해석된다.

## 영향 범위

- 변경 파일 1개 (`StreamingEventController.kt`)
- 런타임 동작 변화 없음 (Swagger 문서 렌더링만 개선)
- 기존 테스트 영향 없음

## 검증

- `./gradlew :backend:compileKotlin` BUILD SUCCESSFUL