### PR TITLE
ci: docs-only PR 자동 SUCCESS 처리 (#266 머지 unblock)

### DIFF
--- a/.github/workflows/pr-review-notify.yml
+++ b/.github/workflows/pr-review-notify.yml
@@ -11,6 +11,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  statuses: write
 
 jobs:
   notify:
@@ -77,6 +78,19 @@ jobs:
           if [ "$HTTP_CODE" -ge 400 ]; then
             echo "::warning::Webhook call failed with HTTP $HTTP_CODE"
           fi
+
+      - name: Auto-approve docs-only PR
+        if: steps.check.outputs.should_notify == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # 코드 파일 변경 없는 PR(문서/설정만)은 claude-code-review 컨텍스트를 자동 SUCCESS 처리.
+          # 룰셋 'AI Review Protection'이 해당 컨텍스트를 요구하므로, 봇 호출이 스킵되면 영구 BLOCKED 됨.
+          gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }} \
+            -f state=success \
+            -f context=claude-code-review \
+            -f description="Auto-approved: no reviewable code changes" \
+            -f target_url="${{ github.event.pull_request.html_url }}"
 
       - name: Send Telegram notification
         if: steps.check.outputs.should_notify == 'true'


### PR DESCRIPTION
## Summary
- docs/설정만 변경하는 PR이 \`claude-code-review\` 컨텍스트 부재로 영구 BLOCKED 되는 부트스트랩 문제 해결
- 워크플로우의 \`should_notify=false\` 분기에서 commit status를 자동 SUCCESS 처리
- 즉시 영향: PR #266(MVP 문서 최신화) 머지 가능 상태로 회복

## 배경
- 룰셋 'AI Review Protection'은 \`claude-code-review\` 컨텍스트의 SUCCESS 요구
- 기존 워크플로우는 \`grep -qE '\\.kt\$|\\.java\$|\\.py\$|\\.ts\$|\\.tsx\$|\\.js\$|\\.jsx\$'\` 매치되지 않으면 봇 호출 자체 스킵
- 봇 호출이 스킵되면 컨텍스트가 생성되지 않아 룰셋이 만족되지 않음 → 영구 BLOCKED

## 변경
- \`permissions:\` 에 \`statuses: write\` 추가
- \`should_notify=false\` 분기에 \`Auto-approve docs-only PR\` step 추가
- \`gh api .../statuses/{sha}\` 로 \`state=success\`, \`context=claude-code-review\` 자동 박음

## Test plan
- [ ] 본 PR 자체도 .yml만 변경이라 같은 deadlock에 걸림 → 1회 admin merge 또는 룰셋 일시 비활성화 필요
- [ ] 머지 후 PR #266에 빈 커밋 push 하면 새 워크플로우가 자동 SUCCESS 박음 → BLOCKED 해소 확인
- [ ] 향후 docs/설정만 변경하는 PR이 정상 머지되는지 확인