### PR TITLE
수정: 프론트엔드 콘텐츠 API 계약 정합화

### DIFF
--- a/web/e2e/news.spec.ts
+++ b/web/e2e/news.spec.ts
@@ -3,11 +3,11 @@ import { expect, test, type Page } from '@playwright/test'
 // ── Mock Data ───────────────────────────────────────
 
 const mockNewsDetail = {
-  id: 1,
+  id: '11111111-1111-1111-1111-111111111111',
+  artistId: '22222222-2222-2222-2222-222222222222',
   title: 'BTS 새 앨범 발매 예정',
-  summary: 'BTS가 2026년 3월 새 앨범 발매를 예고했다.',
   thumbnailUrl: 'https://picsum.photos/seed/bts-news/800/450',
-  source: '스포츠조선',
+  sourceName: '스포츠조선',
   publishedAt: '2026-02-01T09:00:00Z',
   content: `
     <p>BTS가 2026년 3월 새 앨범 발매를 예고했다. 멤버들의 솔로 활동 이후 첫 완전체 앨범으로 팬들의 기대를 모으고 있다.</p>
@@ -16,18 +16,23 @@ const mockNewsDetail = {
     <p>BTS는 "팬들에게 새로운 모습을 보여드리고 싶다"고 전했다.</p>
   `,
   sourceUrl: 'https://sports.chosun.com/article/bts-2026',
-  author: '김기자',
+  category: 'GENERAL',
+  viewCount: 0,
+  createdAt: '2026-02-01T09:00:00Z',
 }
 
 const mockNewsDetail2 = {
-  id: 2,
+  id: '33333333-3333-3333-3333-333333333333',
+  artistId: '44444444-4444-4444-4444-444444444444',
   title: 'BLACKPINK 월드투어 추가 공연',
-  summary: 'BLACKPINK가 아시아 투어에 서울 추가 공연을 확정했다.',
   thumbnailUrl: 'https://picsum.photos/seed/bp-news/800/450',
-  source: '엔터미디어',
+  sourceName: '엔터미디어',
   publishedAt: '2026-01-31T15:30:00Z',
   content: '<p>BLACKPINK가 아시아 투어에 서울 추가 공연을 확정했다.</p>',
   sourceUrl: 'https://enter.media.com/article/bp-tour',
+  category: 'GENERAL',
+  viewCount: 0,
+  createdAt: '2026-01-31T15:30:00Z',
 }
 
 // ── Setup Helper ────────────────────────────────
@@ -79,7 +84,7 @@ async function setupMocks(
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ data: newsData }),
+      body: JSON.stringify({ success: true, data: newsData }),
     })
   })
 }
@@ -104,12 +109,12 @@ test.describe('News Detail - 뉴스 상세', () => {
     await expect(page.locator('img[alt="BTS 새 앨범 발매 예정"]')).toBeVisible()
   })
 
