### PR TITLE
수정: Django 컨테이너 메모리 여유 확보

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512M
+          memory: 768M
     networks:
       - fanpulse-net
 


### PR DESCRIPTION
## 요약
- `django-ai` container memory limit만 512MiB에서 768MiB로 높였습니다.
- PostgreSQL·Spring·news-worker limit과 나머지 service 설정은 유지했습니다.

## 운영 확인
정상 기동 약 1시간 후 Django가 512MiB cgroup limit 중 약 496MiB인 92.45%를 사용했습니다. VM은 전체 4GiB 중 약 1.6GiB만 사용하고 있어 host memory pressure는 없었습니다. Django에 256MiB의 여유를 추가해 host 부담 없이 cgroup OOM 위험을 줄였습니다.

## 검증
- `docker compose config --format json` 통과
- 적용 limit: Django 768MiB, Spring 1536MiB, PostgreSQL 512MiB, news-worker 256MiB
- 변경 범위: 파일 1개, 설정 1줄
