### PR TITLE
수정: 원격 이미지와 Instant 검증 강화

### DIFF
--- a/web/src/app/components/home/LiveCard.test.tsx
+++ b/web/src/app/components/home/LiveCard.test.tsx
@@ -33,6 +33,16 @@ describe('LiveCard', () => {
     expect(img).toBeInTheDocument();
   });
 
+  it('renders external API thumbnails directly without the Next image optimizer', () => {
+    const thumbnailUrl = 'https://cdn.example.com/live.jpg';
+    render(<LiveCard live={{ ...mockLive, thumbnailUrl }} />);
+
+    const img = screen.getByAltText(mockLive.title);
+    expect(img).toHaveAttribute('src', thumbnailUrl);
+    expect(img).not.toHaveAttribute('srcset');
+    expect(img).toHaveAttribute('referrerpolicy', 'no-referrer');
+  });
+
   it('renders an explicit empty thumbnail state for null API thumbnails', () => {
     render(<LiveCard live={{ ...mockLive, thumbnailUrl: null }} />);
 

--- a/web/src/app/components/home/LiveCard.tsx
+++ b/web/src/app/components/home/LiveCard.tsx
@@ -22,6 +22,8 @@ export default function LiveCard({ live }: LiveCardProps) {
             alt={title}
             width={280}
             height={160}
+            unoptimized={/^https:\/\//i.test(thumbnailUrl)}
+            referrerPolicy="no-referrer"
             className="w-full h-40 object-cover group-hover:scale-105 transition-transform duration-300"
           />
         ) : (

--- a/web/src/app/components/home/NewsCard.test.tsx
+++ b/web/src/app/components/home/NewsCard.test.tsx
@@ -19,6 +19,21 @@ describe('NewsCard', () => {
     expect(img).toBeInTheDocument();
   });
 
+  it.each([
+    'https://images.example.com/news.jpg',
+    'HTTPS://images.example.com/news.jpg',
+  ])(
+    'renders external API thumbnails directly without the Next image optimizer: %s',
+    (thumbnailUrl) => {
+      render(<NewsCard news={{ ...mockNews, thumbnailUrl }} />);
+
+      const img = screen.getByAltText(mockNews.title);
+      expect(img).toHaveAttribute('src', thumbnailUrl);
+      expect(img).not.toHaveAttribute('srcset');
+      expect(img).toHaveAttribute('referrerpolicy', 'no-referrer');
+    }
+  );
+
   it('renders title', () => {
     render(<NewsCard news={mockNews} />);
     expect(screen.getByText(mockNews.title)).toBeInTheDocument();

--- a/web/src/app/components/home/NewsCard.tsx
+++ b/web/src/app/components/home/NewsCard.tsx
@@ -23,6 +23,8 @@ export default function NewsCard({ news }: NewsCardProps) {
           alt={title}
           width={96}
           height={80}
+          unoptimized={/^https:\/\//i.test(thumbnailUrl)}
+          referrerPolicy="no-referrer"
           className="w-24 h-20 rounded-lg object-cover object-top flex-shrink-0"
         />
       ) : (

--- a/web/src/app/live/components/LiveListItem.test.tsx
+++ b/web/src/app/live/components/LiveListItem.test.tsx
@@ -12,6 +12,16 @@ describe('LiveListItem', () => {
     expect(screen.getByText('NewJeans Official')).toBeInTheDocument();
   });
 
+  it('renders external API thumbnails directly without the Next image optimizer', () => {
+    const thumbnailUrl = 'https://stream.example.com/live.jpg';
+    render(<LiveListItem live={{ ...mockLiveNow[0], thumbnailUrl }} />);
+
+    const img = screen.getByAltText('NewJeans 컴백 쇼케이스');
+    expect(img).toHaveAttribute('src', thumbnailUrl);
+    expect(img).not.toHaveAttribute('srcset');
+    expect(img).toHaveAttribute('referrerpolicy', 'no-referrer');
+  });
+
   it('renders an explicit empty thumbnail state for null API thumbnails', () => {
     render(<LiveListItem live={{ ...mockLiveNow[0], thumbnailUrl: null }} />);
 

--- a/web/src/app/live/components/LiveListItem.tsx
+++ b/web/src/app/live/components/LiveListItem.tsx
@@ -24,6 +24,8 @@ export default function LiveListItem({ live }: LiveListItemProps) {
               width={384}
               height={192}
               sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
+              unoptimized={/^https:\/\//i.test(thumbnailUrl)}
+              referrerPolicy="no-referrer"
               className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-300"
             />
           ) : (

--- a/web/src/lib/api-response.test.ts
+++ b/web/src/lib/api-response.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { isIsoInstant } from './api-response';
+
+describe('isIsoInstant', () => {
+  it.each([
+    '2026-08-14T02:00:00Z',
+    '2026-08-14T02:00:00.123456Z',
+    '2026-08-14T11:00:00+09:00',
+  ])('accepts an ISO-8601 instant with an explicit offset: %s', (value) => {
+    expect(isIsoInstant(value)).toBe(true);
+  });
+
+  it('rejects a date-time without an explicit UTC offset', () => {
+    expect(isIsoInstant('2026-08-14T02:00:00')).toBe(false);
+  });
+});

--- a/web/src/lib/api-response.ts
+++ b/web/src/lib/api-response.ts
@@ -52,6 +52,13 @@ export function isIsoDateTime(value: unknown): value is string {
   );
 }
 
+export function isIsoInstant(value: unknown): value is string {
+  return (
+    isIsoDateTime(value) &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/.test(value)
+  );
+}
+
 export function unwrapApiResponse<T>(
   payload: unknown,
   errorMessage: string,

--- a/web/src/lib/api/artist.ts
+++ b/web/src/lib/api/artist.ts
@@ -1,7 +1,7 @@
 import { apiClient } from '@/lib/api-client';
 import {
   isIsoDate,
-  isIsoDateTime,
+  isIsoInstant,
   isNonEmptyString,
   isNullableString,
   isRecord,
@@ -38,7 +38,7 @@ function isArtistDetail(value: unknown): value is ArtistDetail {
     value.members.every(isNonEmptyString) &&
     typeof value.active === 'boolean' &&
     (value.debutDate === null || isIsoDate(value.debutDate)) &&
-    isIsoDateTime(value.createdAt)
+    isIsoInstant(value.createdAt)
   );
 }
 

--- a/web/src/lib/api/chart.ts
+++ b/web/src/lib/api/chart.ts
@@ -1,7 +1,7 @@
 import { apiClient } from '@/lib/api-client';
 import {
   isIsoDate,
-  isIsoDateTime,
+  isIsoInstant,
   isNonEmptyString,
   isNullableInteger,
   isPositiveInteger,
@@ -82,7 +82,7 @@ function isChartResponse(value: unknown): value is ChartResponse {
     isIsoDate(value.chartDate) &&
     Array.isArray(value.entries) &&
     value.entries.every(isChartEntry) &&
-    isIsoDateTime(value.createdAt)
+    isIsoInstant(value.createdAt)
   );
 }
 

--- a/web/src/lib/api/news-contract.ts
+++ b/web/src/lib/api/news-contract.ts
@@ -1,6 +1,6 @@
 import type { News, NewsDetail } from '@/types/news';
 import {
-  isIsoDateTime,
+  isIsoInstant,
   isNonEmptyString,
   isRecord,
   isUuid,
@@ -77,8 +77,8 @@ export function isNewsApiDto(value: unknown): value is NewsApiDto {
     NEWS_CATEGORIES.has(value.category) &&
     Number.isInteger(value.viewCount) &&
     (value.viewCount as number) >= 0 &&
-    isIsoDateTime(value.publishedAt) &&
-    isIsoDateTime(value.createdAt)
+    isIsoInstant(value.publishedAt) &&
+    isIsoInstant(value.createdAt)
   );
 }
 
@@ -120,7 +120,7 @@ export function isNewsSummaryApiDto(value: unknown): value is NewsSummaryApiDto 
     isNonEmptyString(value.sourceName) &&
     typeof value.category === 'string' &&
     NEWS_CATEGORIES.has(value.category) &&
-    isIsoDateTime(value.publishedAt)
+    isIsoInstant(value.publishedAt)
   );
 }
 
@@ -143,7 +143,7 @@ export function isSearchNewsApiDto(value: unknown): value is SearchNewsApiDto {
     isNonEmptyString(value.title) &&
     isNonEmptyString(value.summary) &&
     isNonEmptyString(value.sourceName) &&
-    isIsoDateTime(value.publishedAt)
+    isIsoInstant(value.publishedAt)
   );
 }
 

--- a/web/src/lib/api/search.ts
+++ b/web/src/lib/api/search.ts
@@ -2,7 +2,7 @@ import type { Live } from '@/types/live';
 import type { News } from '@/types/news';
 import { apiClient } from '@/lib/api-client';
 import {
-  isIsoDateTime,
+  isIsoInstant,
   isNonEmptyString,
   isRecord,
   isUuid,
@@ -40,7 +40,7 @@ function isSearchLiveApiDto(value: unknown): value is SearchLiveApiDto {
     isNonEmptyString(value.artistName) &&
     isNullableHttpsUrl(value.thumbnailUrl) &&
     (value.status === 'LIVE' || value.status === 'SCHEDULED' || value.status === 'ENDED') &&
-    isIsoDateTime(value.scheduledAt)
+    isIsoInstant(value.scheduledAt)
   );
 }
 


### PR DESCRIPTION
## 요약
- 외부 HTTPS 뉴스·live thumbnail을 임의 host에 대한 Next image optimizer 요청 대신 browser에서 직접 렌더링합니다.
- 원격 thumbnail 요청에 `no-referrer`를 적용하고 로컬·정적 이미지는 기존 최적화를 유지합니다.
- `Z` 또는 명시적 UTC offset을 요구하는 `Instant` 전용 runtime guard를 추가했습니다.
- 즐겨찾기와 알림의 timezone 없는 `LocalDateTime` 지원은 유지합니다.
- News·Search·Chart·Artist DTO에 strict `Instant` guard를 적용했습니다.

## 검증
- RED regression으로 optimizer URL 생성과 timezone 없는 timestamp 허용을 재현
- Focused API/component test: 10 files / 75 tests
- 전체 Vitest: 55 files / 233 tests
- 변경 파일 ESLint 및 TypeScript 통과
- Next production build 통과
- 뉴스 Playwright: 12 tests
- 운영 News·Search·Chart·Artist timestamp가 모두 명시적 offset 형식과 일치함을 확인