-  test('메타데이터(출처, 작성자, 날짜)가 표시된다', async ({ page }) => {
+  test('메타데이터(출처, 날짜)가 표시된다', async ({ page }) => {
     await setupMocks(page)
     await page.goto('/news/1')
 
     await expect(page.getByText('스포츠조선', { exact: true })).toBeVisible({ timeout: 10000 })
-    await expect(page.getByText('김기자')).toBeVisible()
+
   })
 
   test('HTML 본문 콘텐츠가 렌더링된다', async ({ page }) => {
@@ -154,7 +159,7 @@ test.describe('News Detail - 뉴스 상세', () => {
     })
   })
 
-  test('작성자가 없는 뉴스도 정상 렌더링된다', async ({ page }) => {
+  test('두 번째 실제 DTO 뉴스도 정상 렌더링된다', async ({ page }) => {
     await setupMocks(page, { newsData: mockNewsDetail2 })
     await page.goto('/news/2')
 
@@ -162,7 +167,7 @@ test.describe('News Detail - 뉴스 상세', () => {
     await expect(
       page.getByRole('heading', { name: 'BLACKPINK 월드투어 추가 공연', level: 1 })
     ).toBeVisible()
-    await expect(page.getByText('김기자')).not.toBeVisible()
+
   })
 
   test('존재하지 않는 뉴스 ID로 접근 시 404 에러 메시지가 표시된다', async ({
@@ -237,7 +242,7 @@ test.describe('News Detail - 뉴스 상세', () => {
         await route.fulfill({
           status: 200,
           contentType: 'application/json',
-          body: JSON.stringify({ data: mockNewsDetail }),
+          body: JSON.stringify({ success: true, data: mockNewsDetail }),
         })
       }
     })

--- a/web/src/__mocks__/live.ts
+++ b/web/src/__mocks__/live.ts
@@ -2,7 +2,7 @@ import type { Live, LiveDetail } from '@/types/live';
 
 export const mockLiveNow: Live[] = [
   {
-    id: 1,
+    id: '1',
     title: 'NewJeans 컴백 쇼케이스',
     artistName: 'NewJeans Official',
     thumbnailUrl: '/images/mock/live-1.jpg',
@@ -10,7 +10,7 @@ export const mockLiveNow: Live[] = [
     viewerCount: 24583,
   },
   {
-    id: 2,
+    id: '2',
     title: 'BTS Fan Meeting Special',
     artistName: 'BTS',
     thumbnailUrl: '/images/mock/live-2.jpg',
@@ -18,7 +18,7 @@ export const mockLiveNow: Live[] = [
     viewerCount: 89200,
   },
   {
-    id: 3,
+    id: '3',
     title: 'BLACKPINK Behind The Scenes',
     artistName: 'BLACKPINK',
     thumbnailUrl: '/images/mock/live-3.jpg',
@@ -29,7 +29,7 @@ export const mockLiveNow: Live[] = [
 
 export const mockUpcoming: Live[] = [
   {
-    id: 10,
+    id: '10',
     title: 'SEVENTEEN Dance Practice',
     artistName: 'SEVENTEEN',
     thumbnailUrl: '/images/mock/upcoming-1.jpg',
@@ -37,7 +37,7 @@ export const mockUpcoming: Live[] = [
     scheduledAt: '2026-02-15T14:00:00Z',
   },
   {
-    id: 11,
+    id: '11',
     title: 'Stray Kids World Tour Highlights',
     artistName: 'Stray Kids',
     thumbnailUrl: '/images/mock/upcoming-2.jpg',
@@ -50,7 +50,7 @@ export const mockLiveList: Live[] = [
   ...mockLiveNow,
   ...mockUpcoming,
   {
-    id: 20,
+    id: '20',
     title: 'TWICE Concert Replay',
     artistName: 'TWICE',
     thumbnailUrl: '/images/mock/ended-1.jpg',
@@ -59,7 +59,7 @@ export const mockLiveList: Live[] = [
 ];
 
 export const mockLiveDetail: LiveDetail = {
-  id: 1,
+  id: '1',
   title: 'NewJeans 컴백 쇼케이스',
   artistName: 'NewJeans Official',
   thumbnailUrl: '/images/mock/live-1.jpg',

--- a/web/src/__mocks__/news.ts
+++ b/web/src/__mocks__/news.ts
@@ -1,7 +1,8 @@
 import type { News, NewsDetail } from '@/types/news';
 
 export const mockNewsDetail: NewsDetail = {
-  id: 1,
+  id: '1',
+  artistId: '22222222-2222-2222-2222-222222222222',
   title: 'BTS 새 앨범 발매 예정',
   summary: 'BTS가 2026년 3월 새 앨범 발매를 예고했다. 멤버들의 솔로 활동 이후 첫 완전체 앨범으로 팬들의 기대를 모으고 있다.',
   thumbnailUrl: '/images/mock/news-1.jpg',
@@ -13,12 +14,14 @@ export const mockNewsDetail: NewsDetail = {
     <img src="/images/mock/bts-album.jpg" alt="BTS 앨범 커버" />
   `,
   sourceUrl: 'https://sports.chosun.com/article/bts-2026',
-  author: '김기자',
+  category: 'GENERAL',
+  viewCount: 0,
+  createdAt: '2026-02-01T09:00:00Z',
 };
 
 export const mockLatestNews: News[] = [
   {
-    id: 1,
+    id: '1',
     title: 'BTS 새 앨범 발매 예정',
     summary: 'BTS가 2026년 3월 새 앨범 발매를 예고했다. 멤버들의 솔로 활동 이후 첫 완전체 앨범으로 팬들의 기대를 모으고 있다.',
     thumbnailUrl: '/images/mock/news-1.jpg',
@@ -26,7 +29,7 @@ export const mockLatestNews: News[] = [
     publishedAt: '2026-02-01T09:00:00Z',
   },
   {
-    id: 2,
+    id: '2',
     title: 'BLACKPINK 월드투어 추가 공연',
     summary: 'BLACKPINK가 아시아 투어에 서울 추가 공연을 확정했다.',
     thumbnailUrl: '/images/mock/news-2.jpg',
@@ -34,7 +37,7 @@ export const mockLatestNews: News[] = [
     publishedAt: '2026-01-31T15:30:00Z',
   },
   {
-    id: 3,
+    id: '3',
     title: 'NewJeans 신곡 음원차트 1위',
     summary: 'NewJeans의 신곡이 발매 즉시 주요 음원차트 1위를 석권했다.',
     thumbnailUrl: '/images/mock/news-3.jpg',

--- a/web/src/app/components/home/LiveCard.test.tsx
+++ b/web/src/app/components/home/LiveCard.test.tsx
@@ -4,7 +4,7 @@ import LiveCard from './LiveCard';
 import type { Live } from '@/types/live';
 
 const mockLive: Live = {
-  id: 1,
+  id: '1',
   title: 'NewJeans 컴백 쇼케이스',
   artistName: 'NewJeans Official',
   thumbnailUrl: '/images/mock/live-1.jpg',
@@ -13,7 +13,7 @@ const mockLive: Live = {
 };
 
 const mockScheduled: Live = {
-  id: 10,
+  id: '10',
   title: 'SEVENTEEN Dance Practice',
   artistName: 'SEVENTEEN',
   thumbnailUrl: '/images/mock/upcoming-1.jpg',
@@ -31,6 +31,15 @@ describe('LiveCard', () => {
     render(<LiveCard live={mockLive} />);
     const img = screen.getByAltText(mockLive.title);
     expect(img).toBeInTheDocument();
+  });
+
+  it('renders an explicit empty thumbnail state for null API thumbnails', () => {
+    render(<LiveCard live={{ ...mockLive, thumbnailUrl: null }} />);
+
+    expect(
+      screen.getByRole('img', { name: `${mockLive.title} 썸네일 없음` })
+    ).toBeInTheDocument();
+    expect(screen.queryByAltText(mockLive.title)).not.toBeInTheDocument();
   });
 
   it('renders title and artist name', () => {

--- a/web/src/app/components/home/LiveCard.tsx
+++ b/web/src/app/components/home/LiveCard.tsx
@@ -16,13 +16,23 @@ export default function LiveCard({ live }: LiveCardProps) {
   return (
     <Link href={`/live/${id}`} className="block flex-shrink-0 w-[280px] group">
       <div className="relative rounded-2xl overflow-hidden bg-white shadow-sm hover:shadow-md transition-shadow">
-        <Image
-          src={thumbnailUrl}
-          alt={title}
-          width={280}
-          height={160}
-          className="w-full h-40 object-cover group-hover:scale-105 transition-transform duration-300"
-        />
+        {thumbnailUrl ? (
+          <Image
+            src={thumbnailUrl}
+            alt={title}
+            width={280}
+            height={160}
+            className="w-full h-40 object-cover group-hover:scale-105 transition-transform duration-300"
+          />
+        ) : (
+          <div
+            role="img"
+            aria-label={`${title} 썸네일 없음`}
+            className="w-full h-40 bg-gray-100 text-gray-400 flex items-center justify-center"
+          >
+            <span className="text-sm">썸네일 없음</span>
+          </div>
+        )}
 
         {status === 'LIVE' && (
           <div className="absolute top-3 left-3">

--- a/web/src/app/components/home/NewsCard.test.tsx
+++ b/web/src/app/components/home/NewsCard.test.tsx
@@ -4,7 +4,7 @@ import NewsCard from './NewsCard';
 import type { News } from '@/types/news';
 
 const mockNews: News = {
-  id: 1,
+  id: '1',
   title: 'BTS 새 앨범 발매 예정',
   summary: 'BTS가 2026년 3월 새 앨범 발매를 예고했다. 멤버들의 솔로 활동 이후 첫 완전체 앨범이다.',
   thumbnailUrl: '/images/mock/news-1.jpg',

--- a/web/src/app/live/components/LiveListItem.test.tsx
+++ b/web/src/app/live/components/LiveListItem.test.tsx
@@ -12,6 +12,15 @@ describe('LiveListItem', () => {
     expect(screen.getByText('NewJeans Official')).toBeInTheDocument();
   });
 
+  it('renders an explicit empty thumbnail state for null API thumbnails', () => {
+    render(<LiveListItem live={{ ...mockLiveNow[0], thumbnailUrl: null }} />);
+
+    expect(
+      screen.getByRole('img', { name: 'NewJeans 컴백 쇼케이스 썸네일 없음' })
+    ).toBeInTheDocument();
+    expect(screen.queryByAltText('NewJeans 컴백 쇼케이스')).not.toBeInTheDocument();
+  });
+
   it('renders LIVE badge and viewer count for live stream', () => {
     render(<LiveListItem live={mockLiveNow[0]} />);
 

--- a/web/src/app/live/components/LiveListItem.tsx
+++ b/web/src/app/live/components/LiveListItem.tsx
@@ -17,14 +17,24 @@ export default function LiveListItem({ live }: LiveListItemProps) {
     <Link href={`/live/${id}`} className="block group">
       <article className="bg-white rounded-2xl overflow-hidden shadow-sm hover:shadow-md transition-shadow">
         <div className="relative">
-          <Image
-            src={thumbnailUrl}
-            alt={title}
-            width={384}
-            height={192}
-            sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
-            className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-300"
-          />
+          {thumbnailUrl ? (
+            <Image
+              src={thumbnailUrl}
+              alt={title}
+              width={384}
+              height={192}
+              sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+              className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-300"
+            />
+          ) : (
+            <div
+              role="img"
+              aria-label={`${title} 썸네일 없음`}
+              className="w-full h-48 bg-gray-100 text-gray-400 flex items-center justify-center"
+            >
+              <span className="text-sm">썸네일 없음</span>
+            </div>
+          )}
           <div className="absolute top-3 left-3">
             <StatusBadge status={status} />
           </div>

--- a/web/src/app/live/components/LiveMetadata.test.tsx
+++ b/web/src/app/live/components/LiveMetadata.test.tsx
@@ -4,7 +4,7 @@ import LiveMetadata from './LiveMetadata';
 import type { LiveDetail } from '@/types/live';
 
 const mockLiveDetail: LiveDetail = {
-  id: 1,
+  id: '1',
   title: 'NewJeans 컴백 쇼케이스',
   artistName: 'NewJeans Official',
   thumbnailUrl: '/images/mock/live-1.jpg',

--- a/web/src/app/news/[id]/components/NewsHeader.tsx
+++ b/web/src/app/news/[id]/components/NewsHeader.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 
 interface NewsHeaderProps {
   title: string;
-  thumbnailUrl: string;
+  thumbnailUrl: string | null;
 }
 
 export default function NewsHeader({ title, thumbnailUrl }: NewsHeaderProps) {

--- a/web/src/app/news/[id]/page.test.tsx
+++ b/web/src/app/news/[id]/page.test.tsx
@@ -54,7 +54,6 @@ describe('NewsDetailPage', () => {
     });
 
     expect(screen.getByText('스포츠조선')).toBeInTheDocument();
-    expect(screen.getByText('김기자')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /원문 보기/ })).toBeInTheDocument();
   });
 

--- a/web/src/app/news/[id]/page.tsx
+++ b/web/src/app/news/[id]/page.tsx
@@ -7,7 +7,6 @@ import NewsHeader from './components/NewsHeader';
 import NewsMetadata from './components/NewsMetadata';
 import NewsContent from './components/NewsContent';
 import SourceLink from './components/SourceLink';
-import SkeletonCard from '@/components/ui/SkeletonCard';
 
 export default function NewsDetailPage() {
   const params = useParams();
@@ -88,7 +87,6 @@ export default function NewsDetailPage() {
       <NewsMetadata
         source={news.source}
         publishedAt={news.publishedAt}
-        author={news.author}
       />
 
       <hr className="my-4 mx-4 border-gray-100" />

--- a/web/src/lib/api/home.test.ts
+++ b/web/src/lib/api/home.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/api-client';
+import { fetchLatestNews } from './home';
+
+const apiNews = {
+  id: '11111111-1111-1111-1111-111111111111',
+  artistId: '22222222-2222-2222-2222-222222222222',
+  title: '실제 API 뉴스',
+  content: '실제 수집 기사 요약 내용',
+  sourceUrl: 'https://news.google.com/articles/real',
+  sourceName: '실제 언론사',
+  thumbnailUrl: null,
+  category: 'GENERAL',
+  viewCount: 0,
+  publishedAt: '2026-08-14T02:30:00Z',
+  createdAt: '2026-08-14T02:50:00Z',
+};
+
+const mappedNews = {
+  id: apiNews.id,
+  title: apiNews.title,
+  summary: apiNews.content,
+  thumbnailUrl: null,
+  source: apiNews.sourceName,
+  publishedAt: apiNews.publishedAt,
+};
+
+describe('fetchLatestNews', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('validates the API envelope and maps the production news DTO', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: { success: true, data: [apiNews] },
+    });
+
+    await expect(fetchLatestNews(5)).resolves.toEqual([mappedNews]);
+    expect(apiClient.get).toHaveBeenCalledWith('/news/latest', {
+      params: { limit: 5 },
+      signal: undefined,
+    });
+  });
+
+  it.each([
+    { success: false, data: [apiNews] },
+    { success: true, data: null },
+    [apiNews],
+  ])('rejects unsuccessful, empty, or legacy raw payloads: %o', async (payload) => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: payload });
+
+    await expect(fetchLatestNews()).rejects.toThrow(
+      '뉴스 API 응답이 올바르지 않습니다.'
+    );
+  });
+
+  it.each([
+    { ...apiNews, id: 1 },
+    { ...apiNews, artistId: 'not-a-uuid' },
+    { ...apiNews, sourceName: '' },
+    { ...apiNews, thumbnailUrl: 42 },
+    { ...apiNews, thumbnailUrl: 'http://images.example.com/news.jpg' },
+    { ...apiNews, sourceUrl: 'javascript:alert(1)' },
+    { ...apiNews, publishedAt: 'not-a-date' },
+  ])('rejects malformed successful news payloads: %o', async (item) => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: { success: true, data: [item] },
+    });
+
+    await expect(fetchLatestNews()).rejects.toThrow(
+      '뉴스 API 응답이 올바르지 않습니다.'
+    );
+  });
+});

--- a/web/src/lib/api/home.ts
+++ b/web/src/lib/api/home.ts
@@ -2,6 +2,8 @@ import type { Live } from '@/types/live';
 import type { News } from '@/types/news';
 import type { PaginatedResponse } from '@/types/api';
 import { apiClient } from '@/lib/api-client';
+import { unwrapApiResponse } from '@/lib/api-response';
+import { isNewsApiDtoArray, mapNewsApiDto } from '@/lib/api/news-contract';
 
 export async function fetchLiveNow(limit = 5, signal?: AbortSignal): Promise<PaginatedResponse<Live>> {
   const { data } = await apiClient.get('/streaming-events', {
@@ -28,17 +30,14 @@ export async function fetchRecentLives(limit = 10, signal?: AbortSignal): Promis
 }
 
 export async function fetchLatestNews(limit = 10, signal?: AbortSignal): Promise<News[]> {
-  const { data } = await apiClient.get('/news/latest', {
+  const response = await apiClient.get('/news/latest', {
     params: { limit },
     signal,
   });
 
-  const result = Array.isArray(data.data) ? data.data : Array.isArray(data) ? data : null;
-
-  if (result === null) {
-    console.error('[fetchLatestNews] 예상치 못한 응답 구조:', data);
-    return [];
-  }
-
-  return result;
+  return unwrapApiResponse(
+    response.data,
+    '뉴스 API 응답이 올바르지 않습니다.',
+    isNewsApiDtoArray
+  ).map(mapNewsApiDto);
 }

--- a/web/src/lib/api/news-contract.ts
+++ b/web/src/lib/api/news-contract.ts
@@ -1,0 +1,123 @@
+import type { News, NewsDetail } from '@/types/news';
+import {
+  isIsoDateTime,
+  isNonEmptyString,
+  isRecord,
+  isUuid,
+} from '@/lib/api-response';
+
+const NEWS_CATEGORIES = new Set([
+  'GENERAL',
+  'RELEASE',
+  'TOUR',
+  'AWARD',
+  'VARIETY',
+  'SOCIAL_MEDIA',
+  'COLLABORATION',
+]);
+
+interface NewsApiDto {
+  id: string;
+  artistId: string;
+  title: string;
+  content: string;
+  sourceUrl: string;
+  sourceName: string;
+  thumbnailUrl: string | null;
+  category: string;
+  viewCount: number;
+  publishedAt: string;
+  createdAt: string;
+}
+
+interface SearchNewsApiDto {
+  id: string;
+  title: string;
+  summary: string;
+  sourceName: string;
+  publishedAt: string;
+}
+
+function isHttpsUrl(value: unknown): value is string {
+  if (!isNonEmptyString(value)) return false;
+
+  try {
+    return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function isNullableHttpsUrl(value: unknown): value is string | null {
+  return value === null || isHttpsUrl(value);
+}
+
+export function isNewsApiDto(value: unknown): value is NewsApiDto {
+  if (!isRecord(value)) return false;
+
+  return (
+    isUuid(value.id) &&
+    isUuid(value.artistId) &&
+    isNonEmptyString(value.title) &&
+    isNonEmptyString(value.content) &&
+    isHttpsUrl(value.sourceUrl) &&
+    isNonEmptyString(value.sourceName) &&
+    isNullableHttpsUrl(value.thumbnailUrl) &&
+    typeof value.category === 'string' &&
+    NEWS_CATEGORIES.has(value.category) &&
+    Number.isInteger(value.viewCount) &&
+    (value.viewCount as number) >= 0 &&
+    isIsoDateTime(value.publishedAt) &&
+    isIsoDateTime(value.createdAt)
+  );
+}
+
+export function isNewsApiDtoArray(value: unknown): value is NewsApiDto[] {
+  return Array.isArray(value) && value.every(isNewsApiDto);
+}
+
+export function mapNewsApiDto(value: NewsApiDto): News {
+  return {
+    id: value.id,
+    title: value.title,
+    summary: value.content,
+    thumbnailUrl: value.thumbnailUrl,
+    source: value.sourceName,
+    publishedAt: value.publishedAt,
+  };
+}
+
+export function mapNewsDetailApiDto(value: NewsApiDto): NewsDetail {
+  return {
+    ...mapNewsApiDto(value),
+    artistId: value.artistId,
+    content: value.content,
+    sourceUrl: value.sourceUrl,
+    category: value.category,
+    viewCount: value.viewCount,
+    createdAt: value.createdAt,
+  };
+}
+
+export function isSearchNewsApiDto(value: unknown): value is SearchNewsApiDto {
+  if (!isRecord(value)) return false;
+
+  return (
+    isUuid(value.id) &&
+    isNonEmptyString(value.title) &&
+    isNonEmptyString(value.summary) &&
+    isNonEmptyString(value.sourceName) &&
+    isIsoDateTime(value.publishedAt)
+  );
+}
+
+export function mapSearchNewsApiDto(value: SearchNewsApiDto): News {
+  return {
+    id: value.id,
+    title: value.title,
+    summary: value.summary,
+    thumbnailUrl: null,
+    source: value.sourceName,
+    publishedAt: value.publishedAt,
+  };
+}

--- a/web/src/lib/api/news.test.ts
+++ b/web/src/lib/api/news.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/api-client';
+import { fetchNewsDetail, fetchNewsList } from './news';
+
+const apiNews = {
+  id: '11111111-1111-1111-1111-111111111111',
+  artistId: '22222222-2222-2222-2222-222222222222',
+  title: '실제 API 뉴스',
+  content: '실제 수집 기사 요약 내용',
+  sourceUrl: 'https://news.google.com/articles/real',
+  sourceName: '실제 언론사',
+  thumbnailUrl: null,
+  category: 'GENERAL',
+  viewCount: 0,
+  publishedAt: '2026-08-14T02:30:00Z',
+  createdAt: '2026-08-14T02:50:00Z',
+};
+
+const mappedSummary = {
+  id: apiNews.id,
+  title: apiNews.title,
+  summary: apiNews.content,
+  thumbnailUrl: null,
+  source: apiNews.sourceName,
+  publishedAt: apiNews.publishedAt,
+};
+
+const mappedDetail = {
+  ...mappedSummary,
+  artistId: apiNews.artistId,
+  content: apiNews.content,
+  sourceUrl: apiNews.sourceUrl,
+  category: apiNews.category,
+  viewCount: apiNews.viewCount,
+  createdAt: apiNews.createdAt,
+};
+
+describe('news API', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('maps validated latest news list responses', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: { success: true, data: [apiNews] },
+    });
+
+    await expect(fetchNewsList(20, 5)).resolves.toEqual([mappedSummary]);
+    expect(apiClient.get).toHaveBeenCalledWith('/news/latest', {
+      params: { limit: 20, offset: 5 },
+      signal: undefined,
+    });
+  });
+
+  it('maps validated news detail responses', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: { success: true, data: apiNews },
+    });
+
+    await expect(fetchNewsDetail(apiNews.id)).resolves.toEqual(mappedDetail);
+    expect(apiClient.get).toHaveBeenCalledWith(`/news/${apiNews.id}`, {
+      signal: undefined,
+    });
+  });
+
+  it('rejects malformed list elements instead of returning them as News', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: { success: true, data: [{ ...apiNews, content: null }] },
+    });
+
+    await expect(fetchNewsList()).rejects.toThrow(
+      '뉴스 API 응답이 올바르지 않습니다.'
+    );
+  });
+
+  it('rejects malformed detail payloads', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: { success: true, data: { ...apiNews, sourceUrl: '' } },
+    });
+
+    await expect(fetchNewsDetail(apiNews.id)).rejects.toThrow(
+      '뉴스 상세 API 응답이 올바르지 않습니다.'
+    );
+  });
+});

--- a/web/src/lib/api/news.ts
+++ b/web/src/lib/api/news.ts
@@ -1,30 +1,40 @@
 import type { News, NewsDetail } from '@/types/news';
 import { apiClient } from '@/lib/api-client';
+import { unwrapApiResponse } from '@/lib/api-response';
+import {
+  isNewsApiDto,
+  isNewsApiDtoArray,
+  mapNewsApiDto,
+  mapNewsDetailApiDto,
+} from '@/lib/api/news-contract';
 
 export async function fetchNewsList(
   limit = 20,
   offset = 0,
   signal?: AbortSignal
 ): Promise<News[]> {
-  const { data } = await apiClient.get('/news/latest', {
+  const response = await apiClient.get('/news/latest', {
     params: { limit, offset },
     signal,
   });
 
-  const result = Array.isArray(data.data) ? data.data : Array.isArray(data) ? data : null;
-
-  if (result === null) {
-    console.error('[fetchNewsList] 예상치 못한 응답 구조:', data);
-    return [];
-  }
-
-  return result;
+  return unwrapApiResponse(
+    response.data,
+    '뉴스 API 응답이 올바르지 않습니다.',
+    isNewsApiDtoArray
+  ).map(mapNewsApiDto);
 }
 
 export async function fetchNewsDetail(
   id: string | number,
   signal?: AbortSignal
 ): Promise<NewsDetail> {
-  const { data } = await apiClient.get(`/news/${id}`, { signal });
-  return data.data;
+  const response = await apiClient.get(`/news/${id}`, { signal });
+  return mapNewsDetailApiDto(
+    unwrapApiResponse(
+      response.data,
+      '뉴스 상세 API 응답이 올바르지 않습니다.',
+      isNewsApiDto
+    )
+  );
 }

--- a/web/src/lib/api/search.test.ts
+++ b/web/src/lib/api/search.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/api-client';
+import { searchAll } from './search';
+
+const live = {
+  id: '11111111-1111-1111-1111-111111111111',
+  title: 'Live',
+  artistId: '22222222-2222-2222-2222-222222222222',
+  artistName: 'Artist',
+  thumbnailUrl: null,
+  status: 'LIVE',
+  scheduledAt: '2026-08-14T02:00:00Z',
+};
+
+const searchNews = {
+  id: '33333333-3333-3333-3333-333333333333',
+  title: '검색된 실제 뉴스',
+  summary: '검색 API가 제공한 실제 요약',
+  sourceName: '실제 언론사',
+  publishedAt: '2026-08-14T02:30:00Z',
+};
+
+describe('searchAll news contract', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('maps validated search news items to the shared card model', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: {
+        live: { items: [live], totalCount: 1 },
+        news: { items: [searchNews], totalCount: 1 },
+      },
+    });
+
+    await expect(searchAll('검색')).resolves.toEqual({
+      live: {
+        items: [
+          {
+            id: live.id,
+            title: live.title,
+            artistName: live.artistName,
+            thumbnailUrl: null,
+            status: live.status,
+            scheduledAt: live.scheduledAt,
+          },
+        ],
+        totalCount: 1,
+      },
+      news: {
+        items: [
+          {
+            id: searchNews.id,
+            title: searchNews.title,
+            summary: searchNews.summary,
+            thumbnailUrl: null,
+            source: searchNews.sourceName,
+            publishedAt: searchNews.publishedAt,
+          },
+        ],
+        totalCount: 1,
+      },
+    });
+  });
+
+  it('rejects malformed successful search news items', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: {
+        live: { items: [], totalCount: 0 },
+        news: { items: [{ ...searchNews, id: 7 }], totalCount: 1 },
+      },
+    });
+
+    await expect(searchAll('검색')).rejects.toThrow(
+      '검색 API 응답이 올바르지 않습니다.'
+    );
+  });
+
+  it('rejects malformed successful search live items', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: {
+        live: { items: [{ ...live, scheduledAt: 'not-a-date' }], totalCount: 1 },
+        news: { items: [], totalCount: 0 },
+      },
+    });
+
+    await expect(searchAll('검색')).rejects.toThrow(
+      '검색 API 응답이 올바르지 않습니다.'
+    );
+  });
+
+  it('rejects non-HTTPS search live thumbnails', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: {
+        live: {
+          items: [{ ...live, thumbnailUrl: 'http://images.example.com/live.jpg' }],
+          totalCount: 1,
+        },
+        news: { items: [], totalCount: 0 },
+      },
+    });
+
+    await expect(searchAll('검색')).rejects.toThrow(
+      '검색 API 응답이 올바르지 않습니다.'
+    );
+  });
+});

--- a/web/src/lib/api/search.ts
+++ b/web/src/lib/api/search.ts
@@ -1,6 +1,59 @@
 import type { Live } from '@/types/live';
 import type { News } from '@/types/news';
 import { apiClient } from '@/lib/api-client';
+import {
+  isIsoDateTime,
+  isNonEmptyString,
+  isRecord,
+  isUuid,
+} from '@/lib/api-response';
+import { isSearchNewsApiDto, mapSearchNewsApiDto } from '@/lib/api/news-contract';
+
+interface SearchLiveApiDto {
+  id: string;
+  title: string;
+  artistId: string;
+  artistName: string;
+  thumbnailUrl: string | null;
+  status: Live['status'];
+  scheduledAt: string;
+}
+
+function isNullableHttpsUrl(value: unknown): value is string | null {
+  if (value === null) return true;
+  if (!isNonEmptyString(value)) return false;
+
+  try {
+    return new URL(value).protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function isSearchLiveApiDto(value: unknown): value is SearchLiveApiDto {
+  if (!isRecord(value)) return false;
+
+  return (
+    isUuid(value.id) &&
+    isUuid(value.artistId) &&
+    isNonEmptyString(value.title) &&
+    isNonEmptyString(value.artistName) &&
+    isNullableHttpsUrl(value.thumbnailUrl) &&
+    (value.status === 'LIVE' || value.status === 'SCHEDULED' || value.status === 'ENDED') &&
+    isIsoDateTime(value.scheduledAt)
+  );
+}
+
+function mapSearchLiveApiDto(value: SearchLiveApiDto): Live {
+  return {
+    id: value.id,
+    title: value.title,
+    artistName: value.artistName,
+    thumbnailUrl: value.thumbnailUrl,
+    status: value.status,
+    scheduledAt: value.scheduledAt,
+  };
+}
 
 export interface SearchResponse {
   live: { items: Live[]; totalCount: number };
@@ -12,9 +65,41 @@ export async function searchAll(
   limit = 20,
   signal?: AbortSignal
 ): Promise<SearchResponse> {
-  const { data } = await apiClient.get('/search', {
+  const response = await apiClient.get('/search', {
     params: { q: query, limit },
     signal,
   });
-  return data;
+
+  const data: unknown = response.data;
+  if (!isRecord(data) || !isRecord(data.live) || !isRecord(data.news)) {
+    throw new Error('검색 API 응답이 올바르지 않습니다.');
+  }
+
+  const liveItems = data.live.items;
+  const newsItems = data.news.items;
+  const liveTotal = data.live.totalCount;
+  const newsTotal = data.news.totalCount;
+  if (
+    !Array.isArray(liveItems) ||
+    !liveItems.every(isSearchLiveApiDto) ||
+    !Array.isArray(newsItems) ||
+    !newsItems.every(isSearchNewsApiDto) ||
+    !Number.isInteger(liveTotal) ||
+    (liveTotal as number) < 0 ||
+    !Number.isInteger(newsTotal) ||
+    (newsTotal as number) < 0
+  ) {
+    throw new Error('검색 API 응답이 올바르지 않습니다.');
+  }
+
+  return {
+    live: {
+      items: liveItems.map(mapSearchLiveApiDto),
+      totalCount: liveTotal as number,
+    },
+    news: {
+      items: newsItems.map(mapSearchNewsApiDto),
+      totalCount: newsTotal as number,
+    },
+  };
 }

--- a/web/src/types/live.ts
+++ b/web/src/types/live.ts
@@ -1,10 +1,10 @@
 export type LiveStatus = 'LIVE' | 'SCHEDULED' | 'ENDED';
 
 export interface Live {
-  id: number;
+  id: string;
   title: string;
   artistName: string;
-  thumbnailUrl: string;
+  thumbnailUrl: string | null;
   status: LiveStatus;
   scheduledAt?: string;
   viewerCount?: number;

--- a/web/src/types/news.ts
+++ b/web/src/types/news.ts
@@ -1,14 +1,17 @@
 export interface News {
-  id: number;
+  id: string;
   title: string;
   summary: string;
-  thumbnailUrl: string;
+  thumbnailUrl: string | null;
   source: string;
   publishedAt: string;
 }
 
 export interface NewsDetail extends News {
+  artistId: string;
   content: string;
   sourceUrl: string;
-  author?: string;
+  category: string;
+  viewCount: number;
+  createdAt: string;
 }


### PR DESCRIPTION
## 요약
- 운영 뉴스 payload를 프론트엔드 API 경계에서 검증합니다.
- Spring 뉴스·검색 DTO를 명시적인 UI model로 변환합니다.
- UUID 식별자를 유지하고 nullable thumbnail을 mock fallback 없이 처리합니다.
- 통합 검색의 live·news 항목과 HTTPS 외부 URL을 런타임 검증합니다.

## 운영 문제
배포된 Spring API는 실제 뉴스 row를 정상 반환했지만 프론트엔드는 여전히 기존 mock 구조인 숫자 ID, `summary`, `source`, 필수 thumbnail을 기대했습니다. 이번 변경으로 프론트엔드 계약을 운영 API와 일치시키고, 잘못된 성공 응답은 fail-closed로 거부합니다.

## 검증
- Frontend unit test: 53 files / 215 tests
- TypeScript 통과
- 변경 파일 ESLint warning 0건
- Next.js production build 통과
- 뉴스 Playwright E2E: 12 tests
- 운영 latest→detail 뉴스 세로 슬라이스 통과
- 운영 통합 검색의 실제 news 계약 통과
