### PR TITLE
fix(web): SkeletonCard layout prop 수정

### DIFF
--- a/web/src/app/live/[id]/page.tsx
+++ b/web/src/app/live/[id]/page.tsx
@@ -31,7 +31,7 @@ export default function LiveDetailPage() {
         </header>
         <div className="w-full aspect-video bg-gray-200 animate-pulse" />
         <div className="p-4 space-y-3">
-          <SkeletonCard variant="horizontal" />
+          <SkeletonCard layout="horizontal" />
         </div>
       </div>
     );

--- a/web/src/app/live/components/LiveGrid.tsx
+++ b/web/src/app/live/components/LiveGrid.tsx
@@ -17,7 +17,7 @@ export default function LiveGrid({ lives, state, error, onRetry }: LiveGridProps
     return (
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {Array.from({ length: 6 }).map((_, i) => (
-          <SkeletonCard key={`skeleton-${i}`} variant="vertical" />
+          <SkeletonCard key={`skeleton-${i}`} layout="vertical" />
         ))}
       </div>
     );


### PR DESCRIPTION
SkeletonCard 컴포넌트에 잘못 전달된 `variant` prop을 `layout`으로 수정합니다.

- 라이브 상세 스켈레톤: `layout="horizontal"`
- 라이브 그리드 스켈레톤: `layout="vertical"`
- `npm run build` 검증 완료