### PR TITLE
수정: 뉴스 목록 페이지네이션 계약 적용

### DIFF
--- a/web/src/app/components/home/NewsCard.test.tsx
+++ b/web/src/app/components/home/NewsCard.test.tsx
@@ -26,7 +26,12 @@ describe('NewsCard', () => {
 
   it('renders summary', () => {
     render(<NewsCard news={mockNews} />);
-    expect(screen.getByText(mockNews.summary)).toBeInTheDocument();
+    expect(screen.getByText(mockNews.summary!)).toBeInTheDocument();
+  });
+
+  it('does not fabricate a summary when the list DTO has none', () => {
+    const { container } = render(<NewsCard news={{ ...mockNews, summary: null }} />);
+    expect(container.querySelector('.line-clamp-2')).not.toBeInTheDocument();
   });
 
   it('renders source', () => {

--- a/web/src/app/components/home/NewsCard.tsx
+++ b/web/src/app/components/home/NewsCard.tsx
@@ -34,7 +34,9 @@ export default function NewsCard({ news }: NewsCardProps) {
       )}
       <div className="flex-1 min-w-0">
         <h3 className="font-medium text-gray-900 line-clamp-1">{title}</h3>
-        <p className="text-sm text-gray-600 line-clamp-2 mt-0.5">{summary}</p>
+        {summary && (
+          <p className="text-sm text-gray-600 line-clamp-2 mt-0.5">{summary}</p>
+        )}
         <span className="text-xs text-gray-400 mt-1 block">
           {source} · {formatRelativeTime(publishedAt)}
         </span>

--- a/web/src/hooks/useNewsList.test.ts
+++ b/web/src/hooks/useNewsList.test.ts
@@ -1,0 +1,58 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useNewsList } from './useNewsList';
+import { fetchNewsList } from '@/lib/api/news';
+
+vi.mock('@/lib/api/news', () => ({
+  fetchNewsList: vi.fn(),
+}));
+
+const first = {
+  id: '11111111-1111-1111-1111-111111111111',
+  title: '첫 기사',
+  summary: null,
+  thumbnailUrl: null,
+  source: '언론사',
+  publishedAt: '2026-08-14T03:00:00Z',
+};
+
+const second = {
+  ...first,
+  id: '22222222-2222-2222-2222-222222222222',
+  title: '둘째 기사',
+};
+
+describe('useNewsList', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('advances by nextOffset and stops from server pagination metadata', async () => {
+    vi.mocked(fetchNewsList)
+      .mockResolvedValueOnce({
+        items: [first],
+        nextOffset: 1,
+        hasMore: true,
+        totalElements: 2,
+      })
+      .mockResolvedValueOnce({
+        items: [second],
+        nextOffset: 2,
+        hasMore: false,
+        totalElements: 2,
+      });
+
+    const { result } = renderHook(() => useNewsList({ limit: 1 }));
+
+    await waitFor(() => expect(result.current.state).toBe('success'));
+    expect(result.current.items).toEqual([first]);
+    expect(result.current.hasMore).toBe(true);
+    expect(fetchNewsList).toHaveBeenNthCalledWith(1, 1, 0, expect.any(AbortSignal));
+
+    await act(async () => {
+      await result.current.loadMore();
+    });
+
+    expect(result.current.items).toEqual([first, second]);
+    expect(result.current.hasMore).toBe(false);
+    expect(fetchNewsList).toHaveBeenNthCalledWith(2, 1, 1, expect.any(AbortSignal));
+  });
+});

--- a/web/src/hooks/useNewsList.ts
+++ b/web/src/hooks/useNewsList.ts
@@ -60,13 +60,13 @@ export function useNewsList(
         if (abortControllerRef.current.signal.aborted) return;
 
         if (isRefresh) {
-          setItems(result);
+          setItems(result.items);
         } else {
-          setItems((prev) => [...prev, ...result]);
+          setItems((prev) => [...prev, ...result.items]);
         }
 
-        offsetRef.current = (isRefresh ? 0 : offsetRef.current) + result.length;
-        setHasMore(result.length >= limit);
+        offsetRef.current = result.nextOffset;
+        setHasMore(result.hasMore);
         setState('success');
       } catch (err) {
         if (axios.isCancel(err)) return;
@@ -80,9 +80,13 @@ export function useNewsList(
   );
 
   useEffect(() => {
-    fetchData(true);
+    let active = true;
+    queueMicrotask(() => {
+      if (active) void fetchData(true);
+    });
 
     return () => {
+      active = false;
       abortControllerRef.current?.abort();
     };
   }, [fetchData]);

--- a/web/src/lib/api/news-contract.ts
+++ b/web/src/lib/api/news-contract.ts
@@ -38,6 +38,16 @@ interface SearchNewsApiDto {
   publishedAt: string;
 }
 
+export interface NewsSummaryApiDto {
+  id: string;
+  artistId: string;
+  title: string;
+  thumbnailUrl: string | null;
+  sourceName: string;
+  category: string;
+  publishedAt: string;
+}
+
 function isHttpsUrl(value: unknown): value is string {
   if (!isNonEmptyString(value)) return false;
 
@@ -96,6 +106,32 @@ export function mapNewsDetailApiDto(value: NewsApiDto): NewsDetail {
     category: value.category,
     viewCount: value.viewCount,
     createdAt: value.createdAt,
+  };
+}
+
+export function isNewsSummaryApiDto(value: unknown): value is NewsSummaryApiDto {
+  if (!isRecord(value)) return false;
+
+  return (
+    isUuid(value.id) &&
+    isUuid(value.artistId) &&
+    isNonEmptyString(value.title) &&
+    isNullableHttpsUrl(value.thumbnailUrl) &&
+    isNonEmptyString(value.sourceName) &&
+    typeof value.category === 'string' &&
+    NEWS_CATEGORIES.has(value.category) &&
+    isIsoDateTime(value.publishedAt)
+  );
+}
+
+export function mapNewsSummaryApiDto(value: NewsSummaryApiDto): News {
+  return {
+    id: value.id,
+    title: value.title,
+    summary: null,
+    thumbnailUrl: value.thumbnailUrl,
+    source: value.sourceName,
+    publishedAt: value.publishedAt,
   };
 }
 

--- a/web/src/lib/api/news.test.ts
+++ b/web/src/lib/api/news.test.ts
@@ -23,10 +23,20 @@ const apiNews = {
   createdAt: '2026-08-14T02:50:00Z',
 };
 
+const apiNewsSummary = {
+  id: apiNews.id,
+  artistId: apiNews.artistId,
+  title: apiNews.title,
+  thumbnailUrl: apiNews.thumbnailUrl,
+  sourceName: apiNews.sourceName,
+  category: apiNews.category,
+  publishedAt: apiNews.publishedAt,
+};
+
 const mappedSummary = {
   id: apiNews.id,
   title: apiNews.title,
-  summary: apiNews.content,
+  summary: null,
   thumbnailUrl: null,
   source: apiNews.sourceName,
   publishedAt: apiNews.publishedAt,
@@ -34,6 +44,7 @@ const mappedSummary = {
 
 const mappedDetail = {
   ...mappedSummary,
+  summary: apiNews.content,
   artistId: apiNews.artistId,
   content: apiNews.content,
   sourceUrl: apiNews.sourceUrl,
@@ -42,18 +53,46 @@ const mappedDetail = {
   createdAt: apiNews.createdAt,
 };
 
+const apiPage = {
+  content: [apiNewsSummary],
+  totalElements: 41,
+  page: 1,
+  size: 20,
+  totalPages: 3,
+};
+
 describe('news API', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('maps validated latest news list responses', async () => {
+  it('maps the canonical paginated news endpoint without fabricating a summary', async () => {
     vi.mocked(apiClient.get).mockResolvedValue({
-      data: { success: true, data: [apiNews] },
+      data: { success: true, data: apiPage },
     });
 
-    await expect(fetchNewsList(20, 5)).resolves.toEqual([mappedSummary]);
-    expect(apiClient.get).toHaveBeenCalledWith('/news/latest', {
-      params: { limit: 20, offset: 5 },
+    await expect(fetchNewsList(20, 20)).resolves.toEqual({
+      items: [mappedSummary],
+      nextOffset: 40,
+      hasMore: true,
+      totalElements: 41,
+    });
+    expect(apiClient.get).toHaveBeenCalledWith('/news', {
+      params: { page: 1, size: 20, sortBy: 'publishedAt', sortDir: 'desc' },
       signal: undefined,
+    });
+  });
+
+  it('uses totalPages rather than page length to close pagination', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: {
+        success: true,
+        data: { ...apiPage, totalElements: 40, page: 1, totalPages: 2 },
+      },
+    });
+
+    await expect(fetchNewsList(20, 20)).resolves.toMatchObject({
+      nextOffset: 40,
+      hasMore: false,
+      totalElements: 40,
     });
   });
 
@@ -68,12 +107,30 @@ describe('news API', () => {
     });
   });
 
-  it('rejects malformed list elements instead of returning them as News', async () => {
+  it.each([
+    { ...apiPage, content: [{ ...apiNewsSummary, artistId: 'not-a-uuid' }] },
+    { ...apiPage, totalElements: -1 },
+    { ...apiPage, page: '1' },
+    { ...apiPage, size: 0 },
+    { ...apiPage, totalPages: -1 },
+    { ...apiPage, totalElements: 100, totalPages: 3 },
+    [apiNews],
+  ])('rejects malformed successful paginated payloads: %o', async (data) => {
     vi.mocked(apiClient.get).mockResolvedValue({
-      data: { success: true, data: [{ ...apiNews, content: null }] },
+      data: { success: true, data },
     });
 
     await expect(fetchNewsList()).rejects.toThrow(
+      '뉴스 API 응답이 올바르지 않습니다.'
+    );
+  });
+
+  it('rejects a valid-shaped page that does not match the requested page', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: { success: true, data: { ...apiPage, page: 0 } },
+    });
+
+    await expect(fetchNewsList(20, 20)).rejects.toThrow(
       '뉴스 API 응답이 올바르지 않습니다.'
     );
   });

--- a/web/src/lib/api/news.ts
+++ b/web/src/lib/api/news.ts
@@ -1,28 +1,76 @@
 import type { News, NewsDetail } from '@/types/news';
 import { apiClient } from '@/lib/api-client';
-import { unwrapApiResponse } from '@/lib/api-response';
+import { isRecord, unwrapApiResponse } from '@/lib/api-response';
 import {
   isNewsApiDto,
-  isNewsApiDtoArray,
-  mapNewsApiDto,
+  isNewsSummaryApiDto,
   mapNewsDetailApiDto,
+  mapNewsSummaryApiDto,
+  type NewsSummaryApiDto,
 } from '@/lib/api/news-contract';
+
+interface NewsListApiDto {
+  content: NewsSummaryApiDto[];
+  totalElements: number;
+  page: number;
+  size: number;
+  totalPages: number;
+}
+
+export interface NewsPage {
+  items: News[];
+  nextOffset: number;
+  hasMore: boolean;
+  totalElements: number;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) > 0;
+}
+
+function isNewsListApiDto(value: unknown): value is NewsListApiDto {
+  if (!isRecord(value)) return false;
+  if (!Array.isArray(value.content) || !value.content.every(isNewsSummaryApiDto)) return false;
+  if (!isNonNegativeInteger(value.totalElements)) return false;
+  if (!isNonNegativeInteger(value.page)) return false;
+  if (!isPositiveInteger(value.size) || value.size > 100) return false;
+  if (!isNonNegativeInteger(value.totalPages)) return false;
+  if (value.content.length > value.size) return false;
+
+  return value.totalPages === Math.ceil(value.totalElements / value.size);
+}
 
 export async function fetchNewsList(
   limit = 20,
   offset = 0,
   signal?: AbortSignal
-): Promise<News[]> {
-  const response = await apiClient.get('/news/latest', {
-    params: { limit, offset },
+): Promise<NewsPage> {
+  const size = Math.min(100, Math.max(1, Math.trunc(limit)));
+  const safeOffset = Math.max(0, Math.trunc(offset));
+  const page = Math.floor(safeOffset / size);
+  const response = await apiClient.get('/news', {
+    params: { page, size, sortBy: 'publishedAt', sortDir: 'desc' },
     signal,
   });
-
-  return unwrapApiResponse(
+  const data = unwrapApiResponse(
     response.data,
     '뉴스 API 응답이 올바르지 않습니다.',
-    isNewsApiDtoArray
-  ).map(mapNewsApiDto);
+    isNewsListApiDto
+  );
+  if (data.page !== page || data.size !== size) {
+    throw new Error('뉴스 API 응답이 올바르지 않습니다.');
+  }
+
+  return {
+    items: data.content.map(mapNewsSummaryApiDto),
+    nextOffset: (data.page + 1) * data.size,
+    hasMore: data.page + 1 < data.totalPages,
+    totalElements: data.totalElements,
+  };
 }
 
 export async function fetchNewsDetail(

--- a/web/src/types/news.ts
+++ b/web/src/types/news.ts
@@ -1,7 +1,7 @@
 export interface News {
   id: string;
   title: string;
-  summary: string;
+  summary: string | null;
   thumbnailUrl: string | null;
   source: string;
   publishedAt: string;


### PR DESCRIPTION
## 요약
- 뉴스 목록을 정식 `/news?page=&size=` endpoint로 전환했습니다.
- `NewsListResponse`를 검증하고 반환된 page metadata가 요청과 일치하는지 확인합니다.
- 더보기 상태는 서버 pagination metadata를 기준으로 계산합니다.
- 목록 DTO에 요약이 없으면 내용을 만들어내지 않고 summary 영역을 생략합니다.

## 운영 문제
`/news/latest`는 `limit`만 지원하며 프론트엔드가 보낸 `offset`을 무시합니다. 따라서 더보기 요청마다 같은 첫 page가 반복됐습니다. 일반 뉴스 목록은 page 기반 `/news` endpoint를 사용해야 합니다.

## 검증
- Pagination focused test: 19 tests
- Frontend unit test: 54 files / 225 tests
- TypeScript 통과
- 변경 파일 ESLint warning 0건
- Next.js production build 통과
- 뉴스 Playwright E2E: 12 tests
- 운영 `/news` 전체 page에서 UUID 중복 없이 일관된 metadata 확인
