### PR TITLE
feat: 커뮤니티 실제 데이터 세로 슬라이스 구현

### DIFF
--- a/backend/src/main/kotlin/com/fanpulse/application/dto/comment/CommentDtos.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/dto/comment/CommentDtos.kt
@@ -84,17 +84,21 @@ data class CommentResponse(
     val parentCommentId: UUID?,
 
     @Schema(description = "작성 일시")
-    val createdAt: Instant
+    val createdAt: Instant,
+
+    @Schema(description = "작성자명")
+    val authorName: String? = null
 ) {
     companion object {
-        fun from(comment: Comment): CommentResponse = CommentResponse(
+        fun from(comment: Comment, authorName: String? = null): CommentResponse = CommentResponse(
             id = comment.id,
             postId = comment.postId,
             userId = comment.userId,
             content = comment.content,
             status = comment.status,
             parentCommentId = comment.parentCommentId,
-            createdAt = comment.createdAt
+            createdAt = comment.createdAt,
+            authorName = authorName
         )
     }
 }

--- a/backend/src/main/kotlin/com/fanpulse/application/service/comment/CommentCommandServiceImpl.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/service/comment/CommentCommandServiceImpl.kt
@@ -39,6 +39,13 @@ class CommentCommandServiceImpl(
         content: String,
         parentCommentId: UUID?
     ): CommentResponse {
+        if (parentCommentId != null) {
+            val parent = commentPort.findById(parentCommentId)
+                ?: throw NoSuchElementException("부모 댓글을 찾을 수 없습니다")
+            require(parent.postId == postId) { "부모 댓글은 같은 게시글에 속해야 합니다" }
+            require(parent.status == CommentStatus.APPROVED) { "승인된 댓글에만 답글을 작성할 수 있습니다" }
+        }
+
         // 1. 도메인 엔티티 생성 (content 검증 포함, PENDING 초기 상태)
         val comment = Comment.create(postId, userId, content, parentCommentId)
 
@@ -74,7 +81,9 @@ class CommentCommandServiceImpl(
     private fun resolveStatus(comment: Comment, filterResult: FilterResult) {
         when {
             filterResult.isFiltered -> comment.block(filterResult.reason ?: "AI 필터에 의해 차단됨")
-            filterResult.filterType == "fallback" -> {} // AI 장애 → PENDING 유지 (Fail-Pending)
+            filterResult.filterType.lowercase() in setOf("fallback", "noop") -> {
+                // AI 장애 또는 명시적 비활성화 → PENDING 유지 (Fail-Pending)
+            }
             else -> comment.approve()
         }
     }

--- a/backend/src/main/kotlin/com/fanpulse/application/service/comment/CommentQueryServiceImpl.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/service/comment/CommentQueryServiceImpl.kt
@@ -5,6 +5,7 @@ import com.fanpulse.application.dto.comment.CommentResponse
 import com.fanpulse.domain.comment.CommentStatus
 import com.fanpulse.domain.comment.port.CommentPort
 import com.fanpulse.infrastructure.common.PaginationConverter
+import com.fanpulse.infrastructure.persistence.identity.UserJpaRepository
 import mu.KotlinLogging
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -18,16 +19,19 @@ private val logger = KotlinLogging.logger {}
 @Service
 @Transactional(readOnly = true)
 class CommentQueryServiceImpl(
-    private val commentPort: CommentPort
+    private val commentPort: CommentPort,
+    private val userRepository: UserJpaRepository
 ) : CommentQueryService {
 
     override fun getComments(postId: String, pageable: Pageable): CommentListResponse {
         logger.debug { "Getting APPROVED comments for post: $postId" }
         val pageRequest = PaginationConverter.toDomainPageRequest(pageable)
         val pageResult = commentPort.findByPostIdAndStatus(postId, CommentStatus.APPROVED, pageRequest)
+        val authorNames = userRepository.findAllByIds(pageResult.content.map { it.userId }.distinct())
+            .associate { it.id to it.username }
 
         return CommentListResponse(
-            content = pageResult.content.map { CommentResponse.from(it) },
+            content = pageResult.content.map { CommentResponse.from(it, authorNames[it.userId]) },
             totalElements = pageResult.totalElements,
             page = pageResult.page,
             size = pageResult.size,

--- a/backend/src/main/kotlin/com/fanpulse/application/service/community/CommunityService.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/service/community/CommunityService.kt
@@ -1,0 +1,59 @@
+package com.fanpulse.application.service.community
+
+import java.time.Instant
+import java.util.UUID
+
+class CommunityModerationUnavailableException(
+    message: String,
+    cause: Throwable? = null
+) : RuntimeException(message, cause)
+
+enum class CommunitySort {
+    LATEST,
+    POPULAR
+}
+
+data class CreateCommunityPostRequest(
+    val artistId: UUID?,
+    val content: String
+)
+
+data class CommunityPostResponse(
+    val id: UUID,
+    val authorId: UUID,
+    val authorName: String,
+    val artistId: UUID?,
+    val artistName: String?,
+    val artistProfileImageUrl: String?,
+    val content: String,
+    val imageUrl: String?,
+    val likeCount: Long,
+    val commentCount: Long,
+    val createdAt: Instant
+)
+
+data class CommunityPostPageResponse(
+    val content: List<CommunityPostResponse>,
+    val page: Int,
+    val size: Int,
+    val totalElements: Long,
+    val totalPages: Int,
+    val last: Boolean
+)
+
+data class CommunityPostState(
+    val liked: Boolean,
+    val saved: Boolean
+)
+
+interface CommunityService {
+    fun createPost(userId: UUID, request: CreateCommunityPostRequest): CommunityPostResponse
+    fun getPosts(page: Int, size: Int, sort: CommunitySort): CommunityPostPageResponse
+    fun getPost(postId: UUID): CommunityPostResponse
+    fun like(userId: UUID, postId: UUID): CommunityPostState
+    fun unlike(userId: UUID, postId: UUID): CommunityPostState
+    fun save(userId: UUID, postId: UUID): CommunityPostState
+    fun unsave(userId: UUID, postId: UUID): CommunityPostState
+    fun getState(userId: UUID, postId: UUID): CommunityPostState
+    fun getSavedPosts(userId: UUID, page: Int, size: Int): CommunityPostPageResponse
+}

--- a/backend/src/main/kotlin/com/fanpulse/application/service/community/CommunityServiceImpl.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/service/community/CommunityServiceImpl.kt
@@ -1,0 +1,217 @@
+package com.fanpulse.application.service.community
+
+import com.fanpulse.domain.ai.port.ContentModerationPort
+import com.fanpulse.domain.community.CommunityPost
+import com.fanpulse.domain.community.CommunityPostStatus
+import com.fanpulse.domain.community.CommunityLike
+import com.fanpulse.domain.community.CommunitySavedPost
+import com.fanpulse.domain.comment.CommentStatus
+import com.fanpulse.infrastructure.persistence.comment.CommentJpaRepository
+import com.fanpulse.infrastructure.persistence.community.CommunityLikeJpaRepository
+import com.fanpulse.infrastructure.persistence.community.CommunityPostJpaRepository
+import com.fanpulse.infrastructure.persistence.community.CommunitySavedPostJpaRepository
+import com.fanpulse.infrastructure.persistence.content.ArtistJpaRepository
+import com.fanpulse.infrastructure.persistence.identity.UserJpaRepositoryInterface
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class CommunityServiceImpl(
+    private val users: UserJpaRepositoryInterface,
+    private val artists: ArtistJpaRepository,
+    private val posts: CommunityPostJpaRepository,
+    private val likes: CommunityLikeJpaRepository,
+    private val savedPosts: CommunitySavedPostJpaRepository,
+    private val comments: CommentJpaRepository,
+    private val moderation: ContentModerationPort
+) : CommunityService {
+
+    @Transactional
+    override fun createPost(userId: UUID, request: CreateCommunityPostRequest): CommunityPostResponse {
+        users.findById(userId).orElseThrow { NoSuchElementException("사용자를 찾을 수 없습니다") }
+        val artist = request.artistId?.let { artistId ->
+            artists.findById(artistId)
+                .filter { it.active }
+                .orElseThrow { NoSuchElementException("활성 아티스트를 찾을 수 없습니다") }
+        }
+        val content = request.content.trim()
+        require(content.isNotEmpty()) { "게시글 내용은 비어 있을 수 없습니다" }
+
+        val moderationResult = try {
+            moderation.checkContent(content)
+        } catch (exception: Exception) {
+            throw CommunityModerationUnavailableException(
+                "모더레이션 서비스를 사용할 수 없어 게시글을 저장하지 않았습니다",
+                exception
+            )
+        }
+        val moderationModel = moderationResult.modelUsed.trim().lowercase()
+        if (
+            moderationResult.error != null ||
+            moderationModel == "fallback" ||
+            moderationModel == "noop"
+        ) {
+            throw CommunityModerationUnavailableException(
+                "모더레이션 서비스를 사용할 수 없어 게시글을 저장하지 않았습니다"
+            )
+        }
+        require(!moderationResult.isFlagged && !moderationResult.action.equals("block", ignoreCase = true)) {
+            "허용되지 않는 게시글 내용입니다"
+        }
+
+        val post = posts.save(CommunityPost.create(userId, artist?.id, content))
+        return toResponse(post)
+    }
+
+    override fun getPosts(page: Int, size: Int, sort: CommunitySort): CommunityPostPageResponse {
+        val pageable = PageRequest.of(validPage(page), validSize(size))
+        val result = when (sort) {
+            CommunitySort.LATEST -> posts.findByStatusOrderByCreatedAtDesc(CommunityPostStatus.PUBLISHED, pageable)
+            CommunitySort.POPULAR -> posts.findPopular(pageable)
+        }
+        return toPageResponse(result)
+    }
+
+    override fun getPost(postId: UUID): CommunityPostResponse =
+        toResponse(findPublishedPost(postId))
+
+    @Transactional
+    override fun like(userId: UUID, postId: UUID): CommunityPostState {
+        requireUser(userId)
+        lockPublishedPost(postId)
+        if (!likes.existsByUserIdAndTargetTypeAndTargetId(userId, POST_TARGET_TYPE, postId)) {
+            likes.save(CommunityLike(userId = userId, targetType = POST_TARGET_TYPE, targetId = postId))
+        }
+        return getState(userId, postId)
+    }
+
+    @Transactional
+    override fun unlike(userId: UUID, postId: UUID): CommunityPostState {
+        requireUser(userId)
+        lockPublishedPost(postId)
+        likes.deleteByUserIdAndTargetTypeAndTargetId(userId, POST_TARGET_TYPE, postId)
+        return getState(userId, postId)
+    }
+
+    @Transactional
+    override fun save(userId: UUID, postId: UUID): CommunityPostState {
+        requireUser(userId)
+        lockPublishedPost(postId)
+        if (!savedPosts.existsByUserIdAndPostId(userId, postId)) {
+            savedPosts.save(CommunitySavedPost(userId = userId, postId = postId))
+        }
+        return getState(userId, postId)
+    }
+
+    @Transactional
+    override fun unsave(userId: UUID, postId: UUID): CommunityPostState {
+        requireUser(userId)
+        lockPublishedPost(postId)
+        savedPosts.deleteByUserIdAndPostId(userId, postId)
+        return getState(userId, postId)
+    }
+
+    override fun getState(userId: UUID, postId: UUID): CommunityPostState {
+        requireUserAndPost(userId, postId)
+        return CommunityPostState(
+            liked = likes.existsByUserIdAndTargetTypeAndTargetId(userId, POST_TARGET_TYPE, postId),
+            saved = savedPosts.existsByUserIdAndPostId(userId, postId)
+        )
+    }
+
+    override fun getSavedPosts(userId: UUID, page: Int, size: Int): CommunityPostPageResponse {
+        users.findById(userId).orElseThrow { NoSuchElementException("사용자를 찾을 수 없습니다") }
+        val savedPage = savedPosts.findPublishedByUserId(
+            userId,
+            CommunityPostStatus.PUBLISHED,
+            PageRequest.of(validPage(page), validSize(size))
+        )
+        val postById = posts.findAllById(savedPage.content.map { it.postId }).associateBy { it.id }
+        val visiblePosts = savedPage.content.mapNotNull { saved -> postById[saved.postId] }
+        return CommunityPostPageResponse(
+            content = toResponses(visiblePosts),
+            page = savedPage.number,
+            size = savedPage.size,
+            totalElements = savedPage.totalElements,
+            totalPages = savedPage.totalPages,
+            last = savedPage.isLast
+        )
+    }
+
+    private fun toPageResponse(page: Page<CommunityPost>) = CommunityPostPageResponse(
+        content = toResponses(page.content),
+        page = page.number,
+        size = page.size,
+        totalElements = page.totalElements,
+        totalPages = page.totalPages,
+        last = page.isLast
+    )
+
+    private fun toResponse(post: CommunityPost): CommunityPostResponse = toResponses(listOf(post)).single()
+
+    private fun toResponses(postList: List<CommunityPost>): List<CommunityPostResponse> {
+        if (postList.isEmpty()) return emptyList()
+
+        val postIds = postList.map { it.id }
+        val authorById = users.findAllById(postList.map { it.userId }.distinct()).associateBy { it.id }
+        val artistById = artists.findAllById(postList.mapNotNull { it.artistId }.distinct()).associateBy { it.id }
+        val likeCountByPostId = likes.countGroupedByTargetId(POST_TARGET_TYPE, postIds)
+            .associate { it.getTargetId() to it.getTotal() }
+        val commentCountByPostId = comments.countGroupedByPostIdAndStatus(
+            postIds.map(UUID::toString),
+            CommentStatus.APPROVED
+        ).associate { it.getPostId() to it.getTotal() }
+
+        return postList.map { post ->
+            val author = authorById[post.userId]
+                ?: throw IllegalStateException("게시글 작성자를 찾을 수 없습니다")
+            val artist = post.artistId?.let(artistById::get)
+            CommunityPostResponse(
+                id = post.id,
+                authorId = author.id,
+                authorName = author.username,
+                artistId = artist?.id,
+                artistName = artist?.name,
+                artistProfileImageUrl = artist?.profileImageUrl,
+                content = post.content,
+                imageUrl = post.imageUrl,
+                likeCount = likeCountByPostId[post.id] ?: 0,
+                commentCount = commentCountByPostId[post.id.toString()] ?: 0,
+                createdAt = post.createdAt
+            )
+        }
+    }
+
+    private fun requireUserAndPost(userId: UUID, postId: UUID) {
+        requireUser(userId)
+        findPublishedPost(postId)
+    }
+
+    private fun requireUser(userId: UUID) {
+        users.findById(userId).orElseThrow { NoSuchElementException("사용자를 찾을 수 없습니다") }
+    }
+
+    private fun lockPublishedPost(postId: UUID): CommunityPost =
+        posts.findPublishedByIdForUpdate(postId)
+            ?: throw NoSuchElementException("게시글을 찾을 수 없습니다")
+
+    private fun findPublishedPost(postId: UUID): CommunityPost = posts.findById(postId)
+        .filter { it.status == CommunityPostStatus.PUBLISHED }
+        .orElseThrow { NoSuchElementException("게시글을 찾을 수 없습니다") }
+
+
+    private fun validPage(page: Int): Int {
+        require(page >= 0) { "페이지 번호는 0 이상이어야 합니다" }
+        return page
+    }
+
+    private fun validSize(size: Int): Int = size.coerceIn(1, 100)
+
+    companion object {
+        private const val POST_TARGET_TYPE = "POST"
+    }
+}

--- a/backend/src/main/kotlin/com/fanpulse/domain/comment/Comment.kt
+++ b/backend/src/main/kotlin/com/fanpulse/domain/comment/Comment.kt
@@ -23,7 +23,7 @@ class Comment private constructor(
     @Column(columnDefinition = "uuid")
     val id: UUID,
 
-    @Column(name = "post_id", length = 24, nullable = false)
+    @Column(name = "post_id", length = 36, nullable = false)
     val postId: String,
 
     @Column(name = "user_id", columnDefinition = "uuid", nullable = false)

--- a/backend/src/main/kotlin/com/fanpulse/domain/community/CommunityPost.kt
+++ b/backend/src/main/kotlin/com/fanpulse/domain/community/CommunityPost.kt
@@ -1,0 +1,114 @@
+package com.fanpulse.domain.community
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.Instant
+import java.util.UUID
+
+enum class CommunityPostStatus {
+    PUBLISHED,
+    REMOVED
+}
+
+@Entity
+@Table(name = "community_posts")
+class CommunityPost private constructor(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: UUID,
+
+    @Column(name = "user_id", columnDefinition = "uuid", nullable = false)
+    val userId: UUID,
+
+    @Column(name = "artist_id", columnDefinition = "uuid")
+    val artistId: UUID?,
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    val content: String,
+
+    @Column(name = "image_url", columnDefinition = "TEXT")
+    val imageUrl: String?,
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    var status: CommunityPostStatus,
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: Instant,
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: Instant
+) {
+    companion object {
+        fun create(userId: UUID, artistId: UUID?, content: String): CommunityPost {
+            val normalized = content.trim()
+            require(normalized.isNotEmpty()) { "게시글 내용은 비어 있을 수 없습니다" }
+            require(normalized.length <= 5_000) { "게시글 내용은 5,000자를 초과할 수 없습니다" }
+            val now = Instant.now()
+            return CommunityPost(
+                id = UUID.randomUUID(),
+                userId = userId,
+                artistId = artistId,
+                content = normalized,
+                imageUrl = null,
+                status = CommunityPostStatus.PUBLISHED,
+                createdAt = now,
+                updatedAt = now
+            )
+        }
+    }
+}
+
+@Entity
+@Table(
+    name = "likes",
+    uniqueConstraints = [UniqueConstraint(
+        name = "uq_likes_user_target",
+        columnNames = ["user_id", "target_type", "target_id"]
+    )]
+)
+class CommunityLike(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: UUID = UUID.randomUUID(),
+
+    @Column(name = "user_id", columnDefinition = "uuid", nullable = false)
+    val userId: UUID,
+
+    @Column(name = "target_type", length = 20, nullable = false)
+    val targetType: String,
+
+    @Column(name = "target_id", columnDefinition = "uuid", nullable = false)
+    val targetId: UUID,
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: Instant = Instant.now()
+)
+
+@Entity
+@Table(
+    name = "community_saved_posts",
+    uniqueConstraints = [UniqueConstraint(
+        name = "uq_community_saved_posts",
+        columnNames = ["user_id", "post_id"]
+    )]
+)
+class CommunitySavedPost(
+    @Id
+    @Column(columnDefinition = "uuid")
+    val id: UUID = UUID.randomUUID(),
+
+    @Column(name = "user_id", columnDefinition = "uuid", nullable = false)
+    val userId: UUID,
+
+    @Column(name = "post_id", columnDefinition = "uuid", nullable = false)
+    val postId: UUID,
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: Instant = Instant.now()
+)

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/persistence/comment/CommentJpaRepository.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/persistence/comment/CommentJpaRepository.kt
@@ -5,6 +5,8 @@ import com.fanpulse.domain.comment.CommentStatus
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.*
 
 /**
@@ -16,4 +18,24 @@ interface CommentJpaRepository : JpaRepository<Comment, UUID> {
      * Finds comments by post ID and status with pagination.
      */
     fun findByPostIdAndStatus(postId: String, status: CommentStatus, pageable: Pageable): Page<Comment>
+
+    fun countByPostIdAndStatus(postId: String, status: CommentStatus): Long
+
+    @Query(
+        """
+        SELECT c.postId AS postId, COUNT(c.id) AS total
+        FROM Comment c
+        WHERE c.status = :status AND c.postId IN :postIds
+        GROUP BY c.postId
+        """
+    )
+    fun countGroupedByPostIdAndStatus(
+        @Param("postIds") postIds: Collection<String>,
+        @Param("status") status: CommentStatus
+    ): List<CommentPostCount>
+}
+
+interface CommentPostCount {
+    fun getPostId(): String
+    fun getTotal(): Long
 }

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/persistence/community/CommunityRepositories.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/persistence/community/CommunityRepositories.kt
@@ -1,0 +1,112 @@
+package com.fanpulse.infrastructure.persistence.community
+
+import com.fanpulse.domain.community.CommunityLike
+import com.fanpulse.domain.community.CommunityPost
+import com.fanpulse.domain.community.CommunityPostStatus
+import com.fanpulse.domain.community.CommunitySavedPost
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.UUID
+
+interface CommunityPostJpaRepository : JpaRepository<CommunityPost, UUID> {
+    fun findByStatusOrderByCreatedAtDesc(status: CommunityPostStatus, pageable: Pageable): Page<CommunityPost>
+
+    @Query(
+        value = "SELECT * FROM community_posts WHERE id = :id AND status = 'PUBLISHED' FOR UPDATE",
+        nativeQuery = true
+    )
+    fun findPublishedByIdForUpdate(@Param("id") id: UUID): CommunityPost?
+
+    @Query(
+        value = """
+            SELECT p.*
+            FROM community_posts p
+            LEFT JOIN (
+                SELECT target_id, COUNT(*) AS like_count
+                FROM likes
+                WHERE target_type = 'POST'
+                GROUP BY target_id
+            ) l ON l.target_id = p.id
+            LEFT JOIN (
+                SELECT post_id, COUNT(*) AS comment_count
+                FROM comments
+                WHERE status = 'APPROVED'
+                GROUP BY post_id
+            ) c ON c.post_id = CAST(p.id AS VARCHAR)
+            WHERE p.status = 'PUBLISHED'
+            ORDER BY COALESCE(l.like_count, 0) DESC,
+                     COALESCE(c.comment_count, 0) DESC,
+                     p.created_at DESC,
+                     p.id DESC
+        """,
+        countQuery = "SELECT COUNT(*) FROM community_posts WHERE status = 'PUBLISHED'",
+        nativeQuery = true
+    )
+    fun findPopular(pageable: Pageable): Page<CommunityPost>
+}
+
+interface CommunityLikeJpaRepository : JpaRepository<CommunityLike, UUID> {
+    fun existsByUserIdAndTargetTypeAndTargetId(userId: UUID, targetType: String, targetId: UUID): Boolean
+    fun countByTargetTypeAndTargetId(targetType: String, targetId: UUID): Long
+
+    @Query(
+        """
+        SELECT l.targetId AS targetId, COUNT(l.id) AS total
+        FROM CommunityLike l
+        WHERE l.targetType = :targetType AND l.targetId IN :targetIds
+        GROUP BY l.targetId
+        """
+    )
+    fun countGroupedByTargetId(
+        @Param("targetType") targetType: String,
+        @Param("targetIds") targetIds: Collection<UUID>
+    ): List<CommunityTargetCount>
+
+    fun deleteByUserIdAndTargetTypeAndTargetId(userId: UUID, targetType: String, targetId: UUID): Long
+}
+
+interface CommunityTargetCount {
+    fun getTargetId(): UUID
+    fun getTotal(): Long
+}
+
+interface CommunitySavedPostJpaRepository : JpaRepository<CommunitySavedPost, UUID> {
+    fun existsByUserIdAndPostId(userId: UUID, postId: UUID): Boolean
+    fun deleteByUserIdAndPostId(userId: UUID, postId: UUID): Long
+    fun findAllByUserIdOrderByCreatedAtDesc(userId: UUID): List<CommunitySavedPost>
+    fun findAllByUserIdOrderByCreatedAtDesc(userId: UUID, pageable: Pageable): Page<CommunitySavedPost>
+
+    @Query(
+        value = """
+            SELECT saved
+            FROM CommunitySavedPost saved
+            WHERE saved.userId = :userId
+              AND EXISTS (
+                  SELECT post.id
+                  FROM CommunityPost post
+                  WHERE post.id = saved.postId
+                    AND post.status = :status
+              )
+            ORDER BY saved.createdAt DESC
+        """,
+        countQuery = """
+            SELECT COUNT(saved)
+            FROM CommunitySavedPost saved
+            WHERE saved.userId = :userId
+              AND EXISTS (
+                  SELECT post.id
+                  FROM CommunityPost post
+                  WHERE post.id = saved.postId
+                    AND post.status = :status
+              )
+        """
+    )
+    fun findPublishedByUserId(
+        @Param("userId") userId: UUID,
+        @Param("status") status: CommunityPostStatus,
+        pageable: Pageable
+    ): Page<CommunitySavedPost>
+}

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/persistence/identity/UserJpaRepository.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/persistence/identity/UserJpaRepository.kt
@@ -34,6 +34,10 @@ class UserJpaRepository(
         return jpaRepository.findByEmail(email)
     }
 
+    fun findAllByIds(ids: Collection<UUID>): List<User> {
+        return jpaRepository.findAllById(ids)
+    }
+
     override fun findByUsername(username: String): User? {
         return jpaRepository.findByUsername(username)
     }

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/security/SecurityConfig.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/security/SecurityConfig.kt
@@ -78,6 +78,7 @@ class SecurityConfig(
                     .requestMatchers("/api/v1/charts/**").permitAll()
                     .requestMatchers("/api/v1/artists/**").permitAll()
                     .requestMatchers("/api/v1/search/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/v1/community/posts", "/api/v1/community/posts/**").permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/v1/comments/**").permitAll()
 
                     // Admin: 뉴스 동기화 수동 트리거 (#272)

--- a/backend/src/main/kotlin/com/fanpulse/interfaces/rest/GlobalExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/fanpulse/interfaces/rest/GlobalExceptionHandler.kt
@@ -1,6 +1,7 @@
 package com.fanpulse.interfaces.rest
 
 import com.fanpulse.application.identity.*
+import com.fanpulse.application.service.community.CommunityModerationUnavailableException
 import com.fanpulse.application.service.search.SearchServiceException
 import com.fanpulse.interfaces.rest.error.*
 import mu.KotlinLogging
@@ -159,6 +160,19 @@ class GlobalExceptionHandler {
         logger.error(ex) { "Search service error: ${ex.message}" }
         return createResponse(
             ErrorType.SEARCH_SERVICE_UNAVAILABLE,
+            detail = ex.message,
+            request = request
+        )
+    }
+
+    @ExceptionHandler(CommunityModerationUnavailableException::class)
+    fun handleCommunityModerationUnavailable(
+        ex: CommunityModerationUnavailableException,
+        request: WebRequest
+    ): ResponseEntity<ProblemDetail> {
+        logger.warn { "Community moderation unavailable: ${ex.message}" }
+        return createResponse(
+            ErrorType.COMMUNITY_MODERATION_UNAVAILABLE,
             detail = ex.message,
             request = request
         )

--- a/backend/src/main/kotlin/com/fanpulse/interfaces/rest/community/CommunityController.kt
+++ b/backend/src/main/kotlin/com/fanpulse/interfaces/rest/community/CommunityController.kt
@@ -1,0 +1,140 @@
+package com.fanpulse.interfaces.rest.community
+
+import com.fanpulse.application.dto.comment.CommentListResponse
+import com.fanpulse.application.dto.comment.CommentResponse
+import com.fanpulse.application.service.comment.CommentCommandService
+import com.fanpulse.application.service.comment.CommentQueryService
+import com.fanpulse.application.service.community.CommunityPostPageResponse
+import com.fanpulse.application.service.community.CommunityPostResponse
+import com.fanpulse.application.service.community.CommunityPostState
+import com.fanpulse.application.service.community.CommunityService
+import com.fanpulse.application.service.community.CommunitySort
+import com.fanpulse.application.service.community.CreateCommunityPostRequest
+import com.fanpulse.domain.comment.CommentStatus
+import com.fanpulse.interfaces.rest.common.ApiResponse
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestAttribute
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.Locale
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/community")
+class CommunityController(
+    private val service: CommunityService,
+    private val commentCommandService: CommentCommandService,
+    private val commentQueryService: CommentQueryService
+) {
+    @GetMapping("/posts")
+    fun getPosts(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int,
+        @RequestParam(defaultValue = "LATEST") sort: String
+    ): ApiResponse<CommunityPostPageResponse> = ApiResponse.success(
+        service.getPosts(page, size, parseSort(sort))
+    )
+
+    @GetMapping("/posts/{postId}")
+    fun getPost(@PathVariable postId: UUID): ApiResponse<CommunityPostResponse> =
+        ApiResponse.success(service.getPost(postId))
+
+    @GetMapping("/posts/{postId}/comments")
+    fun getComments(
+        @PathVariable postId: UUID,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): ApiResponse<CommentListResponse> {
+        service.getPost(postId)
+        val pageable = PageRequest.of(
+            page,
+            size.coerceIn(1, 100),
+            Sort.by(Sort.Direction.DESC, "createdAt")
+        )
+        return ApiResponse.success(commentQueryService.getComments(postId.toString(), pageable))
+    }
+
+    @PostMapping("/posts")
+    fun createPost(
+        @RequestAttribute("userId") userId: UUID,
+        @RequestBody request: CreateCommunityPostRequest
+    ): ResponseEntity<ApiResponse<CommunityPostResponse>> = ResponseEntity
+        .status(HttpStatus.CREATED)
+        .body(ApiResponse.success(service.createPost(userId, request)))
+
+    @PostMapping("/posts/{postId}/comments")
+    fun createComment(
+        @RequestAttribute("userId") userId: UUID,
+        @PathVariable postId: UUID,
+        @RequestBody request: CreateCommunityCommentRequest
+    ): ResponseEntity<ApiResponse<CommentResponse>> {
+        service.getPost(postId)
+        val response = commentCommandService.createComment(
+            postId = postId.toString(),
+            userId = userId,
+            content = request.content,
+            parentCommentId = request.parentCommentId
+        )
+        val status = if (response.status == CommentStatus.PENDING) HttpStatus.ACCEPTED else HttpStatus.CREATED
+        return ResponseEntity.status(status).body(ApiResponse.success(response))
+    }
+
+    @PostMapping("/posts/{postId}/likes")
+    fun like(
+        @RequestAttribute("userId") userId: UUID,
+        @PathVariable postId: UUID
+    ): ApiResponse<CommunityPostState> = ApiResponse.success(service.like(userId, postId))
+
+    @DeleteMapping("/posts/{postId}/likes")
+    fun unlike(
+        @RequestAttribute("userId") userId: UUID,
+        @PathVariable postId: UUID
+    ): ApiResponse<CommunityPostState> = ApiResponse.success(service.unlike(userId, postId))
+
+    @PostMapping("/posts/{postId}/saved")
+    fun save(
+        @RequestAttribute("userId") userId: UUID,
+        @PathVariable postId: UUID
+    ): ApiResponse<CommunityPostState> = ApiResponse.success(service.save(userId, postId))
+
+    @DeleteMapping("/posts/{postId}/saved")
+    fun unsave(
+        @RequestAttribute("userId") userId: UUID,
+        @PathVariable postId: UUID
+    ): ApiResponse<CommunityPostState> = ApiResponse.success(service.unsave(userId, postId))
+
+    @GetMapping("/me/posts/{postId}/state")
+    fun getState(
+        @RequestAttribute("userId") userId: UUID,
+        @PathVariable postId: UUID
+    ): ApiResponse<CommunityPostState> = ApiResponse.success(service.getState(userId, postId))
+
+    @GetMapping("/me/saved")
+    fun getSavedPosts(
+        @RequestAttribute("userId") userId: UUID,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): ApiResponse<CommunityPostPageResponse> = ApiResponse.success(
+        service.getSavedPosts(userId, page, size)
+    )
+
+    private fun parseSort(value: String): CommunitySort = runCatching {
+        CommunitySort.valueOf(value.uppercase(Locale.ROOT))
+    }.getOrElse {
+        throw IllegalArgumentException("지원하지 않는 커뮤니티 정렬입니다")
+    }
+}
+
+data class CreateCommunityCommentRequest(
+    val content: String,
+    val parentCommentId: UUID? = null
+)

--- a/backend/src/main/kotlin/com/fanpulse/interfaces/rest/error/ErrorType.kt
+++ b/backend/src/main/kotlin/com/fanpulse/interfaces/rest/error/ErrorType.kt
@@ -117,6 +117,12 @@ enum class ErrorType(
         status = HttpStatus.SERVICE_UNAVAILABLE.value(),
         code = "SEARCH_SERVICE_UNAVAILABLE"
     ),
+    COMMUNITY_MODERATION_UNAVAILABLE(
+        slug = "community-moderation-unavailable",
+        title = "Community Moderation Unavailable",
+        status = HttpStatus.SERVICE_UNAVAILABLE.value(),
+        code = "COMMUNITY_MODERATION_UNAVAILABLE"
+    ),
 
     // === Server Errors (500) ===
     INTERNAL_ERROR(

--- a/backend/src/main/resources/db/migration/V122__create_core_domain_api_tables.sql
+++ b/backend/src/main/resources/db/migration/V122__create_core_domain_api_tables.sql
@@ -1,0 +1,47 @@
+-- PostgreSQL-backed community model for the core domain APIs.
+-- Existing saved_posts stores legacy MongoDB ObjectIds and must remain intact.
+
+CREATE TABLE community_posts (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL,
+    artist_id UUID,
+    content TEXT NOT NULL,
+    image_url TEXT,
+    status VARCHAR(20) NOT NULL DEFAULT 'PUBLISHED',
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_community_posts_user FOREIGN KEY (user_id)
+        REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_community_posts_artist FOREIGN KEY (artist_id)
+        REFERENCES artists(id) ON DELETE SET NULL,
+    CONSTRAINT chk_community_posts_content_not_empty CHECK (LENGTH(TRIM(content)) > 0),
+    CONSTRAINT chk_community_posts_status CHECK (status IN ('PUBLISHED', 'REMOVED'))
+);
+
+CREATE INDEX idx_community_posts_status_created
+    ON community_posts(status, created_at DESC);
+CREATE INDEX idx_community_posts_user_created
+    ON community_posts(user_id, created_at DESC);
+CREATE INDEX idx_community_posts_artist_created
+    ON community_posts(artist_id, created_at DESC);
+
+CREATE TABLE community_saved_posts (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL,
+    post_id UUID NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_community_saved_posts_user FOREIGN KEY (user_id)
+        REFERENCES users(id) ON DELETE CASCADE,
+    CONSTRAINT fk_community_saved_posts_post FOREIGN KEY (post_id)
+        REFERENCES community_posts(id) ON DELETE CASCADE,
+    CONSTRAINT uq_community_saved_posts UNIQUE (user_id, post_id)
+);
+
+CREATE INDEX idx_community_saved_posts_user_created
+    ON community_saved_posts(user_id, created_at DESC);
+CREATE INDEX idx_community_saved_posts_post_id
+    ON community_saved_posts(post_id);
+
+-- Existing comments support legacy 24-char ObjectIds. UUID text requires 36 chars.
+ALTER TABLE comments
+    ALTER COLUMN post_id TYPE VARCHAR(36);

--- a/backend/src/test/kotlin/com/fanpulse/application/service/comment/CommentCommandServiceTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/application/service/comment/CommentCommandServiceTest.kt
@@ -127,8 +127,8 @@ class CommentCommandServiceTest {
         }
 
         @Test
-        @DisplayName("noop 필터 타입이면 APPROVED 상태로 저장되어야 한다")
-        fun `should approve comment when noop filter type`() {
+        @DisplayName("noop 필터 타입이면 PENDING 상태로 저장되어야 한다")
+        fun `should keep PENDING when noop filter type`() {
             // given
             val filterResult = FilterResult(isFiltered = false, filterType = "noop")
             every { commentFilterPort.filterComment(any()) } returns filterResult
@@ -139,7 +139,7 @@ class CommentCommandServiceTest {
             val response = service.createComment(postId, userId, "noop 댓글")
 
             // then
-            assertEquals(CommentStatus.APPROVED, response.status)
+            assertEquals(CommentStatus.PENDING, response.status)
         }
     }
 
@@ -232,6 +232,19 @@ class CommentCommandServiceTest {
     @Nested
     @DisplayName("입력 검증")
     inner class Validation {
+
+        @Test
+        @DisplayName("다른 게시글의 댓글을 부모로 지정하면 거부해야 한다")
+        fun `should reject a parent comment from another post`() {
+            val parent = Comment.create("another-post", userId, "부모 댓글")
+            every { commentPort.findById(parent.id) } returns parent
+
+            assertThrows<IllegalArgumentException> {
+                service.createComment(postId, userId, "교차 게시글 답글", parent.id)
+            }
+            verify(exactly = 0) { commentFilterPort.filterComment(any()) }
+            verify(exactly = 0) { commentPort.save(any()) }
+        }
 
         @Test
         @DisplayName("빈 내용으로 댓글을 생성하면 예외가 발생해야 한다")

--- a/backend/src/test/kotlin/com/fanpulse/application/service/comment/CommentQueryServiceIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/application/service/comment/CommentQueryServiceIntegrationTest.kt
@@ -1,0 +1,36 @@
+package com.fanpulse.application.service.comment
+
+import com.fanpulse.domain.comment.Comment
+import com.fanpulse.domain.identity.User
+import com.fanpulse.infrastructure.persistence.comment.CommentJpaRepository
+import com.fanpulse.infrastructure.persistence.comment.CommentAdapter
+import com.fanpulse.infrastructure.persistence.identity.UserJpaRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.domain.PageRequest
+import java.util.UUID
+
+@DataJpaTest(properties = ["spring.flyway.enabled=false", "spring.jpa.hibernate.ddl-auto=create-drop"])
+@Import(CommentQueryServiceImpl::class, CommentAdapter::class, UserJpaRepository::class)
+class CommentQueryServiceIntegrationTest @Autowired constructor(
+    private val service: CommentQueryService,
+    private val comments: CommentJpaRepository,
+    private val users: UserJpaRepository
+) {
+    @Test
+    fun `returns the persisted comment author's real username`() {
+        val user = users.save(User(email = "comment-author@example.com", username = "comment-author"))
+        val postId = UUID.randomUUID().toString()
+        val comment = Comment.create(postId = postId, userId = user.id, content = "실제 댓글")
+        comment.approve()
+        comments.save(comment)
+
+        val result = service.getComments(postId, PageRequest.of(0, 20))
+
+        assertThat(result.content).hasSize(1)
+        assertThat(result.content.single().authorName).isEqualTo("comment-author")
+    }
+}

--- a/backend/src/test/kotlin/com/fanpulse/application/service/community/CommunityPostgresVerticalSliceIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/application/service/community/CommunityPostgresVerticalSliceIntegrationTest.kt
@@ -1,0 +1,129 @@
+package com.fanpulse.application.service.community
+
+import com.fanpulse.application.service.comment.CommentCommandService
+import com.fanpulse.application.service.comment.CommentQueryService
+import com.fanpulse.domain.ai.FilterResult
+import com.fanpulse.domain.ai.ModerationResult
+import com.fanpulse.domain.ai.port.CommentFilterPort
+import com.fanpulse.domain.ai.port.ContentModerationPort
+import com.fanpulse.domain.content.Artist
+import com.fanpulse.domain.identity.User
+import com.fanpulse.infrastructure.persistence.comment.CommentJpaRepository
+import com.fanpulse.infrastructure.persistence.community.CommunityLikeJpaRepository
+import com.fanpulse.infrastructure.persistence.community.CommunityPostJpaRepository
+import com.fanpulse.infrastructure.persistence.community.CommunitySavedPostJpaRepository
+import com.fanpulse.infrastructure.persistence.content.ArtistJpaRepository
+import com.fanpulse.infrastructure.persistence.identity.UserJpaRepositoryInterface
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
+import org.springframework.test.context.ActiveProfiles
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+@SpringBootTest
+@ActiveProfiles("test")
+@EnabledIfEnvironmentVariable(named = "SPRING_TEST_POSTGRES", matches = "true")
+@DisplayName("PostgreSQL community vertical slice")
+class CommunityPostgresVerticalSliceIntegrationTest {
+    @Autowired private lateinit var service: CommunityService
+    @Autowired private lateinit var commentCommandService: CommentCommandService
+    @Autowired private lateinit var commentQueryService: CommentQueryService
+    @Autowired private lateinit var posts: CommunityPostJpaRepository
+    @Autowired private lateinit var likes: CommunityLikeJpaRepository
+    @Autowired private lateinit var savedPosts: CommunitySavedPostJpaRepository
+    @Autowired private lateinit var comments: CommentJpaRepository
+    @Autowired private lateinit var users: UserJpaRepositoryInterface
+    @Autowired private lateinit var artists: ArtistJpaRepository
+    @MockkBean private lateinit var moderation: ContentModerationPort
+    @MockkBean private lateinit var commentFilter: CommentFilterPort
+
+    @BeforeEach
+    fun setUp() {
+        comments.deleteAll()
+        savedPosts.deleteAll()
+        likes.deleteAll()
+        posts.deleteAll()
+        users.deleteAll()
+        artists.deleteAll()
+        every { moderation.checkContent(any()) } returns ModerationResult(
+            isFlagged = false,
+            action = "allow",
+            confidence = 0.99,
+            modelUsed = "integration-test"
+        )
+        every { commentFilter.filterComment(any()) } returns FilterResult(
+            isFiltered = false,
+            filterType = "integration-test"
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        comments.deleteAll()
+        savedPosts.deleteAll()
+        likes.deleteAll()
+        posts.deleteAll()
+        users.deleteAll()
+        artists.deleteAll()
+    }
+
+    @Test
+    fun `persists post comment like and save through PostgreSQL and reads them back`() {
+        val user = users.saveAndFlush(User(email = "community-pg@example.com", username = "community-pg"))
+        val artist = artists.saveAndFlush(Artist.create("Community PG Artist", null, null, isGroup = true))
+        val post = service.createPost(
+            user.id,
+            CreateCommunityPostRequest(artist.id, "PostgreSQL community slice")
+        )
+
+        runConcurrently { service.like(user.id, post.id) }
+        runConcurrently { service.save(user.id, post.id) }
+        val comment = commentCommandService.createComment(post.id.toString(), user.id, "PostgreSQL comment", null)
+
+        val latest = service.getPosts(0, 20, CommunitySort.LATEST)
+        val popular = service.getPosts(0, 20, CommunitySort.POPULAR)
+        val saved = service.getSavedPosts(user.id, 0, 20)
+        val commentPage = commentQueryService.getComments(post.id.toString(), PageRequest.of(0, 20))
+
+        assertThat(comment.status.name).isEqualTo("APPROVED")
+        assertThat(latest.content.single().id).isEqualTo(post.id)
+        assertThat(latest.content.single().likeCount).isEqualTo(1)
+        assertThat(latest.content.single().commentCount).isEqualTo(1)
+        assertThat(popular.content.single().id).isEqualTo(post.id)
+        assertThat(saved.content.single().id).isEqualTo(post.id)
+        assertThat(commentPage.content.single().authorName).isEqualTo("community-pg")
+        assertThat(likes.countByTargetTypeAndTargetId("POST", post.id)).isEqualTo(1)
+        assertThat(savedPosts.findAllByUserIdOrderByCreatedAtDesc(user.id)).hasSize(1)
+    }
+
+    private fun runConcurrently(action: () -> Unit) {
+        val executor = Executors.newFixedThreadPool(2)
+        val ready = CountDownLatch(2)
+        val start = CountDownLatch(1)
+        try {
+            val futures = (1..2).map {
+                executor.submit {
+                    ready.countDown()
+                    check(start.await(10, TimeUnit.SECONDS))
+                    action()
+                }
+            }
+            check(ready.await(10, TimeUnit.SECONDS))
+            start.countDown()
+            futures.forEach { it.get(20, TimeUnit.SECONDS) }
+        } finally {
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS)
+        }
+    }
+}

--- a/backend/src/test/kotlin/com/fanpulse/application/service/community/CommunityServiceIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/application/service/community/CommunityServiceIntegrationTest.kt
@@ -1,0 +1,244 @@
+package com.fanpulse.application.service.community
+
+import com.fanpulse.domain.ai.ModerationResult
+import com.fanpulse.domain.ai.port.ContentModerationPort
+import com.fanpulse.domain.content.Artist
+import com.fanpulse.domain.identity.User
+import com.fanpulse.infrastructure.persistence.comment.CommentJpaRepository
+import com.fanpulse.infrastructure.persistence.community.CommunityLikeJpaRepository
+import com.fanpulse.infrastructure.persistence.community.CommunityPostJpaRepository
+import com.fanpulse.infrastructure.persistence.community.CommunitySavedPostJpaRepository
+import com.fanpulse.infrastructure.persistence.content.ArtistJpaRepository
+import com.fanpulse.infrastructure.persistence.identity.UserJpaRepositoryInterface
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.test.context.ActiveProfiles
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import(CommunityServiceImpl::class, CommunityServiceIntegrationTest.ModerationConfig::class)
+@DisplayName("CommunityService")
+class CommunityServiceIntegrationTest {
+    @Autowired lateinit var entityManager: TestEntityManager
+    @Autowired lateinit var service: CommunityService
+    @Autowired lateinit var users: UserJpaRepositoryInterface
+    @Autowired lateinit var artists: ArtistJpaRepository
+    @Autowired lateinit var posts: CommunityPostJpaRepository
+    @Autowired lateinit var likes: CommunityLikeJpaRepository
+    @Autowired lateinit var savedPosts: CommunitySavedPostJpaRepository
+    @Autowired lateinit var comments: CommentJpaRepository
+    @Autowired lateinit var moderation: ContentModerationPort
+
+    @Test
+    fun `creates and lists only persisted posts with real author and artist data`() {
+        val author = users.save(User(email = "community-author@example.com", username = "real-author"))
+        val artist = artists.save(Artist.create("Real Artist", null, "Real Agency", isGroup = true))
+        artist.updateProfileImage("https://cdn.example.com/artist.jpg")
+        every { moderation.checkContent("실제 사용자가 작성한 게시글") } returns allow()
+
+        val created = service.createPost(
+            userId = author.id,
+            request = CreateCommunityPostRequest(
+                artistId = artist.id,
+                content = "실제 사용자가 작성한 게시글"
+            )
+        )
+        entityManager.flush()
+        entityManager.clear()
+
+        val result = service.getPosts(page = 0, size = 20, sort = CommunitySort.LATEST)
+
+        assertThat(result.content).hasSize(1)
+        val post = result.content.single()
+        assertThat(post.id).isEqualTo(created.id)
+        assertThat(post.authorName).isEqualTo("real-author")
+        assertThat(post.artistName).isEqualTo("Real Artist")
+        assertThat(post.artistProfileImageUrl).isEqualTo("https://cdn.example.com/artist.jpg")
+        assertThat(post.imageUrl).isNull()
+        assertThat(post.likeCount).isZero()
+        assertThat(post.commentCount).isZero()
+    }
+
+    @Test
+    fun `rejects a post explicitly blocked by moderation`() {
+        val author = users.save(User(email = "blocked-author@example.com", username = "blocked-author"))
+        every { moderation.checkContent("차단될 게시글") } returns allow().copy(isFlagged = true, action = "block")
+
+        assertThatThrownBy {
+            service.createPost(author.id, CreateCommunityPostRequest(null, "차단될 게시글"))
+        }.isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("허용되지 않는")
+        assertThat(posts.count()).isZero()
+    }
+
+    @Test
+    fun `rejects an unknown artist relation instead of guessing an artist`() {
+        val author = users.save(User(email = "artist-author@example.com", username = "artist-author"))
+        val missingArtistId = java.util.UUID.randomUUID()
+        every { moderation.checkContent(any()) } returns allow()
+
+        assertThatThrownBy {
+            service.createPost(author.id, CreateCommunityPostRequest(missingArtistId, "아티스트 게시글"))
+        }.isInstanceOf(NoSuchElementException::class.java)
+        assertThat(posts.count()).isZero()
+    }
+
+    @Test
+    fun `like and save mutations are idempotent and isolated by authenticated user`() {
+        val author = users.save(User(email = "post-author@example.com", username = "post-author"))
+        val owner = users.save(User(email = "post-owner@example.com", username = "post-owner"))
+        val other = users.save(User(email = "post-other@example.com", username = "post-other"))
+        every { moderation.checkContent(any()) } returns allow()
+        val post = service.createPost(author.id, CreateCommunityPostRequest(null, "저장할 게시글"))
+
+        service.like(owner.id, post.id)
+        service.like(owner.id, post.id)
+        service.save(owner.id, post.id)
+        service.save(owner.id, post.id)
+        service.save(other.id, post.id)
+
+        assertThat(likes.countByTargetTypeAndTargetId("POST", post.id)).isEqualTo(1)
+        assertThat(savedPosts.findAllByUserIdOrderByCreatedAtDesc(owner.id)).hasSize(1)
+        assertThat(service.getState(owner.id, post.id)).isEqualTo(CommunityPostState(liked = true, saved = true))
+        assertThat(service.getSavedPosts(owner.id, 0, 20).content.map { it.id }).containsExactly(post.id)
+        assertThat(service.getSavedPosts(other.id, 0, 20).content.map { it.id }).containsExactly(post.id)
+    }
+
+    @Test
+    fun `popular sort uses persisted like counts and approved comment counts`() {
+        val author = users.save(User(email = "popular-author@example.com", username = "popular-author"))
+        val firstFan = users.save(User(email = "fan-one@example.com", username = "fan-one"))
+        val secondFan = users.save(User(email = "fan-two@example.com", username = "fan-two"))
+        every { moderation.checkContent(any()) } returns allow()
+        val quieter = service.createPost(author.id, CreateCommunityPostRequest(null, "조용한 글"))
+        val popular = service.createPost(author.id, CreateCommunityPostRequest(null, "인기 글"))
+        service.like(firstFan.id, popular.id)
+        service.like(secondFan.id, popular.id)
+        comments.save(com.fanpulse.domain.comment.Comment.create(popular.id.toString(), firstFan.id, "승인 댓글").also { it.approve() })
+        comments.save(com.fanpulse.domain.comment.Comment.create(popular.id.toString(), secondFan.id, "보류 댓글"))
+        entityManager.flush()
+        entityManager.clear()
+
+        val result = service.getPosts(0, 20, CommunitySort.POPULAR)
+
+        assertThat(result.content.map { it.id }).containsExactly(popular.id, quieter.id)
+        val popularResponse = result.content.first()
+        assertThat(popularResponse.likeCount).isEqualTo(2)
+        assertThat(popularResponse.commentCount).isEqualTo(1)
+    }
+
+    private fun allow() = ModerationResult(
+        isFlagged = false,
+        action = "allow",
+        confidence = 1.0,
+        modelUsed = "test"
+    )
+
+    @Test
+    fun `unlike and unsave remove only the authenticated user's rows`() {
+        val owner = users.save(User(email = "toggle-owner@example.com", username = "toggle-owner"))
+        val other = users.save(User(email = "toggle-other@example.com", username = "toggle-other"))
+        every { moderation.checkContent(any()) } returns allow()
+        val post = service.createPost(owner.id, CreateCommunityPostRequest(null, "토글 테스트"))
+
+        service.like(owner.id, post.id)
+        service.like(other.id, post.id)
+        service.save(owner.id, post.id)
+        service.save(other.id, post.id)
+
+        service.unlike(owner.id, post.id)
+        service.unsave(owner.id, post.id)
+
+        assertThat(service.getState(owner.id, post.id)).isEqualTo(CommunityPostState(liked = false, saved = false))
+        assertThat(service.getState(other.id, post.id)).isEqualTo(CommunityPostState(liked = true, saved = true))
+        assertThat(likes.countByTargetTypeAndTargetId("POST", post.id)).isEqualTo(1)
+        assertThat(savedPosts.findAllByUserIdOrderByCreatedAtDesc(other.id)).hasSize(1)
+    }
+
+    @Test
+    fun `moderation fallback and noop results never publish a post`() {
+        val owner = users.save(User(email = "moderation-outage@example.com", username = "moderation-outage"))
+
+        listOf("fallback", "noop").forEach { modelUsed ->
+            every { moderation.checkContent(any()) } returns ModerationResult(
+                isFlagged = false,
+                action = "allow",
+                confidence = 0.0,
+                modelUsed = modelUsed,
+                error = if (modelUsed == "fallback") "AI service unavailable" else null
+            )
+
+            assertThatThrownBy {
+                service.createPost(owner.id, CreateCommunityPostRequest(null, "장애 시 게시되면 안 됩니다"))
+            }
+                .isInstanceOf(CommunityModerationUnavailableException::class.java)
+                .hasMessageContaining("모더레이션")
+        }
+
+        assertThat(posts.count()).isZero()
+    }
+
+    @Test
+    fun `moderation exceptions never publish and map to the unavailable error`() {
+        val owner = users.save(User(email = "moderation-throw@example.com", username = "moderation-throw"))
+        every { moderation.checkContent(any()) } throws IllegalStateException("connection refused")
+
+        assertThatThrownBy {
+            service.createPost(owner.id, CreateCommunityPostRequest(null, "예외 시 게시되면 안 됩니다"))
+        }
+            .isInstanceOf(CommunityModerationUnavailableException::class.java)
+            .hasMessageContaining("모더레이션")
+
+        assertThat(posts.count()).isZero()
+    }
+
+    @Test
+    fun `saved pagination excludes removed posts from rows and metadata`() {
+        val owner = users.save(User(email = "saved-pagination@example.com", username = "saved-pagination"))
+        every { moderation.checkContent(any()) } returns allow()
+        val visible = service.createPost(owner.id, CreateCommunityPostRequest(null, "표시할 글"))
+        val removed = service.createPost(owner.id, CreateCommunityPostRequest(null, "삭제할 글"))
+        service.save(owner.id, visible.id)
+        service.save(owner.id, removed.id)
+        entityManager.entityManager.createNativeQuery("UPDATE community_posts SET status = 'REMOVED' WHERE id = :id")
+            .setParameter("id", removed.id)
+            .executeUpdate()
+        entityManager.flush()
+        entityManager.clear()
+
+        val result = service.getSavedPosts(owner.id, 0, 1)
+
+        assertThat(result.content.map { it.id }).containsExactly(visible.id)
+        assertThat(result.totalElements).isEqualTo(1)
+        assertThat(result.totalPages).isEqualTo(1)
+        assertThat(result.last).isTrue()
+    }
+
+    @Test
+    fun `rejects content longer than the server limit`() {
+        val owner = users.save(User(email = "long-post@example.com", username = "long-post"))
+        every { moderation.checkContent(any()) } returns allow()
+
+        assertThatThrownBy {
+            service.createPost(owner.id, CreateCommunityPostRequest(null, "가".repeat(5001)))
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("5,000자")
+    }
+
+    @TestConfiguration
+    class ModerationConfig {
+        @Bean
+        fun moderation(): ContentModerationPort = mockk()
+    }
+}

--- a/backend/src/test/kotlin/com/fanpulse/integration/CoreDomainSchemaMigrationTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/integration/CoreDomainSchemaMigrationTest.kt
@@ -1,0 +1,28 @@
+package com.fanpulse.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+@DisplayName("Core domain schema migration")
+class CoreDomainSchemaMigrationTest {
+
+    private val migration = Path.of("src/main/resources/db/migration/V122__create_core_domain_api_tables.sql")
+
+    @Test
+    fun `preserves legacy bookmarks and creates UUID backed community tables`() {
+        assertThat(Files.exists(migration)).isTrue()
+        val sql = Files.readString(migration).lowercase()
+
+        assertThat(sql).contains("create table community_posts")
+        assertThat(sql).contains("create table community_saved_posts")
+        assertThat(sql).contains("post_id uuid not null")
+        assertThat(sql).contains("references community_posts(id) on delete cascade")
+        assertThat(sql).contains("alter table comments")
+        assertThat(sql).contains("varchar(36)")
+        assertThat(sql).doesNotContain("alter table saved_posts rename")
+        assertThat(sql).doesNotContain("create table post_likes")
+    }
+}

--- a/backend/src/test/kotlin/com/fanpulse/interfaces/rest/community/CommunityControllerTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/interfaces/rest/community/CommunityControllerTest.kt
@@ -1,0 +1,224 @@
+package com.fanpulse.interfaces.rest.community
+
+import com.fanpulse.application.dto.comment.CommentListResponse
+import com.fanpulse.application.dto.comment.CommentResponse
+import com.fanpulse.application.service.comment.CommentCommandService
+import com.fanpulse.application.service.comment.CommentQueryService
+import com.fanpulse.application.service.community.CommunityPostPageResponse
+import com.fanpulse.application.service.community.CommunityPostResponse
+import com.fanpulse.application.service.community.CommunityPostState
+import com.fanpulse.application.service.community.CommunityModerationUnavailableException
+import com.fanpulse.application.service.community.CommunityService
+import com.fanpulse.application.service.community.CommunitySort
+import com.fanpulse.domain.comment.CommentStatus
+import com.fanpulse.infrastructure.security.JwtTokenProvider
+import com.fanpulse.infrastructure.security.SecurityConfig
+import com.fanpulse.interfaces.rest.GlobalExceptionHandler
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.mockk.verify
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import java.time.Instant
+import java.util.UUID
+
+@WebMvcTest(CommunityController::class)
+@Import(SecurityConfig::class, GlobalExceptionHandler::class)
+@DisplayName("CommunityController")
+class CommunityControllerTest {
+    @Autowired lateinit var mockMvc: MockMvc
+    @MockkBean lateinit var service: CommunityService
+    @MockkBean lateinit var commentCommandService: CommentCommandService
+    @MockkBean lateinit var commentQueryService: CommentQueryService
+    @MockkBean lateinit var jwtTokenProvider: JwtTokenProvider
+
+    private val userId = UUID.randomUUID()
+    private val postId = UUID.randomUUID()
+    private val createdAt = Instant.parse("2026-08-14T08:00:00Z")
+
+    @Test
+    fun `public list returns persisted post page in the API envelope`() {
+        every { service.getPosts(0, 20, CommunitySort.LATEST) } returns page()
+
+        mockMvc.get("/api/v1/community/posts")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data.content[0].id") { value(postId.toString()) }
+                jsonPath("$.data.content[0].content") { value("실제 게시글") }
+                jsonPath("$.data.content[0].createdAt") { value("2026-08-14T08:00:00Z") }
+                jsonPath("$.data.totalElements") { value(1) }
+            }
+    }
+
+    @Test
+    @WithMockUser
+    fun `create uses only the authenticated request attribute user`() {
+        every { service.createPost(userId, any()) } returns post()
+
+        mockMvc.post("/api/v1/community/posts") {
+            requestAttr("userId", userId)
+            contentType = MediaType.APPLICATION_JSON
+            content = """
+                {
+                  "artistId": null,
+                  "content": "실제 게시글"
+                }
+            """.trimIndent()
+        }.andExpect {
+            status { isCreated() }
+            jsonPath("$.success") { value(true) }
+            jsonPath("$.data.id") { value(postId.toString()) }
+        }
+
+        verify(exactly = 1) { service.createPost(userId, match { it.content == "실제 게시글" }) }
+    }
+
+    @Test
+    @WithMockUser
+    fun `moderation outage returns service unavailable without creating a post`() {
+        every { service.createPost(userId, any()) } throws
+            CommunityModerationUnavailableException("모더레이션 서비스를 사용할 수 없습니다")
+
+        mockMvc.post("/api/v1/community/posts") {
+            requestAttr("userId", userId)
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"artistId":null,"content":"재시도할 게시글"}"""
+        }.andExpect {
+            status { isEqualTo(503) }
+            jsonPath("$.status") { value(503) }
+            jsonPath("$.errorCode") { value("COMMUNITY_MODERATION_UNAVAILABLE") }
+        }
+
+        verify(exactly = 1) { service.createPost(userId, any()) }
+    }
+
+    @Test
+    @WithMockUser
+    fun `like save and their delete operations are scoped to the authenticated user`() {
+        every { service.like(userId, postId) } returns CommunityPostState(liked = true, saved = false)
+        every { service.save(userId, postId) } returns CommunityPostState(liked = true, saved = true)
+        every { service.unlike(userId, postId) } returns CommunityPostState(liked = false, saved = true)
+        every { service.unsave(userId, postId) } returns CommunityPostState(liked = false, saved = false)
+
+        mockMvc.post("/api/v1/community/posts/$postId/likes") { requestAttr("userId", userId) }
+            .andExpect { status { isOk() }; jsonPath("$.data.liked") { value(true) } }
+        mockMvc.post("/api/v1/community/posts/$postId/saved") { requestAttr("userId", userId) }
+            .andExpect { status { isOk() }; jsonPath("$.data.saved") { value(true) } }
+        mockMvc.delete("/api/v1/community/posts/$postId/likes") { requestAttr("userId", userId) }
+            .andExpect { status { isOk() }; jsonPath("$.data.liked") { value(false) } }
+        mockMvc.delete("/api/v1/community/posts/$postId/saved") { requestAttr("userId", userId) }
+            .andExpect { status { isOk() }; jsonPath("$.data.saved") { value(false) } }
+
+        verify(exactly = 1) { service.like(userId, postId) }
+        verify(exactly = 1) { service.save(userId, postId) }
+        verify(exactly = 1) { service.unlike(userId, postId) }
+        verify(exactly = 1) { service.unsave(userId, postId) }
+    }
+
+    @Test
+    @WithMockUser
+    fun `state and saved list use the authenticated user`() {
+        every { service.getState(userId, postId) } returns CommunityPostState(liked = true, saved = true)
+        every { service.getSavedPosts(userId, 0, 20) } returns page()
+
+        mockMvc.get("/api/v1/community/me/posts/$postId/state") { requestAttr("userId", userId) }
+            .andExpect { status { isOk() }; jsonPath("$.data.saved") { value(true) } }
+        mockMvc.get("/api/v1/community/me/saved") { requestAttr("userId", userId) }
+            .andExpect { status { isOk() }; jsonPath("$.data.content[0].id") { value(postId.toString()) } }
+    }
+
+    @Test
+    fun `unauthenticated mutation is rejected`() {
+        mockMvc.post("/api/v1/community/posts/$postId/likes")
+            .andExpect { status { isForbidden() } }
+    }
+
+    @Test
+    fun `public comment list is returned in a strict API envelope`() {
+        every { service.getPost(postId) } returns post()
+        every { commentQueryService.getComments(postId.toString(), any()) } returns commentPage()
+
+        mockMvc.get("/api/v1/community/posts/$postId/comments")
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data.content[0].authorName") { value("comment-author") }
+                jsonPath("$.data.content[0].content") { value("실제 댓글") }
+            }
+    }
+
+    @Test
+    @WithMockUser
+    fun `comment creation takes the author only from the authenticated request attribute`() {
+        every { service.getPost(postId) } returns post()
+        every {
+            commentCommandService.createComment(postId.toString(), userId, "실제 댓글", null)
+        } returns comment()
+
+        mockMvc.post("/api/v1/community/posts/$postId/comments") {
+            requestAttr("userId", userId)
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"content":"실제 댓글","parentCommentId":null}"""
+        }.andExpect {
+            status { isCreated() }
+            jsonPath("$.success") { value(true) }
+            jsonPath("$.data.id") { value(comment().id.toString()) }
+        }
+
+        verify(exactly = 1) {
+            commentCommandService.createComment(postId.toString(), userId, "실제 댓글", null)
+        }
+    }
+
+    private fun page() = CommunityPostPageResponse(
+        content = listOf(post()),
+        page = 0,
+        size = 20,
+        totalElements = 1,
+        totalPages = 1,
+        last = true
+    )
+
+    private fun post() = CommunityPostResponse(
+        id = postId,
+        authorId = userId,
+        authorName = "real-author",
+        artistId = null,
+        artistName = null,
+        artistProfileImageUrl = null,
+        content = "실제 게시글",
+        imageUrl = null,
+        likeCount = 2,
+        commentCount = 1,
+        createdAt = createdAt
+    )
+
+    private fun comment() = CommentResponse(
+        id = UUID.fromString("44444444-4444-4444-4444-444444444444"),
+        postId = postId.toString(),
+        userId = userId,
+        content = "실제 댓글",
+        status = CommentStatus.APPROVED,
+        parentCommentId = null,
+        createdAt = createdAt,
+        authorName = "comment-author"
+    )
+
+    private fun commentPage() = CommentListResponse(
+        content = listOf(comment()),
+        totalElements = 1,
+        page = 0,
+        size = 20,
+        totalPages = 1
+    )
+}

--- a/web/e2e/community-real.spec.ts
+++ b/web/e2e/community-real.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test'
+import { createHmac, randomUUID } from 'node:crypto'
+
+const E2E_USER_ID = '22222222-2222-2222-2222-222222222222'
+
+function base64Url(value: string | Buffer) {
+  return Buffer.from(value).toString('base64url')
+}
+
+function createAccessToken() {
+  const jwtSecret = process.env.COMMUNITY_E2E_JWT_SECRET
+  if (!jwtSecret) throw new Error('COMMUNITY_E2E_JWT_SECRET이 필요합니다')
+  const secretBytes = Buffer.from(jwtSecret)
+  if (secretBytes.length < 32) {
+    throw new Error('COMMUNITY_E2E_JWT_SECRET은 32바이트 이상이어야 합니다')
+  }
+  const { alg, digest } = secretBytes.length >= 64
+    ? { alg: 'HS512', digest: 'sha512' }
+    : secretBytes.length >= 48
+      ? { alg: 'HS384', digest: 'sha384' }
+      : { alg: 'HS256', digest: 'sha256' }
+  const now = Math.floor(Date.now() / 1000)
+  const header = base64Url(JSON.stringify({ alg, typ: 'JWT' }))
+  const payload = base64Url(JSON.stringify({
+    sub: E2E_USER_ID,
+    type: 'access',
+    jti: randomUUID(),
+    iat: now,
+    exp: now + 3600,
+  }))
+  const signature = createHmac(digest, secretBytes)
+    .update(`${header}.${payload}`)
+    .digest('base64url')
+  return `${header}.${payload}.${signature}`
+}
+
+test.describe('Community real vertical slice', () => {
+  test.skip(
+    process.env.COMMUNITY_REAL_E2E !== 'true',
+    '실제 PostgreSQL/Spring E2E는 명시적으로 실행한다',
+  )
+
+  test('PostgreSQL 게시글과 댓글이 Spring API를 거쳐 목록과 상세에 표시된다', async ({ page }) => {
+    const consoleErrors: string[] = []
+    page.on('console', (message) => {
+      if (message.type() === 'error') consoleErrors.push(message.text())
+    })
+    page.on('pageerror', (error) => consoleErrors.push(error.message))
+
+    await page.context().addCookies([{
+      name: 'fanpulse_access_token',
+      value: createAccessToken(),
+      domain: '127.0.0.1',
+      path: '/',
+      httpOnly: true,
+      sameSite: 'Lax',
+    }])
+
+    await page.route('**/gsi/client', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: 'window.google={accounts:{id:{initialize:()=>{},renderButton:()=>{}}}};',
+      })
+    })
+
+    await page.goto('/community')
+    await expect(page.getByText('PostgreSQL E2E 게시글')).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByText('e2e-author')).toBeVisible()
+    await expect(page.getByText('E2E Artist')).toBeVisible()
+
+    await page.getByRole('link', { name: /PostgreSQL E2E 게시글 상세 보기/ }).click()
+    await expect(page).toHaveURL(/post-detail\?id=11111111-1111-1111-1111-111111111111/)
+    await expect(page.getByText('PostgreSQL E2E 댓글')).toBeVisible({ timeout: 20_000 })
+    await expect(page.getByText('e2e-author')).toHaveCount(2)
+    expect(consoleErrors).toEqual([])
+  })
+})

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  allowedDevOrigins: ['127.0.0.1'],
   images: {
     remotePatterns: [
       {

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from '@playwright/test'
 
+const playwrightPort = process.env.PLAYWRIGHT_PORT ?? '3001'
+const playwrightBaseUrl = `http://127.0.0.1:${playwrightPort}`
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
@@ -8,17 +11,19 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:3001',
+    baseURL: playwrightBaseUrl,
     trace: 'on-first-retry',
   },
   webServer: {
-    command: 'npm run dev -- -p 3001',
-    url: 'http://localhost:3001',
+    command: `npm run dev -- -p ${playwrightPort}`,
+    url: playwrightBaseUrl,
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
     env: {
       NEXT_PUBLIC_GOOGLE_CLIENT_ID:
         process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ?? 'e2e-google-client-id',
+      NEXT_PUBLIC_API_BASE_URL:
+        process.env.NEXT_PUBLIC_API_BASE_URL ?? 'http://localhost:8080/api/v1',
     },
   },
   projects: [

--- a/web/src/app/community/page.test.tsx
+++ b/web/src/app/community/page.test.tsx
@@ -1,29 +1,91 @@
-import { render, screen } from '@testing-library/react'
-import CommunityPage from './page'
-import { vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import CommunityPage from './page';
+import { fetchCommunityPosts } from '@/lib/api/community';
 
-// useRouter mock
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({
-    back: vi.fn(),
-  }),
-}))
+  useRouter: () => ({ back: vi.fn(), push: vi.fn() }),
+}));
+
+vi.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, layoutId, ...props }: React.HTMLAttributes<HTMLDivElement> & { layoutId?: string }) => {
+      void layoutId;
+      return <div {...props}>{children}</div>;
+    },
+  },
+}));
+
+vi.mock('@/lib/api/community', () => ({
+  fetchCommunityPosts: vi.fn(),
+}));
+
+const post = {
+  id: '11111111-1111-1111-1111-111111111111',
+  author: { id: '22222222-2222-2222-2222-222222222222', name: 'real-author' },
+  artist: { id: '33333333-3333-3333-3333-333333333333', name: 'Real Artist', profileImageUrl: null },
+  content: '실제 PostgreSQL 게시글',
+  imageUrl: null,
+  likeCount: 2,
+  commentCount: 1,
+  createdAt: '2026-08-14T08:00:00Z',
+};
+
+const page = {
+  items: [post],
+  page: 0,
+  size: 20,
+  totalElements: 1,
+  totalPages: 1,
+  last: true,
+};
 
 describe('CommunityPage', () => {
-  it('renders page header with correct title', () => {
-    render(<CommunityPage />)
-    expect(screen.getByText('Community')).toBeInTheDocument()
-  })
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchCommunityPosts).mockResolvedValue(page);
+  });
 
-  it('renders tab navigation', () => {
-    render(<CommunityPage />)
-    expect(screen.getByText('전체')).toBeInTheDocument()
-    expect(screen.getByText('인기')).toBeInTheDocument()
-  })
+  it('renders only posts returned by the real community API', async () => {
+    render(<CommunityPage />);
 
-  it('renders posts', () => {
-    render(<CommunityPage />)
-    expect(screen.getByText('ARMY_Forever')).toBeInTheDocument()
-    expect(screen.getByText('Blink_Girl')).toBeInTheDocument()
-  })
-})
+    expect(await screen.findByText('실제 PostgreSQL 게시글')).toBeInTheDocument();
+    expect(screen.getByText('real-author')).toBeInTheDocument();
+    expect(screen.getByText('Real Artist')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /실제 PostgreSQL 게시글/ })).toHaveAttribute(
+      'href',
+      `/post-detail?id=${post.id}`,
+    );
+    expect(screen.queryByText(/BTS 새 앨범 티저/)).not.toBeInTheDocument();
+    expect(fetchCommunityPosts).toHaveBeenCalledWith('LATEST', 0, 20, expect.any(AbortSignal));
+  });
+
+  it('renders an honest empty state without demo posts', async () => {
+    vi.mocked(fetchCommunityPosts).mockResolvedValue({ ...page, items: [], totalElements: 0, totalPages: 0 });
+    render(<CommunityPage />);
+
+    expect(await screen.findByText('아직 작성된 게시글이 없습니다.')).toBeInTheDocument();
+    expect(screen.queryByText(/ARMY_Forever/)).not.toBeInTheDocument();
+  });
+
+  it('renders a retryable error rather than falling back to fake posts', async () => {
+    vi.mocked(fetchCommunityPosts).mockRejectedValueOnce(new Error('network'));
+    render(<CommunityPage />);
+
+    expect(await screen.findByText('커뮤니티를 불러오지 못했습니다.')).toBeInTheDocument();
+    vi.mocked(fetchCommunityPosts).mockResolvedValue(page);
+    fireEvent.click(screen.getByRole('button', { name: '다시 시도' }));
+    expect(await screen.findByText('실제 PostgreSQL 게시글')).toBeInTheDocument();
+  });
+
+  it('requests server-side popular sorting when the popular tab is selected', async () => {
+    render(<CommunityPage />);
+    await screen.findByText('실제 PostgreSQL 게시글');
+
+    fireEvent.click(screen.getByRole('button', { name: '인기' }));
+
+    await waitFor(() => {
+      expect(fetchCommunityPosts).toHaveBeenLastCalledWith('POPULAR', 0, 20, expect.any(AbortSignal));
+    });
+  });
+});

--- a/web/src/app/community/page.tsx
+++ b/web/src/app/community/page.tsx
@@ -2,229 +2,223 @@
 
 import PageHeader from "@/components/layout/PageHeader";
 import PageWrapper from "@/components/layout/PageWrapper";
-import { useState } from "react";
+import { fetchCommunityPosts, type CommunityPost, type CommunitySort } from "@/lib/api/community";
 import { motion } from "framer-motion";
 import Link from "next/link";
+import { useEffect, useState } from "react";
+
+const PAGE_SIZE = 20;
+
+function formatCreatedAt(value: string): string {
+  return new Intl.DateTimeFormat("ko-KR", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
 
 export default function CommunityPage() {
-  const [activeTab, setActiveTab] = useState("all");
+  const [sort, setSort] = useState<CommunitySort>("LATEST");
+  const [posts, setPosts] = useState<CommunityPost[]>([]);
+  const [page, setPage] = useState(0);
+  const [last, setLast] = useState(true);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState(false);
+  const [retryKey, setRetryKey] = useState(0);
 
-  const posts = [
-    {
-      id: 1,
-      artist: 'BTS',
-      artistId: 'bts',
-      author: 'ARMY_Forever',
-      avatar: 'https://readdy.ai/api/search-image?query=young%20asian%20woman%20profile%20photo%2C%20friendly%20smile%2C%20casual%20style%2C%20high%20quality%20portrait%20photography%2C%20natural%20lighting&width=100&height=100&seq=comm001&orientation=squarish',
-      content: 'BTS 새 앨범 티저 영상 보셨나요? 진짜 너무 기대돼요! 💜 컴백 준비하는 모습 보니까 벌써부터 설레네요',
-      image: 'https://readdy.ai/api/search-image?query=BTS%20comeback%20teaser%20concept%2C%20professional%20photography%2C%20purple%20theme%2C%20modern%20aesthetic%2C%20high%20quality%2C%20artistic%20composition&width=400&height=300&seq=comm002&orientation=landscape',
-      likes: 1234,
-      comments: 89,
-      shares: 45,
-      time: '2시간 전',
-      isVIP: true,
-      isPopular: true
-    },
-    {
-      id: 2,
-      artist: 'BLACKPINK',
-      artistId: 'blackpink',
-      author: 'Blink_Girl',
-      avatar: 'https://readdy.ai/api/search-image?query=young%20asian%20woman%20profile%20photo%2C%20stylish%20look%2C%20modern%20fashion%2C%20high%20quality%20portrait%20photography%2C%20studio%20lighting&width=100&height=100&seq=comm003&orientation=squarish',
-      content: 'BLACKPINK 월드투어 티켓 예매 성공했어요! 너무 설레요 ㅠㅠ 같이 가실 분 계신가요?',
-      image: 'https://readdy.ai/api/search-image?query=BLACKPINK%20world%20tour%20concert%20stage%2C%20spectacular%20lighting%2C%20pink%20and%20black%20theme%2C%20professional%20concert%20photography&width=400&height=300&seq=comm004&orientation=landscape',
-      likes: 856,
-      comments: 67,
-      shares: 34,
-      time: '5시간 전',
-      isVIP: false,
-      isPopular: true
-    },
-    {
-      id: 3,
-      artist: 'SEVENTEEN',
-      artistId: 'seventeen',
-      author: 'Carat_17',
-      avatar: 'https://readdy.ai/api/search-image?query=young%20asian%20woman%20profile%20photo%2C%20cheerful%20expression%2C%20bright%20style%2C%20high%20quality%20portrait%20photography&width=100&height=100&seq=comm005&orientation=squarish',
-      content: 'SEVENTEEN 안무 연습 영상 떴어요! 칼군무 진짜 미쳤다... 13명이 한 명처럼 움직이는 게 신기해요',
-      likes: 645,
-      comments: 52,
-      shares: 28,
-      time: '1일 전',
-      isVIP: true,
-      isPopular: false
-    },
-    {
-      id: 4,
-      artist: 'NewJeans',
-      artistId: 'newjeans',
-      author: 'Bunny_Fan',
-      avatar: 'https://readdy.ai/api/search-image?query=young%20asian%20woman%20profile%20photo%2C%20cute%20style%2C%20pastel%20colors%2C%20high%20quality%20portrait%20photography&width=100&height=100&seq=comm006&orientation=squarish',
-      content: 'NewJeans 신곡 뮤비 1억뷰 돌파! 🎉 우리 토끼들 최고야 ㅠㅠ',
-      image: 'https://readdy.ai/api/search-image?query=NewJeans%20music%20video%20concept%2C%20fresh%20and%20youthful%20style%2C%20pastel%20colors%2C%20modern%20aesthetic%2C%20high%20quality%20photography&width=400&height=300&seq=comm007&orientation=landscape',
-      likes: 523,
-      comments: 41,
-      shares: 19,
-      time: '3시간 전',
-      isVIP: false,
-      isPopular: true
-    },
-    {
-      id: 5,
-      artist: 'Stray Kids',
-      artistId: 'straykids',
-      author: 'Stay_Forever',
-      avatar: 'https://readdy.ai/api/search-image?query=young%20asian%20woman%20profile%20photo%2C%20energetic%20look%2C%20urban%20style%2C%20high%20quality%20portrait%20photography&width=100&height=100&seq=comm008&orientation=squarish',
-      content: 'Stray Kids 자작곡 진짜 천재들... 이번 앨범도 명곡만 가득하네요',
-      likes: 412,
-      comments: 35,
-      shares: 15,
-      time: '6시간 전',
-      isVIP: true,
-      isPopular: false
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(false);
+    setPosts([]);
+    setPage(0);
+    setLast(true);
+
+    fetchCommunityPosts(sort, 0, PAGE_SIZE, controller.signal)
+      .then((result) => {
+        setPosts(result.items);
+        setPage(result.page);
+        setLast(result.last);
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) setError(true);
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [sort, retryKey]);
+
+  const loadMore = async () => {
+    if (loadingMore || last) return;
+    setLoadingMore(true);
+    setError(false);
+    try {
+      const result = await fetchCommunityPosts(sort, page + 1, PAGE_SIZE);
+      setPosts((current) => {
+        const seen = new Set(current.map((post) => post.id));
+        return [...current, ...result.items.filter((post) => !seen.has(post.id))];
+      });
+      setPage(result.page);
+      setLast(result.last);
+    } catch {
+      setError(true);
+    } finally {
+      setLoadingMore(false);
     }
-  ];
-
-  const filteredPosts = posts.filter(post => {
-    if (activeTab === 'popular') return post.isPopular;
-    return true;
-  });
+  };
 
   return (
     <>
-      <PageHeader 
-        title="Community" 
+      <PageHeader
+        title="Community"
         rightAction={
-          <div className="flex items-center gap-2">
-            <Link 
-              href="/post-create" 
-              className="hidden lg:flex items-center gap-1 bg-purple-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-purple-700 transition-colors"
-            >
-              <i className="ri-edit-line"></i>
-              <span>글쓰기</span>
-            </Link>
-            <button className="p-2">
-              <i className="ri-search-line text-xl text-gray-700"></i>
-            </button>
-          </div>
+          <Link
+            href="/post-create"
+            className="hidden items-center gap-1 rounded-lg bg-purple-600 px-4 py-2 font-medium text-white transition-colors hover:bg-purple-700 lg:flex"
+          >
+            <i className="ri-edit-line" />
+            <span>글쓰기</span>
+          </Link>
         }
       />
       <PageWrapper>
-        {/* Tab Navigation */}
-        <div className="sticky top-16 bg-white border-b border-gray-200 z-30">
-          <div className="flex max-w-7xl mx-auto">
-            <button 
-              onClick={() => setActiveTab("all")}
-              className={`flex-1 py-4 text-sm font-medium transition-colors relative ${
-                activeTab === "all" ? "text-purple-600" : "text-gray-500"
+        <div className="sticky top-16 z-30 border-b border-gray-200 bg-white">
+          <div className="mx-auto flex max-w-7xl">
+            <button
+              onClick={() => setSort("LATEST")}
+              className={`relative flex-1 py-4 text-sm font-medium transition-colors ${
+                sort === "LATEST" ? "text-purple-600" : "text-gray-500"
               }`}
             >
               전체
-              {activeTab === "all" && (
-                <motion.div 
+              {sort === "LATEST" && (
+                <motion.div
                   layoutId="activeTab"
-                  className="absolute bottom-0 left-0 right-0 h-0.5 bg-purple-600" 
+                  className="absolute bottom-0 left-0 right-0 h-0.5 bg-purple-600"
                 />
               )}
             </button>
-            <button 
-              onClick={() => setActiveTab("popular")}
-              className={`flex-1 py-4 text-sm font-medium transition-colors relative ${
-                activeTab === "popular" ? "text-purple-600" : "text-gray-500"
+            <button
+              onClick={() => setSort("POPULAR")}
+              className={`relative flex-1 py-4 text-sm font-medium transition-colors ${
+                sort === "POPULAR" ? "text-purple-600" : "text-gray-500"
               }`}
             >
               인기
-              {activeTab === "popular" && (
-                <motion.div 
+              {sort === "POPULAR" && (
+                <motion.div
                   layoutId="activeTab"
-                  className="absolute bottom-0 left-0 right-0 h-0.5 bg-purple-600" 
+                  className="absolute bottom-0 left-0 right-0 h-0.5 bg-purple-600"
                 />
               )}
             </button>
           </div>
         </div>
 
-        <div className="max-w-3xl mx-auto px-4 py-6 space-y-4">
-          {filteredPosts.map((post) => (
+        <div className="mx-auto max-w-3xl space-y-4 px-4 py-6">
+          {loading && (
+            <div role="status" className="rounded-2xl border border-gray-100 bg-white p-8 text-center text-sm text-gray-500">
+              커뮤니티를 불러오는 중입니다.
+            </div>
+          )}
+
+          {!loading && error && posts.length === 0 && (
+            <div className="rounded-2xl border border-red-100 bg-white p-8 text-center">
+              <p className="text-sm text-gray-700">커뮤니티를 불러오지 못했습니다.</p>
+              <button
+                onClick={() => setRetryKey((key) => key + 1)}
+                className="mt-4 rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white"
+              >
+                다시 시도
+              </button>
+            </div>
+          )}
+
+          {!loading && !error && posts.length === 0 && (
+            <div className="rounded-2xl border border-gray-100 bg-white p-10 text-center">
+              <p className="text-sm font-medium text-gray-700">아직 작성된 게시글이 없습니다.</p>
+              <p className="mt-2 text-xs text-gray-500">첫 번째 이야기를 공유해 보세요.</p>
+            </div>
+          )}
+
+          {posts.map((post) => (
             <Link
               key={post.id}
               href={`/post-detail?id=${post.id}`}
-              className="block bg-white rounded-2xl border border-gray-100 overflow-hidden hover:shadow-md transition-shadow"
+              aria-label={`${post.content} 상세 보기`}
+              className="block overflow-hidden rounded-2xl border border-gray-100 bg-white transition-shadow hover:shadow-md"
             >
-              {/* Post Header */}
-              <div className="p-4 flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={post.avatar}
-                    alt={post.author}
-                    className="w-10 h-10 rounded-full object-cover border border-gray-100"
-                  />
-                  <div>
-                    <div className="flex items-center gap-2">
-                      <span className="text-sm font-bold text-gray-900">{post.author}</span>
-                      {post.isVIP && (
-                        <span className="px-2 py-0.5 bg-gradient-to-r from-yellow-400 to-orange-400 text-white text-[10px] rounded-full font-bold">
-                          VIP
-                        </span>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-2 mt-0.5">
-                      <span className="text-xs font-bold text-purple-600">{post.artist}</span>
-                      <span className="text-xs text-gray-400">· {post.time}</span>
-                    </div>
+              <div className="flex items-center gap-3 p-4">
+                <div
+                  aria-hidden="true"
+                  className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-purple-100 text-sm font-bold text-purple-700"
+                >
+                  {post.author.name.slice(0, 1).toUpperCase()}
+                </div>
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-bold text-gray-900">{post.author.name}</div>
+                  <div className="mt-0.5 flex items-center gap-2">
+                    {post.artist && (
+                      <span className="truncate text-xs font-bold text-purple-600">{post.artist.name}</span>
+                    )}
+                    <span className="text-xs text-gray-400">{formatCreatedAt(post.createdAt)}</span>
                   </div>
                 </div>
-                <button className="w-8 h-8 flex items-center justify-center text-gray-400 hover:text-gray-600">
-                  <i className="ri-more-2-fill"></i>
-                </button>
               </div>
 
-              {/* Post Content */}
               <div className="px-4 pb-3">
-                <p className="text-sm text-gray-800 leading-relaxed whitespace-pre-wrap">{post.content}</p>
+                <p className="whitespace-pre-wrap text-sm leading-relaxed text-gray-800">{post.content}</p>
               </div>
 
-              {/* Post Image */}
-              {post.image && (
+              {post.imageUrl && (
                 // eslint-disable-next-line @next/next/no-img-element
                 <img
-                  src={post.image}
-                  alt="Post content"
-                  className="w-full h-64 object-cover"
+                  src={post.imageUrl}
+                  alt="게시글 첨부 이미지"
+                  referrerPolicy="no-referrer"
+                  className="h-64 w-full object-cover"
                 />
               )}
 
-              {/* Post Actions */}
-              <div className="p-3 flex items-center justify-between border-t border-gray-50">
-                <div className="flex items-center gap-4">
-                  <button className="flex items-center gap-1.5 text-gray-500 hover:text-pink-500 transition-colors">
-                    <i className="ri-heart-line text-lg"></i>
-                    <span className="text-xs font-medium">{post.likes.toLocaleString()}</span>
-                  </button>
-                  <button className="flex items-center gap-1.5 text-gray-500 hover:text-blue-500 transition-colors">
-                    <i className="ri-chat-3-line text-lg"></i>
-                    <span className="text-xs font-medium">{post.comments}</span>
-                  </button>
-                  <button className="flex items-center gap-1.5 text-gray-500 hover:text-green-500 transition-colors">
-                    <i className="ri-share-forward-line text-lg"></i>
-                    <span className="text-xs font-medium">{post.shares}</span>
-                  </button>
-                </div>
-                <button className="text-gray-400 hover:text-purple-600 transition-colors">
-                  <i className="ri-bookmark-line text-lg"></i>
-                </button>
+              <div className="flex items-center gap-5 border-t border-gray-50 p-3 text-gray-500">
+                <span className="flex items-center gap-1.5 text-xs font-medium">
+                  <i className="ri-heart-line text-lg" />
+                  {post.likeCount.toLocaleString()}
+                </span>
+                <span className="flex items-center gap-1.5 text-xs font-medium">
+                  <i className="ri-chat-3-line text-lg" />
+                  {post.commentCount.toLocaleString()}
+                </span>
               </div>
             </Link>
           ))}
+
+          {posts.length > 0 && !last && (
+            <button
+              onClick={loadMore}
+              disabled={loadingMore}
+              className="w-full rounded-xl border border-purple-200 bg-white py-3 text-sm font-medium text-purple-700 disabled:text-gray-400"
+            >
+              {loadingMore ? "불러오는 중" : "더 보기"}
+            </button>
+          )}
+
+          {posts.length > 0 && error && (
+            <p role="alert" className="text-center text-sm text-red-600">다음 게시글을 불러오지 못했습니다.</p>
+          )}
         </div>
 
-        {/* Floating Action Button */}
-        <Link 
+        <Link
           href="/post-create"
-          className="fixed bottom-24 right-4 lg:hidden w-14 h-14 bg-gradient-to-r from-purple-600 to-pink-600 rounded-full flex items-center justify-center shadow-lg text-white hover:scale-105 transition-transform"
+          aria-label="글쓰기"
+          className="fixed bottom-24 right-4 flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-r from-purple-600 to-pink-600 text-white shadow-lg transition-transform hover:scale-105 lg:hidden"
         >
-          <i className="ri-add-line text-2xl"></i>
+          <i className="ri-add-line text-2xl" />
         </Link>
       </PageWrapper>
     </>

--- a/web/src/app/post-create/page.test.tsx
+++ b/web/src/app/post-create/page.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PostCreatePage from './page';
+import { fetchActiveArtists } from '@/lib/api/artist';
+import { createCommunityPost } from '@/lib/api/community';
+
+const push = vi.fn();
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push }) }));
+vi.mock('@/components/auth/ProtectedRoute', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/lib/api/artist', () => ({ fetchActiveArtists: vi.fn() }));
+vi.mock('@/lib/api/community', () => ({ createCommunityPost: vi.fn() }));
+
+const artist = {
+  id: '33333333-3333-3333-3333-333333333333',
+  name: 'Real Artist',
+  englishName: null,
+  agency: null,
+  profileImageUrl: null,
+  isGroup: true,
+};
+
+const created = {
+  id: '11111111-1111-1111-1111-111111111111',
+  author: { id: '22222222-2222-2222-2222-222222222222', name: 'real-author' },
+  artist: { id: artist.id, name: artist.name, profileImageUrl: null },
+  content: '실제 작성 내용',
+  imageUrl: null,
+  likeCount: 0,
+  commentCount: 0,
+  createdAt: '2026-08-14T08:00:00Z',
+};
+
+describe('PostCreatePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchActiveArtists).mockResolvedValue([artist]);
+    vi.mocked(createCommunityPost).mockResolvedValue(created);
+  });
+
+  it('loads real active artists and creates a persisted post with the artist UUID', async () => {
+    render(<PostCreatePage />);
+
+    const artistButton = await screen.findByRole('button', { name: 'Real Artist' });
+    expect(screen.queryByRole('button', { name: 'BTS' })).not.toBeInTheDocument();
+    fireEvent.click(artistButton);
+    fireEvent.change(screen.getByLabelText('내용 *'), { target: { value: '실제 작성 내용' } });
+    fireEvent.click(screen.getByRole('button', { name: '게시' }));
+
+    await waitFor(() => {
+      expect(createCommunityPost).toHaveBeenCalledWith({
+        artistId: artist.id,
+        content: '실제 작성 내용',
+      });
+    });
+    expect(push).toHaveBeenCalledWith(`/post-detail?id=${created.id}`);
+  });
+
+  it('shows an honest artist loading error without static choices', async () => {
+    vi.mocked(fetchActiveArtists).mockRejectedValue(new Error('network'));
+    render(<PostCreatePage />);
+
+    expect(await screen.findByText('아티스트를 불러오지 못했습니다.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'BTS' })).not.toBeInTheDocument();
+  });
+
+  it('keeps the form and shows the API error when creation fails', async () => {
+    vi.mocked(createCommunityPost).mockRejectedValue(new Error('blocked'));
+    render(<PostCreatePage />);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Real Artist' }));
+    fireEvent.change(screen.getByLabelText('내용 *'), { target: { value: '차단될 내용' } });
+    fireEvent.click(screen.getByRole('button', { name: '게시' }));
+
+    expect(await screen.findByText('게시글을 등록하지 못했습니다. 내용을 확인해 주세요.')).toBeInTheDocument();
+    expect(push).not.toHaveBeenCalled();
+    expect(screen.getByDisplayValue('차단될 내용')).toBeInTheDocument();
+  });
+});

--- a/web/src/app/post-create/page.tsx
+++ b/web/src/app/post-create/page.tsx
@@ -1,162 +1,154 @@
 "use client";
 
-import PageWrapper from "@/components/layout/PageWrapper";
 import ProtectedRoute from "@/components/auth/ProtectedRoute";
+import PageWrapper from "@/components/layout/PageWrapper";
+import { fetchActiveArtists, type ArtistSummary } from "@/lib/api/artist";
+import { createCommunityPost } from "@/lib/api/community";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function PostCreatePage() {
   const router = useRouter();
-  const [content, setContent] = useState('');
-  const [tags, setTags] = useState<string[]>([]);
-  const [tagInput, setTagInput] = useState('');
-  const [selectedArtist, setSelectedArtist] = useState('');
+  const [content, setContent] = useState("");
+  const [selectedArtistId, setSelectedArtistId] = useState<string | null>(null);
+  const [artists, setArtists] = useState<ArtistSummary[]>([]);
+  const [artistsLoading, setArtistsLoading] = useState(true);
+  const [artistError, setArtistError] = useState(false);
+  const [artistRetryKey, setArtistRetryKey] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState(false);
 
-  const artists = ['BTS', 'BLACKPINK', 'SEVENTEEN', 'NewJeans', 'Stray Kids', 'TWICE'];
+  useEffect(() => {
+    const controller = new AbortController();
+    setArtistsLoading(true);
+    setArtistError(false);
+    fetchActiveArtists(controller.signal)
+      .then(setArtists)
+      .catch(() => {
+        if (!controller.signal.aborted) {
+          setArtists([]);
+          setArtistError(true);
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setArtistsLoading(false);
+      });
+    return () => controller.abort();
+  }, [artistRetryKey]);
 
-  const handleAddTag = () => {
-    if (tagInput.trim() && tags.length < 5) {
-      setTags([...tags, tagInput.trim()]);
-      setTagInput('');
-    }
-  };
+  const canSubmit = content.trim().length > 0 && selectedArtistId !== null && !submitting;
 
-  const handleRemoveTag = (index: number) => {
-    setTags(tags.filter((_, i) => i !== index));
-  };
-
-  const handlePost = () => {
-    if (content.trim() && selectedArtist) {
-      // 게시글 작성 로직 (API call simulation)
-      router.push('/community');
+  const handlePost = async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setSubmitError(false);
+    try {
+      const post = await createCommunityPost({
+        artistId: selectedArtistId,
+        content: content.trim(),
+      });
+      router.push(`/post-detail?id=${post.id}`);
+    } catch {
+      setSubmitError(true);
+    } finally {
+      setSubmitting(false);
     }
   };
 
   return (
     <ProtectedRoute>
-      {/* Custom Header */}
-      <header className="fixed top-0 left-0 right-0 bg-white border-b border-gray-200 z-50 lg:static lg:z-auto lg:border-none lg:bg-transparent lg:pt-8 lg:pb-4">
-        <div className="px-4 py-3 flex items-center justify-between h-16 lg:h-auto lg:px-0 lg:max-w-4xl lg:mx-auto">
-          <Link href="/community" className="text-sm text-gray-600 hover:text-gray-900 transition-colors lg:text-base lg:bg-gray-100 lg:px-4 lg:py-2 lg:rounded-lg">취소</Link>
-          <h1 className="text-base font-bold text-gray-900 lg:text-3xl lg:flex-1 lg:ml-8">게시글 작성</h1>
-          <button 
+      <header className="fixed left-0 right-0 top-0 z-50 border-b border-gray-200 bg-white lg:static lg:z-auto lg:border-none lg:bg-transparent lg:pb-4 lg:pt-8">
+        <div className="flex h-16 items-center justify-between px-4 py-3 lg:mx-auto lg:h-auto lg:max-w-4xl lg:px-0">
+          <Link href="/community" className="text-sm text-gray-600 transition-colors hover:text-gray-900 lg:rounded-lg lg:bg-gray-100 lg:px-4 lg:py-2 lg:text-base">
+            취소
+          </Link>
+          <h1 className="text-base font-bold text-gray-900 lg:ml-8 lg:flex-1 lg:text-3xl">게시글 작성</h1>
+          <button
             onClick={handlePost}
-            disabled={!content.trim() || !selectedArtist}
-            className={`text-sm font-medium transition-colors lg:text-base lg:px-6 lg:py-2 lg:rounded-lg ${
-              content.trim() && selectedArtist 
-                ? 'text-purple-600 hover:text-purple-700 lg:bg-purple-600 lg:text-white lg:hover:bg-purple-700' 
-                : 'text-gray-400 cursor-not-allowed lg:bg-gray-200 lg:text-gray-500'
+            disabled={!canSubmit}
+            className={`text-sm font-medium transition-colors lg:rounded-lg lg:px-6 lg:py-2 lg:text-base ${
+              canSubmit
+                ? "text-purple-600 hover:text-purple-700 lg:bg-purple-600 lg:text-white lg:hover:bg-purple-700"
+                : "cursor-not-allowed text-gray-400 lg:bg-gray-200 lg:text-gray-500"
             }`}
           >
-            게시
+            {submitting ? "등록 중" : "게시"}
           </button>
         </div>
       </header>
 
       <PageWrapper>
-        <div className="px-4 pb-6">
-          {/* Artist Selection */}
+        <div className="mx-auto max-w-4xl px-4 pb-6">
           <div className="py-4">
-            <label className="text-sm font-bold text-gray-900 mb-3 block">
-              아티스트 선택 *
-            </label>
-            <div className="flex flex-wrap gap-2">
-              {artists.map(artist => (
+            <p className="mb-3 block text-sm font-bold text-gray-900">아티스트 선택 *</p>
+            {artistsLoading && <p role="status" className="text-sm text-gray-500">아티스트를 불러오는 중입니다.</p>}
+            {!artistsLoading && artistError && (
+              <div className="rounded-xl border border-red-100 bg-red-50 p-4">
+                <p className="text-sm text-red-700">아티스트를 불러오지 못했습니다.</p>
                 <button
-                  key={artist}
-                  onClick={() => setSelectedArtist(artist)}
-                  className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
-                    selectedArtist === artist
-                      ? 'bg-gradient-to-r from-purple-600 to-pink-600 text-white shadow-md'
-                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                  }`}
+                  onClick={() => setArtistRetryKey((key) => key + 1)}
+                  className="mt-3 rounded-lg bg-white px-3 py-2 text-xs font-medium text-purple-700"
                 >
-                  {artist}
+                  다시 시도
                 </button>
-              ))}
-            </div>
-          </div>
-
-          {/* Content Input */}
-          <div className="py-4">
-            <label className="text-sm font-bold text-gray-900 mb-3 block">
-              내용 *
-            </label>
-            <textarea
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              placeholder="팬 여러분과 공유하고 싶은 이야기를 작성해주세요..."
-              maxLength={500}
-              className="w-full h-48 bg-gray-50 rounded-2xl px-4 py-3 text-sm border-none focus:outline-none focus:ring-2 focus:ring-purple-600 resize-none transition-all"
-            />
-            <div className="flex justify-end mt-2">
-              <span className="text-xs text-gray-500">{content.length}/500</span>
-            </div>
-          </div>
-
-          {/* Image Upload */}
-          <div className="py-4">
-            <label className="text-sm font-bold text-gray-900 mb-3 block">
-              이미지 첨부
-            </label>
-            <button className="w-full h-32 bg-gray-50 rounded-2xl border-2 border-dashed border-gray-300 flex flex-col items-center justify-center gap-2 text-gray-500 hover:border-purple-400 hover:text-purple-500 transition-colors">
-              <i className="ri-image-add-line text-3xl"></i>
-              <span className="text-sm">이미지 추가 (최대 5장)</span>
-            </button>
-          </div>
-
-          {/* Tags */}
-          <div className="py-4">
-            <label className="text-sm font-bold text-gray-900 mb-3 block">
-              태그 (최대 5개)
-            </label>
-            <div className="flex gap-2 mb-3">
-              <input
-                type="text"
-                value={tagInput}
-                onChange={(e) => setTagInput(e.target.value)}
-                onKeyPress={(e) => e.key === 'Enter' && handleAddTag()}
-                placeholder="태그 입력 후 엔터"
-                className="flex-1 bg-gray-50 rounded-full px-4 py-2.5 text-sm border-none focus:outline-none focus:ring-2 focus:ring-purple-600 transition-all"
-              />
-              <button
-                onClick={handleAddTag}
-                disabled={tags.length >= 5}
-                className="px-4 py-2.5 bg-purple-600 text-white rounded-full text-sm font-medium disabled:bg-gray-300 transition-colors shadow-sm"
-              >
-                추가
-              </button>
-            </div>
-            {tags.length > 0 && (
+              </div>
+            )}
+            {!artistsLoading && !artistError && artists.length === 0 && (
+              <p className="text-sm text-gray-500">선택 가능한 아티스트가 없습니다.</p>
+            )}
+            {!artistsLoading && !artistError && artists.length > 0 && (
               <div className="flex flex-wrap gap-2">
-                {tags.map((tag, index) => (
-                  <div
-                    key={index}
-                    className="bg-purple-50 text-purple-600 px-3 py-1.5 rounded-full text-sm flex items-center gap-2"
+                {artists.map((artist) => (
+                  <button
+                    key={artist.id}
+                    onClick={() => setSelectedArtistId(artist.id)}
+                    aria-pressed={selectedArtistId === artist.id}
+                    className={`rounded-full px-4 py-2 text-sm font-medium transition-colors ${
+                      selectedArtistId === artist.id
+                        ? "bg-gradient-to-r from-purple-600 to-pink-600 text-white shadow-md"
+                        : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                    }`}
                   >
-                    <span>#{tag}</span>
-                    <button
-                      onClick={() => handleRemoveTag(index)}
-                      className="w-4 h-4 flex items-center justify-center hover:text-purple-800"
-                    >
-                      <i className="ri-close-line text-sm"></i>
-                    </button>
-                  </div>
+                    {artist.name}
+                  </button>
                 ))}
               </div>
             )}
           </div>
 
-          {/* Guidelines */}
-          <div className="mt-6 bg-purple-50 rounded-2xl p-4">
+          <div className="py-4">
+            <label htmlFor="community-content" className="mb-3 block text-sm font-bold text-gray-900">
+              내용 *
+            </label>
+            <textarea
+              id="community-content"
+              value={content}
+              onChange={(event) => setContent(event.target.value)}
+              placeholder="팬 여러분과 공유하고 싶은 이야기를 작성해주세요..."
+              maxLength={5000}
+              className="h-48 w-full resize-none rounded-2xl border-none bg-gray-50 px-4 py-3 text-sm transition-all focus:outline-none focus:ring-2 focus:ring-purple-600"
+            />
+            <div className="mt-2 flex justify-end">
+              <span className="text-xs text-gray-500">{content.length}/5000</span>
+            </div>
+          </div>
+
+
+          {submitError && (
+            <p role="alert" className="rounded-xl bg-red-50 p-4 text-sm text-red-700">
+              게시글을 등록하지 못했습니다. 내용을 확인해 주세요.
+            </p>
+          )}
+
+          <div className="mt-6 rounded-2xl bg-purple-50 p-4">
             <div className="flex items-start gap-2">
-              <i className="ri-information-line text-purple-600 text-lg flex-shrink-0 mt-0.5"></i>
+              <i className="ri-information-line mt-0.5 flex-shrink-0 text-lg text-purple-600" />
               <div>
-                <h3 className="text-sm font-bold text-purple-900 mb-2">게시글 작성 가이드</h3>
-                <ul className="text-xs text-purple-700 space-y-1">
+                <h3 className="mb-2 text-sm font-bold text-purple-900">게시글 작성 가이드</h3>
+                <ul className="space-y-1 text-xs text-purple-700">
                   <li>• 타인을 존중하는 내용을 작성해주세요</li>
-                  <li>• 욕설, 비방, 허위사실은 삭제될 수 있습니다</li>
+                  <li>• 욕설, 비방, 허위사실은 등록이 거부될 수 있습니다</li>
                   <li>• 저작권을 침해하는 콘텐츠는 게시할 수 없습니다</li>
                 </ul>
               </div>

--- a/web/src/app/post-detail/page.test.tsx
+++ b/web/src/app/post-detail/page.test.tsx
@@ -1,26 +1,123 @@
-import { render, screen } from '@testing-library/react'
-import PostDetailPage from './page'
-import { vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import PostDetailPage from './page';
+import {
+  createCommunityComment,
+  fetchCommunityComments,
+  fetchCommunityPost,
+  fetchCommunityPostState,
+  likeCommunityPost,
+  saveCommunityPost,
+} from '@/lib/api/community';
+
+const nav = vi.hoisted(() => ({
+  id: '11111111-1111-1111-1111-111111111111',
+  back: vi.fn(),
+  push: vi.fn(),
+}));
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({
-    back: vi.fn(),
-  }),
-  useSearchParams: () => ({
-    get: (key: string) => key === 'id' ? '456' : null,
-  }),
-}))
+  useRouter: () => ({ back: nav.back, push: nav.push }),
+  useSearchParams: () => ({ get: (key: string) => key === 'id' ? nav.id : null }),
+}));
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: true, isLoading: false }),
+}));
+vi.mock('@/lib/api/community', () => ({
+  createCommunityComment: vi.fn(),
+  fetchCommunityComments: vi.fn(),
+  fetchCommunityPost: vi.fn(),
+  fetchCommunityPostState: vi.fn(),
+  likeCommunityPost: vi.fn(),
+  saveCommunityPost: vi.fn(),
+  unlikeCommunityPost: vi.fn(),
+  unsaveCommunityPost: vi.fn(),
+}));
+
+const post = {
+  id: nav.id,
+  author: { id: '22222222-2222-2222-2222-222222222222', name: 'real-author' },
+  artist: { id: '33333333-3333-3333-3333-333333333333', name: 'Real Artist', profileImageUrl: null },
+  content: '실제 상세 게시글',
+  imageUrl: null,
+  likeCount: 2,
+  commentCount: 1,
+  createdAt: '2026-08-14T08:00:00Z',
+};
+
+const comment = {
+  id: '44444444-4444-4444-4444-444444444444',
+  postId: nav.id,
+  userId: post.author.id,
+  content: '실제 저장 댓글',
+  status: 'APPROVED' as const,
+  parentCommentId: null,
+  createdAt: '2026-08-14T09:00:00Z',
+  authorName: 'comment-author',
+};
+
+const comments = {
+  items: [comment],
+  totalElements: 1,
+  page: 0,
+  size: 20,
+  totalPages: 1,
+};
 
 describe('PostDetailPage', () => {
-  it('renders page header', () => {
-    render(<PostDetailPage />)
-    expect(screen.getByText('Post Detail')).toBeInTheDocument()
-  })
+  beforeEach(() => {
+    vi.clearAllMocks();
+    nav.id = post.id;
+    vi.mocked(fetchCommunityPost).mockResolvedValue(post);
+    vi.mocked(fetchCommunityComments).mockResolvedValue(comments);
+    vi.mocked(fetchCommunityPostState).mockResolvedValue({ liked: false, saved: false });
+    vi.mocked(likeCommunityPost).mockResolvedValue({ liked: true, saved: false });
+    vi.mocked(saveCommunityPost).mockResolvedValue({ liked: true, saved: true });
+    vi.mocked(createCommunityComment).mockResolvedValue(comment);
+  });
 
-  it('renders post content and comments section', () => {
-    render(<PostDetailPage />)
-    expect(screen.getByText('ARMY_Forever')).toBeInTheDocument()
-    expect(screen.getByText('댓글 3')).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('댓글을 입력하세요...')).toBeInTheDocument()
-  })
-})
+  it('renders only the persisted post and persisted comments', async () => {
+    render(<PostDetailPage />);
+
+    expect(await screen.findByText('실제 상세 게시글')).toBeInTheDocument();
+    expect(await screen.findByText('실제 저장 댓글')).toBeInTheDocument();
+    expect(screen.getByText('real-author')).toBeInTheDocument();
+    expect(screen.getByText('comment-author')).toBeInTheDocument();
+    expect(screen.queryByText('ARMY_Forever')).not.toBeInTheDocument();
+    expect(fetchCommunityPost).toHaveBeenCalledWith(post.id, expect.any(AbortSignal));
+    expect(fetchCommunityComments).toHaveBeenCalledWith(post.id, 0, 20, expect.any(AbortSignal));
+  });
+
+  it('persists like and save mutations for the authenticated user', async () => {
+    render(<PostDetailPage />);
+    await screen.findByText('실제 상세 게시글');
+
+    fireEvent.click(screen.getByRole('button', { name: '좋아요' }));
+    await waitFor(() => expect(likeCommunityPost).toHaveBeenCalledWith(post.id));
+    fireEvent.click(screen.getByRole('button', { name: '저장' }));
+    await waitFor(() => expect(saveCommunityPost).toHaveBeenCalledWith(post.id));
+  });
+
+  it('creates a real comment and reloads the persisted comment list', async () => {
+    vi.mocked(fetchCommunityComments)
+      .mockResolvedValueOnce({ ...comments, items: [], totalElements: 0, totalPages: 0 })
+      .mockResolvedValueOnce(comments);
+    render(<PostDetailPage />);
+    await screen.findByText('실제 상세 게시글');
+
+    fireEvent.change(screen.getByLabelText('댓글 내용'), { target: { value: '실제 저장 댓글' } });
+    fireEvent.click(screen.getByRole('button', { name: '댓글 등록' }));
+
+    await waitFor(() => expect(createCommunityComment).toHaveBeenCalledWith(post.id, '실제 저장 댓글'));
+    expect(await screen.findByText('실제 저장 댓글')).toBeInTheDocument();
+    expect(fetchCommunityComments).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows an honest error instead of a mock post when detail loading fails', async () => {
+    vi.mocked(fetchCommunityPost).mockRejectedValue(new Error('not found'));
+    render(<PostDetailPage />);
+
+    expect(await screen.findByText('게시글을 불러오지 못했습니다.')).toBeInTheDocument();
+    expect(screen.queryByText('ARMY_Forever')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/app/post-detail/page.tsx
+++ b/web/src/app/post-detail/page.tsx
@@ -2,218 +2,341 @@
 
 import PageHeader from "@/components/layout/PageHeader";
 import PageWrapper from "@/components/layout/PageWrapper";
-import { useState } from "react";
-import Link from "next/link";
+import { useAuth } from "@/contexts/AuthContext";
+import {
+  createCommunityComment,
+  fetchCommunityComments,
+  fetchCommunityPost,
+  fetchCommunityPostState,
+  likeCommunityPost,
+  saveCommunityPost,
+  unlikeCommunityPost,
+  unsaveCommunityPost,
+  type CommunityComment,
+  type CommunityPost,
+  type CommunityPostState,
+} from "@/lib/api/community";
+import { useRouter, useSearchParams } from "next/navigation";
+import { FormEvent, useEffect, useState } from "react";
+
+function formatTime(value: string) {
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
 
 export default function PostDetailPage() {
-  const [liked, setLiked] = useState(false);
-  const [bookmarked, setBookmarked] = useState(false);
-  const [comment, setComment] = useState('');
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const postId = searchParams.get("id");
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
 
-  const post = {
-    id: 1,
-    author: {
-      name: 'ARMY_Forever',
-      avatar: 'https://readdy.ai/api/search-image?query=icon%2C%20cute%20purple%20heart%20avatar%2C%202.5D%20illustration%20style%2C%20the%20icon%20should%20take%20up%2070%20percent%20of%20the%20frame%2C%20isolated%20on%20white%20background%2C%20centered%20composition%2C%20soft%20lighting%2C%20vibrant%20colors&width=100&height=100&seq=avatar001&orientation=squarish',
-      badge: 'VIP'
-    },
-    content: 'BTS 새 앨범 티저 영상 보셨나요? 진짜 너무 기대돼요! 💜 컴백 준비하는 모습 보니까 벌써부터 설레네요. 이번 앨범도 대박날 것 같아요!',
-    image: 'https://readdy.ai/api/search-image?query=BTS%20comeback%20teaser%20concept%2C%20professional%20photography%2C%20purple%20theme%2C%20modern%20aesthetic%2C%20high%20quality%2C%20artistic%20composition%2C%20elegant%20lighting&width=800&height=600&seq=post001&orientation=landscape',
-    likes: 1234,
-    comments: 89,
-    shares: 45,
-    time: '2시간 전',
-    tags: ['BTS', '컴백', '새앨범']
+  const [post, setPost] = useState<CommunityPost | null>(null);
+  const [comments, setComments] = useState<CommunityComment[]>([]);
+  const [commentPage, setCommentPage] = useState({ page: 0, totalPages: 0, totalElements: 0 });
+  const [state, setState] = useState<CommunityPostState | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [stateError, setStateError] = useState<string | null>(null);
+  const [mutationLoading, setMutationLoading] = useState(false);
+  const [commentText, setCommentText] = useState("");
+  const [commentSubmitting, setCommentSubmitting] = useState(false);
+  const [commentMessage, setCommentMessage] = useState<string | null>(null);
+  const [commentsLoadingMore, setCommentsLoadingMore] = useState(false);
+  const [retryKey, setRetryKey] = useState(0);
+
+  useEffect(() => {
+    if (!postId) {
+      setError("게시글을 불러오지 못했습니다.");
+      setLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    setPost(null);
+    setComments([]);
+
+    Promise.all([
+      fetchCommunityPost(postId, controller.signal),
+      fetchCommunityComments(postId, 0, 20, controller.signal),
+    ])
+      .then(([postData, commentData]) => {
+        if (controller.signal.aborted) return;
+        setPost(postData);
+        setComments(commentData.items);
+        setCommentPage({
+          page: commentData.page,
+          totalPages: commentData.totalPages,
+          totalElements: commentData.totalElements,
+        });
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) setError("게시글을 불러오지 못했습니다.");
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [postId, retryKey]);
+
+  useEffect(() => {
+    if (!postId || authLoading) return;
+    if (!isAuthenticated) {
+      setState(null);
+      setStateError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    setState(null);
+    setStateError(null);
+    fetchCommunityPostState(postId, controller.signal)
+      .then((result) => {
+        if (!controller.signal.aborted) setState(result);
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) setStateError("좋아요·저장 상태를 불러오지 못했습니다.");
+      });
+    return () => controller.abort();
+  }, [authLoading, isAuthenticated, postId, retryKey]);
+
+  const requireAuthentication = () => {
+    if (isAuthenticated) return true;
+    router.push(`/login?redirect=${encodeURIComponent(`/post-detail?id=${postId ?? ""}`)}`);
+    return false;
   };
 
-  const commentsList = [
-    {
-      id: 1,
-      author: 'Blink_Girl',
-      avatar: 'https://readdy.ai/api/search-image?query=icon%2C%20cute%20pink%20crown%20avatar%2C%202.5D%20illustration%20style%2C%20the%20icon%20should%20take%20up%2070%20percent%20of%20the%20frame%2C%20isolated%20on%20white%20background%2C%20centered%20composition%2C%20soft%20lighting%2C%20vibrant%20colors&width=100&height=100&seq=avatar002&orientation=squarish',
-      content: '저도 티저 보고 소름 돋았어요! 이번 컨셉 진짜 좋은 것 같아요',
-      time: '1시간 전',
-      likes: 23
-    },
-    {
-      id: 2,
-      author: 'Kpop_Lover',
-      avatar: 'https://readdy.ai/api/search-image?query=icon%2C%20cute%20blue%20star%20avatar%2C%202.5D%20illustration%20style%2C%20the%20icon%20should%20take%20up%2070%20percent%20of%20the%20frame%2C%20isolated%20on%20white%20background%2C%20centered%20composition%2C%20soft%20lighting%2C%20vibrant%20colors&width=100&height=100&seq=avatar003&orientation=squarish',
-      content: '벌써부터 기대되네요 ㅠㅠ 빨리 발매일 공개됐으면 좋겠어요',
-      time: '30분 전',
-      likes: 15
-    },
-    {
-      id: 3,
-      author: 'Music_Fan',
-      avatar: 'https://readdy.ai/api/search-image?query=icon%2C%20cute%20orange%20music%20note%20avatar%2C%202.5D%20illustration%20style%2C%20the%20icon%20should%20take%20up%2070%20percent%20of%20the%20frame%2C%20isolated%20on%20white%20background%2C%20centered%20composition%2C%20soft%20lighting%2C%20vibrant%20colors&width=100&height=100&seq=avatar004&orientation=squarish',
-      content: '이번 앨범도 빌보드 1위 가즈아! 💪',
-      time: '15분 전',
-      likes: 8
+  const handleLike = async () => {
+    if (!postId || !requireAuthentication() || !state || mutationLoading) return;
+    setMutationLoading(true);
+    setStateError(null);
+    try {
+      const next = state.liked
+        ? await unlikeCommunityPost(postId)
+        : await likeCommunityPost(postId);
+      setPost((current) => current ? {
+        ...current,
+        likeCount: Math.max(0, current.likeCount + (next.liked ? 1 : -1)),
+      } : current);
+      setState(next);
+    } catch {
+      setStateError("좋아요 상태를 저장하지 못했습니다.");
+    } finally {
+      setMutationLoading(false);
     }
-  ];
+  };
+
+  const handleSave = async () => {
+    if (!postId || !requireAuthentication() || !state || mutationLoading) return;
+    setMutationLoading(true);
+    setStateError(null);
+    try {
+      const next = state.saved
+        ? await unsaveCommunityPost(postId)
+        : await saveCommunityPost(postId);
+      setState(next);
+    } catch {
+      setStateError("게시글 저장 상태를 변경하지 못했습니다.");
+    } finally {
+      setMutationLoading(false);
+    }
+  };
+
+  const reloadComments = async () => {
+    if (!postId) return;
+    const result = await fetchCommunityComments(postId, 0, 20);
+    setComments(result.items);
+    setCommentPage({
+      page: result.page,
+      totalPages: result.totalPages,
+      totalElements: result.totalElements,
+    });
+    setPost((current) => current ? { ...current, commentCount: result.totalElements } : current);
+  };
+
+  const handleCommentSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!postId || !commentText.trim() || !requireAuthentication() || commentSubmitting) return;
+    setCommentSubmitting(true);
+    setCommentMessage(null);
+    try {
+      const result = await createCommunityComment(postId, commentText.trim());
+      setCommentText("");
+      if (result.status === "APPROVED") {
+        await reloadComments();
+      } else if (result.status === "PENDING") {
+        setCommentMessage("댓글이 검토 대기 상태로 저장되었습니다.");
+      } else {
+        setCommentMessage("댓글이 게시 기준을 통과하지 못했습니다.");
+      }
+    } catch {
+      setCommentMessage("댓글을 저장하지 못했습니다.");
+    } finally {
+      setCommentSubmitting(false);
+    }
+  };
+
+  const loadMoreComments = async () => {
+    if (!postId || commentsLoadingMore || commentPage.page + 1 >= commentPage.totalPages) return;
+    setCommentsLoadingMore(true);
+    try {
+      const result = await fetchCommunityComments(postId, commentPage.page + 1, 20);
+      setComments((current) => {
+        const seen = new Set(current.map((comment) => comment.id));
+        return [...current, ...result.items.filter((comment) => !seen.has(comment.id))];
+      });
+      setCommentPage({
+        page: result.page,
+        totalPages: result.totalPages,
+        totalElements: result.totalElements,
+      });
+    } catch {
+      setCommentMessage("댓글을 더 불러오지 못했습니다.");
+    } finally {
+      setCommentsLoadingMore(false);
+    }
+  };
 
   return (
     <>
-      <PageHeader title="Post Detail" />
-      <PageWrapper>
-        {/* Post */}
-        <div className="max-w-3xl mx-auto px-4 py-6 bg-white shadow-sm rounded-b-3xl">
-          {/* Author Info */}
-          <div className="flex items-center gap-3 mb-4">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img 
-              src={post.author.avatar}
-              alt={post.author.name}
-              className="w-12 h-12 rounded-full object-cover border border-gray-100"
-            />
-            <div className="flex-1">
-              <div className="flex items-center gap-2">
-                <h3 className="font-bold text-gray-900">{post.author.name}</h3>
-                <span className="bg-gradient-to-r from-purple-600 to-pink-600 text-white text-[10px] px-2 py-0.5 rounded-full font-bold">
-                  {post.author.badge}
-                </span>
-              </div>
-              <p className="text-xs text-gray-500">{post.time}</p>
-            </div>
-            <button className="px-4 py-1.5 border-2 border-purple-600 text-purple-600 rounded-full text-sm font-medium hover:bg-purple-50 transition-colors">
-              팔로우
+      <PageHeader title="게시글" showBack />
+      <PageWrapper className="mx-auto max-w-3xl px-4 py-6">
+        {loading && <p className="py-16 text-center text-gray-500">게시글을 불러오는 중입니다.</p>}
+
+        {!loading && error && (
+          <div className="py-16 text-center">
+            <p className="text-gray-700">{error}</p>
+            <button
+              type="button"
+              onClick={() => setRetryKey((value) => value + 1)}
+              className="mt-4 rounded-full bg-purple-600 px-5 py-2 text-sm font-semibold text-white"
+            >
+              다시 시도
             </button>
           </div>
+        )}
 
-          {/* Post Content */}
-          <p className="text-gray-800 leading-relaxed mb-4 text-base">
-            {post.content}
-          </p>
-
-          {/* Tags */}
-          <div className="flex flex-wrap gap-2 mb-4">
-            {post.tags.map(tag => (
-              <Link
-                key={tag}
-                href={`/search?tag=${encodeURIComponent(tag)}`}
-                className="text-xs text-purple-600 bg-purple-50 px-3 py-1 rounded-full font-medium hover:bg-purple-100 transition-colors"
+        {!loading && !error && post && (
+          <article className="rounded-3xl bg-white p-5 shadow-sm">
+            <header className="mb-5 flex items-center gap-3">
+              <div
+                aria-hidden="true"
+                className="flex h-11 w-11 items-center justify-center rounded-full bg-purple-100 font-bold text-purple-700"
               >
-                #{tag}
-              </Link>
-            ))}
-          </div>
-
-          {/* Post Image */}
-          <div className="rounded-2xl overflow-hidden mb-6 shadow-sm">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img 
-              src={post.image}
-              alt="Post"
-              className="w-full h-auto object-cover"
-            />
-          </div>
-
-          {/* Engagement Stats */}
-          <div className="flex items-center justify-between py-3 border-y border-gray-100">
-            <div className="flex items-center gap-6 text-sm text-gray-600">
-              <span className="flex items-center gap-1.5">
-                <i className="ri-heart-fill text-pink-500"></i>
-                <span className="font-medium">{post.likes.toLocaleString()}</span>
-              </span>
-              <span className="flex items-center gap-1.5">
-                <i className="ri-chat-3-fill text-blue-500"></i>
-                <span className="font-medium">{post.comments}</span>
-              </span>
-              <span className="flex items-center gap-1.5">
-                <i className="ri-share-forward-fill text-green-500"></i>
-                <span className="font-medium">{post.shares}</span>
-              </span>
-            </div>
-          </div>
-
-          {/* Action Buttons */}
-          <div className="flex items-center gap-2 py-4">
-            <button 
-              onClick={() => setLiked(!liked)}
-              className={`flex-1 py-3 rounded-xl font-medium text-sm flex items-center justify-center gap-2 transition-all ${
-                liked 
-                  ? 'bg-pink-50 text-pink-600 scale-95' 
-                  : 'bg-gray-50 text-gray-600 hover:bg-gray-100'
-              }`}
-            >
-              <i className={liked ? 'ri-heart-fill text-lg' : 'ri-heart-line text-lg'}></i>
-              좋아요
-            </button>
-            <button className="flex-1 bg-gray-50 text-gray-600 hover:bg-gray-100 transition-colors py-3 rounded-xl font-medium text-sm flex items-center justify-center gap-2">
-              <i className="ri-chat-3-line text-lg"></i>
-              댓글
-            </button>
-            <button className="flex-1 bg-gray-50 text-gray-600 hover:bg-gray-100 transition-colors py-3 rounded-xl font-medium text-sm flex items-center justify-center gap-2">
-              <i className="ri-share-line text-lg"></i>
-              공유
-            </button>
-            <button 
-              onClick={() => setBookmarked(!bookmarked)}
-              className={`w-12 h-12 rounded-xl flex items-center justify-center transition-colors ${
-                bookmarked 
-                  ? 'bg-purple-50 text-purple-600' 
-                  : 'bg-gray-50 text-gray-600 hover:bg-gray-100'
-              }`}
-            >
-              <i className={`${bookmarked ? 'ri-bookmark-fill' : 'ri-bookmark-line'} text-xl`}></i>
-            </button>
-          </div>
-        </div>
-
-        {/* Comments Section */}
-        <div className="max-w-3xl mx-auto px-4 py-8 bg-gray-50/50 min-h-[300px]">
-          <h2 className="text-lg font-bold text-gray-900 mb-4 px-1">
-            댓글 {commentsList.length}
-          </h2>
-
-          <div className="space-y-4">
-            {commentsList.map(item => (
-              <div key={item.id} className="bg-white rounded-2xl p-4 shadow-sm border border-gray-100">
-                <div className="flex items-start gap-3">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img 
-                    src={item.avatar}
-                    alt={item.author}
-                    className="w-10 h-10 rounded-full object-cover flex-shrink-0 border border-gray-100"
-                  />
-                  <div className="flex-1">
-                    <div className="flex items-center justify-between mb-1">
-                      <h4 className="font-bold text-sm text-gray-900">{item.author}</h4>
-                      <span className="text-xs text-gray-400">{item.time}</span>
-                    </div>
-                    <p className="text-sm text-gray-700 leading-relaxed mb-3">
-                      {item.content}
-                    </p>
-                    <div className="flex items-center gap-4">
-                      <button className="text-xs text-gray-500 flex items-center gap-1 hover:text-pink-500 transition-colors">
-                        <i className="ri-heart-line"></i>
-                        {item.likes}
-                      </button>
-                      <button className="text-xs text-gray-500 hover:text-purple-600 transition-colors">답글</button>
-                    </div>
-                  </div>
-                </div>
+                {post.author.name.slice(0, 1).toUpperCase()}
               </div>
-            ))}
-          </div>
-        </div>
+              <div className="min-w-0 flex-1">
+                <p className="truncate font-bold text-gray-900">{post.author.name}</p>
+                <p className="text-xs text-gray-500">{formatTime(post.createdAt)}</p>
+              </div>
+              {post.artist && (
+                <span className="rounded-full bg-purple-50 px-3 py-1 text-xs font-semibold text-purple-700">
+                  {post.artist.name}
+                </span>
+              )}
+            </header>
 
-        {/* Comment Input Placeholder */}
-        <div className="sticky bottom-0 left-0 right-0 bg-white border-t border-gray-200 px-4 py-3">
-          <div className="max-w-3xl mx-auto flex items-center gap-3">
-            <input 
-              type="text"
-              value={comment}
-              onChange={(e) => setComment(e.target.value)}
-              placeholder="댓글을 입력하세요..."
-              className="flex-1 bg-gray-100 rounded-full px-5 py-3 text-sm border-none focus:outline-none focus:ring-2 focus:ring-purple-600 transition-all"
-            />
-            <button className="w-11 h-11 bg-gradient-to-r from-purple-600 to-pink-600 rounded-full flex items-center justify-center text-white shadow-md hover:scale-105 transition-transform">
-              <i className="ri-send-plane-fill text-lg"></i>
-            </button>
-          </div>
-        </div>
+            <p className="whitespace-pre-wrap text-base leading-relaxed text-gray-800">{post.content}</p>
+
+            {post.imageUrl && (
+              // eslint-disable-next-line @next/next/no-img-element -- validated external HTTPS URL must bypass Next host allowlists
+              <img
+                src={post.imageUrl}
+                alt="게시글 첨부 이미지"
+                referrerPolicy="no-referrer"
+                className="mt-5 max-h-[560px] w-full rounded-2xl object-cover"
+              />
+            )}
+
+            <div className="mt-6 flex items-center gap-3 border-y border-gray-100 py-3">
+              <button
+                type="button"
+                aria-label="좋아요"
+                aria-pressed={state?.liked ?? false}
+                disabled={mutationLoading || (isAuthenticated && state === null)}
+                onClick={handleLike}
+                className={`rounded-full px-4 py-2 text-sm font-semibold ${state?.liked ? "bg-pink-50 text-pink-600" : "bg-gray-50 text-gray-700"}`}
+              >
+                <i className={state?.liked ? "ri-heart-fill" : "ri-heart-line"} /> {post.likeCount.toLocaleString()}
+              </button>
+              <span className="rounded-full bg-gray-50 px-4 py-2 text-sm text-gray-700">
+                <i className="ri-chat-3-line" /> {commentPage.totalElements.toLocaleString()}
+              </span>
+              <button
+                type="button"
+                aria-label="저장"
+                aria-pressed={state?.saved ?? false}
+                disabled={mutationLoading || (isAuthenticated && state === null)}
+                onClick={handleSave}
+                className={`ml-auto rounded-full px-4 py-2 text-sm font-semibold ${state?.saved ? "bg-purple-50 text-purple-700" : "bg-gray-50 text-gray-700"}`}
+              >
+                <i className={state?.saved ? "ri-bookmark-fill" : "ri-bookmark-line"} /> 저장
+              </button>
+            </div>
+
+            {stateError && <p className="mt-3 text-sm text-red-600">{stateError}</p>}
+
+            <section className="mt-7">
+              <h2 className="mb-4 text-lg font-bold text-gray-900">댓글 {commentPage.totalElements}</h2>
+
+              <form onSubmit={handleCommentSubmit} className="mb-6 flex gap-2">
+                <label htmlFor="comment-content" className="sr-only">댓글 내용</label>
+                <input
+                  id="comment-content"
+                  value={commentText}
+                  onChange={(event) => setCommentText(event.target.value)}
+                  placeholder="댓글을 입력하세요"
+                  maxLength={1000}
+                  className="min-w-0 flex-1 rounded-full border border-gray-200 px-4 py-2.5 outline-none focus:border-purple-500"
+                />
+                <button
+                  type="submit"
+                  disabled={!commentText.trim() || commentSubmitting}
+                  className="rounded-full bg-purple-600 px-4 py-2.5 text-sm font-semibold text-white disabled:opacity-40"
+                >
+                  {commentSubmitting ? "저장 중" : "댓글 등록"}
+                </button>
+              </form>
+
+              {commentMessage && <p className="mb-4 text-sm text-gray-700">{commentMessage}</p>}
+
+              {comments.length === 0 ? (
+                <p className="rounded-2xl bg-gray-50 py-10 text-center text-sm text-gray-500">
+                  아직 작성된 댓글이 없습니다.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {comments.map((comment) => (
+                    <article key={comment.id} className="rounded-2xl bg-gray-50 p-4">
+                      <div className="mb-2 flex items-center justify-between gap-3">
+                        <p className="font-semibold text-gray-900">
+                          {comment.authorName ?? "탈퇴한 사용자"}
+                        </p>
+                        <time className="text-xs text-gray-500">{formatTime(comment.createdAt)}</time>
+                      </div>
+                      <p className="whitespace-pre-wrap text-sm leading-relaxed text-gray-700">{comment.content}</p>
+                    </article>
+                  ))}
+                </div>
+              )}
+
+              {commentPage.page + 1 < commentPage.totalPages && (
+                <button
+                  type="button"
+                  onClick={loadMoreComments}
+                  disabled={commentsLoadingMore}
+                  className="mt-4 w-full rounded-xl border border-gray-200 py-3 text-sm font-semibold text-gray-700"
+                >
+                  {commentsLoadingMore ? "불러오는 중" : "댓글 더 보기"}
+                </button>
+              )}
+            </section>
+          </article>
+        )}
       </PageWrapper>
     </>
   );

--- a/web/src/app/saved/page.test.tsx
+++ b/web/src/app/saved/page.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SavedPage from './page';
+import { fetchSavedCommunityPosts, unsaveCommunityPost } from '@/lib/api/community';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ back: vi.fn(), push: vi.fn() }),
+}));
+vi.mock('@/components/auth/ProtectedRoute', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/lib/api/community', () => ({
+  fetchSavedCommunityPosts: vi.fn(),
+  unsaveCommunityPost: vi.fn(),
+}));
+
+const post = {
+  id: '11111111-1111-1111-1111-111111111111',
+  author: { id: '22222222-2222-2222-2222-222222222222', name: 'saved-author' },
+  artist: null,
+  content: '실제로 저장한 게시글',
+  imageUrl: null,
+  likeCount: 3,
+  commentCount: 2,
+  createdAt: '2026-08-14T08:00:00Z',
+};
+
+const page = {
+  items: [post],
+  page: 0,
+  size: 20,
+  totalElements: 1,
+  totalPages: 1,
+  last: true,
+};
+
+describe('SavedPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchSavedCommunityPosts).mockResolvedValue(page);
+    vi.mocked(unsaveCommunityPost).mockResolvedValue({ liked: false, saved: false });
+  });
+
+  it('renders only posts saved by the authenticated user', async () => {
+    render(<SavedPage />);
+    expect(await screen.findByText('실제로 저장한 게시글')).toBeInTheDocument();
+    expect(screen.getByText('saved-author')).toBeInTheDocument();
+    expect(screen.queryByText('ARMY_Forever')).not.toBeInTheDocument();
+  });
+
+  it('renders a neutral empty state', async () => {
+    vi.mocked(fetchSavedCommunityPosts).mockResolvedValue({
+      ...page,
+      items: [],
+      totalElements: 0,
+      totalPages: 0,
+    });
+    render(<SavedPage />);
+    expect(await screen.findByText('저장한 게시글이 없습니다.')).toBeInTheDocument();
+  });
+
+  it('fails closed instead of showing static saved posts', async () => {
+    vi.mocked(fetchSavedCommunityPosts).mockRejectedValue(new Error('network'));
+    render(<SavedPage />);
+    expect(await screen.findByText('저장한 게시글을 불러오지 못했습니다.')).toBeInTheDocument();
+    expect(screen.queryByText('ARMY_Forever')).not.toBeInTheDocument();
+  });
+
+  it('removes a post only after the real unsave API succeeds', async () => {
+    render(<SavedPage />);
+    await screen.findByText('실제로 저장한 게시글');
+    fireEvent.click(screen.getByRole('button', { name: '저장 취소' }));
+
+    await waitFor(() => expect(unsaveCommunityPost).toHaveBeenCalledWith(post.id));
+    expect(await screen.findByText('저장한 게시글이 없습니다.')).toBeInTheDocument();
+  });
+});

--- a/web/src/app/saved/page.tsx
+++ b/web/src/app/saved/page.tsx
@@ -1,248 +1,183 @@
 "use client";
 
+import ProtectedRoute from "@/components/auth/ProtectedRoute";
 import PageHeader from "@/components/layout/PageHeader";
 import PageWrapper from "@/components/layout/PageWrapper";
-import ProtectedRoute from "@/components/auth/ProtectedRoute";
+import {
+  fetchSavedCommunityPosts,
+  unsaveCommunityPost,
+  type CommunityPost,
+} from "@/lib/api/community";
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+
+function formatTime(value: string) {
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
 
 export default function SavedPage() {
-  const [sortBy, setSortBy] = useState<'recent' | 'saved'>('recent');
-  const [bookmarkedPosts, setBookmarkedPosts] = useState([
-    {
-      id: 1,
-      author: {
-        name: 'ARMY_Forever',
-        avatar: 'https://readdy.ai/api/search-image?query=icon%2C%20cute%20purple%20heart%20avatar%2C%202.5D%20illustration%20style%2C%20the%20icon%20should%20take%20up%2070%20percent%20of%20the%20frame%2C%20isolated%20on%20white%20background%2C%20centered%20composition%2C%20soft%20lighting%2C%20vibrant%20colors&width=100&height=100&seq=saved001&orientation=squarish',
-        badge: 'VIP'
-      },
-      content: 'BTS 새 앨범 티저 영상 보셨나요? 진짜 너무 기대돼요! 💜 컴백 준비하는 모습 보니까 벌써부터 설레네요.',
-      image: 'https://readdy.ai/api/search-image?query=BTS%20comeback%20teaser%20concept%2C%20professional%20photography%2C%20purple%20theme%2C%20modern%20aesthetic%2C%20high%20quality%2C%20artistic%20composition%2C%20elegant%20lighting%2C%20vibrant%20colors%2C%20isolated%20on%20simple%20background&width=800&height=600&seq=saved002&orientation=landscape',
-      likes: 1234,
-      comments: 89,
-      time: '2시간 전',
-      savedTime: '오늘',
-      tags: ['BTS', '컴백']
-    },
-    {
-      id: 2,
-      author: {
-        name: 'Blink_Girl',
-        avatar: 'https://readdy.ai/api/search-image?query=icon%2C%20cute%20pink%20crown%20avatar%2C%202.5D%20illustration%20style%2C%20the%20icon%20should%20take%20up%2070%20percent%20of%20the%20frame%2C%20isolated%20on%20white%20background%2C%20centered%20composition%2C%20soft%20lighting%2C%20vibrant%20colors&width=100&height=100&seq=saved003&orientation=squarish',
-        badge: 'PRO'
-      },
-      content: 'BLACKPINK 월드투어 서울 공연 티켓팅 성공했어요! 🎉 드디어 직관할 수 있게 됐어요 ㅠㅠ',
-      image: 'https://readdy.ai/api/search-image?query=BLACKPINK%20concert%20stage%20performance%2C%20professional%20photography%2C%20pink%20and%20black%20theme%2C%20dynamic%20lighting%2C%20high%20energy%2C%20artistic%20composition%2C%20vibrant%20colors%2C%20isolated%20on%20simple%20background&width=800&height=600&seq=saved004&orientation=landscape',
-      likes: 892,
-      comments: 67,
-      time: '5시간 전',
-      savedTime: '오늘',
-      tags: ['BLACKPINK', '콘서트']
-    },
-    {
-      id: 3,
-      author: {
-        name: 'Kpop_Lover',
-        avatar: 'https://readdy.ai/api/search-image?query=icon%2C%20cute%20blue%20star%20avatar%2C%202.5D%20illustration%20style%2C%20the%20icon%20should%20take%20up%2070%20percent%20of%20the%20frame%2C%20isolated%20on%20white%20background%2C%20centered%20composition%2C%20soft%20lighting%2C%20vibrant%20colors&width=100&height=100&seq=saved005&orientation=squarish',
-        badge: 'VIP'
-      },
-      content: '오늘 음악방송 무대 레전드였어요! 직캠 보고 또 보고 있어요 👀',
-      image: 'https://readdy.ai/api/search-image?query=K-pop%20music%20show%20stage%20performance%2C%20professional%20photography%2C%20colorful%20lighting%2C%20energetic%20atmosphere%2C%20high%20quality%2C%20artistic%20composition%2C%20vibrant%20colors%2C%20isolated%20on%20simple%20background&width=800&height=600&seq=saved006&orientation=landscape',
-      likes: 567,
-      comments: 45,
-      time: '1일 전',
-      savedTime: '어제',
-      tags: ['음악방송', '무대']
-    },
-    {
-      id: 4,
-      author: {
-        name: 'Music_Fan',
-        avatar: 'https://readdy.ai/api/search-image?query=icon%2C%20cute%20orange%20music%20note%20avatar%2C%202.5D%20illustration%20style%2C%20the%20icon%20should%20take%20up%2070%20percent%20of%20the%20frame%2C%20isolated%20on%20white%20background%2C%20centered%20composition%2C%20soft%20lighting%2C%20vibrant%20colors&width=100&height=100&seq=saved007&orientation=squarish',
-        badge: 'PRO'
-      },
-      content: '이번 주 차트 순위 업데이트! 우리 아티스트 1위 유지 중 🏆',
-      image: 'https://readdy.ai/api/search-image?query=music%20chart%20ranking%20display%2C%20modern%20digital%20interface%2C%20colorful%20graphics%2C%20professional%20design%2C%20clean%20composition%2C%20vibrant%20colors%2C%20isolated%20on%20simple%20background&width=800&height=600&seq=saved008&orientation=landscape',
-      likes: 423,
-      comments: 34,
-      time: '2일 전',
-      savedTime: '2일 전',
-      tags: ['차트', '순위']
-    },
-    {
-      id: 5,
-      author: {
-        name: 'Fan_Club',
-        avatar: 'https://readdy.ai/api/search-image?query=icon%2C%20cute%20green%20clover%20avatar%2C%202.5D%20illustration%20style%2C%20the%20icon%20should%20take%20up%2070%20percent%20of%20the%20frame%2C%20isolated%20on%20white%20background%2C%20centered%20composition%2C%20soft%20lighting%2C%20vibrant%20colors&width=100&height=100&seq=saved009&orientation=squarish',
-        badge: 'VIP'
-      },
-      content: '팬미팅 현장 분위기 미쳤어요! 평생 잊지 못할 추억 💚',
-      image: 'https://readdy.ai/api/search-image?query=K-pop%20fan%20meeting%20event%2C%20happy%20fans%20and%20artists%20interaction%2C%20professional%20photography%2C%20warm%20atmosphere%2C%20joyful%20moment%2C%20vibrant%20colors%2C%20isolated%20on%20simple%20background&width=800&height=600&seq=saved010&orientation=landscape',
-      likes: 756,
-      comments: 52,
-      time: '3일 전',
-      savedTime: '3일 전',
-      tags: ['팬미팅', '이벤트']
-    }
-  ]);
+  const [posts, setPosts] = useState<CommunityPost[]>([]);
+  const [page, setPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [totalElements, setTotalElements] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [unsavingId, setUnsavingId] = useState<string | null>(null);
+  const [retryKey, setRetryKey] = useState(0);
 
-  const handleRemoveBookmark = (postId: number) => {
-    setBookmarkedPosts(bookmarkedPosts.filter(post => post.id !== postId));
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    setPosts([]);
+    fetchSavedCommunityPosts(0, 20, controller.signal)
+      .then((result) => {
+        if (controller.signal.aborted) return;
+        setPosts(result.items);
+        setPage(result.page);
+        setTotalPages(result.totalPages);
+        setTotalElements(result.totalElements);
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) setError("저장한 게시글을 불러오지 못했습니다.");
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
+  }, [retryKey]);
+
+  const handleUnsave = async (postId: string) => {
+    if (unsavingId) return;
+    setUnsavingId(postId);
+    setActionError(null);
+    try {
+      const result = await unsaveCommunityPost(postId);
+      if (result.saved) throw new Error("unsave failed");
+      setPosts((current) => current.filter((post) => post.id !== postId));
+      setTotalElements((current) => Math.max(0, current - 1));
+    } catch {
+      setActionError("저장을 취소하지 못했습니다.");
+    } finally {
+      setUnsavingId(null);
+    }
   };
 
-  const sortedPosts = [...bookmarkedPosts].sort((a, b) => {
-    if (sortBy === 'recent') {
-      return a.id - b.id;
+  const loadMore = async () => {
+    if (loadingMore || page + 1 >= totalPages) return;
+    setLoadingMore(true);
+    setActionError(null);
+    try {
+      const result = await fetchSavedCommunityPosts(page + 1, 20);
+      setPosts((current) => {
+        const seen = new Set(current.map((post) => post.id));
+        return [...current, ...result.items.filter((post) => !seen.has(post.id))];
+      });
+      setPage(result.page);
+      setTotalPages(result.totalPages);
+      setTotalElements(result.totalElements);
+    } catch {
+      setActionError("저장한 게시글을 더 불러오지 못했습니다.");
+    } finally {
+      setLoadingMore(false);
     }
-    return b.id - a.id;
-  });
+  };
 
   return (
     <ProtectedRoute>
-      <PageHeader
-        title="저장한 게시물"
-        rightAction={
-          <Link href="/search" className="w-9 h-9 flex items-center justify-center rounded-full hover:bg-gray-100">
-            <i className="ri-search-line text-xl text-gray-700"></i>
-          </Link>
-        }
-      />
-      <PageWrapper>
-        {/* Stats Card */}
-        <div className="bg-gradient-to-r from-purple-600 to-pink-600 rounded-2xl p-4 mb-4 shadow-lg text-white mx-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-white/90 text-sm mb-1">저장한 게시물</p>
-              <p className="text-3xl font-bold">{bookmarkedPosts.length}</p>
-            </div>
-            <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center backdrop-blur-sm">
-              <i className="ri-bookmark-fill text-3xl text-white"></i>
-            </div>
-          </div>
-        </div>
+      <PageHeader title="저장한 게시물" showBack />
+      <PageWrapper className="mx-auto max-w-3xl px-4 py-6">
+        {loading && <p className="py-16 text-center text-gray-500">저장한 게시글을 불러오는 중입니다.</p>}
 
-        {/* Sort Tabs */}
-        <div className="px-4 py-3">
-          <div className="bg-white rounded-full p-1 inline-flex border border-gray-100 shadow-sm">
+        {!loading && error && (
+          <div className="py-16 text-center">
+            <p className="text-gray-700">{error}</p>
             <button
-              onClick={() => setSortBy('recent')}
-              className={`px-4 py-1.5 rounded-full text-sm font-medium transition-all ${
-                sortBy === 'recent'
-                  ? 'bg-purple-600 text-white shadow-sm'
-                  : 'text-gray-600 hover:bg-gray-50'
-              }`}
+              type="button"
+              onClick={() => setRetryKey((value) => value + 1)}
+              className="mt-4 rounded-full bg-purple-600 px-5 py-2 text-sm font-semibold text-white"
             >
-              최신순
-            </button>
-            <button
-              onClick={() => setSortBy('saved')}
-              className={`px-4 py-1.5 rounded-full text-sm font-medium transition-all ${
-                sortBy === 'saved'
-                  ? 'bg-purple-600 text-white shadow-sm'
-                  : 'text-gray-600 hover:bg-gray-50'
-              }`}
-            >
-              저장순
+              다시 시도
             </button>
           </div>
-        </div>
+        )}
 
-        {/* Posts List */}
-        {sortedPosts.length > 0 ? (
-          <div className="px-4 space-y-4 pb-6">
-            {sortedPosts.map(post => (
-              <div key={post.id} className="bg-white rounded-2xl overflow-hidden shadow-sm border border-gray-100">
-                {/* Author Info */}
-                <div className="p-4 pb-3">
-                  <div className="flex items-center gap-3 mb-3">
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img 
-                      src={post.author.avatar}
-                      alt={post.author.name}
-                      className="w-10 h-10 rounded-full object-cover border border-gray-100"
-                    />
-                    <div className="flex-1">
-                      <div className="flex items-center gap-2">
-                        <h3 className="font-bold text-sm text-gray-900">{post.author.name}</h3>
-                        <span className="bg-gradient-to-r from-purple-600 to-pink-600 text-white text-[10px] px-2 py-0.5 rounded-full font-bold">
-                          {post.author.badge}
-                        </span>
+        {!loading && !error && (
+          <>
+            <div className="mb-5 rounded-2xl bg-gradient-to-r from-purple-600 to-pink-600 p-5 text-white shadow-lg">
+              <p className="text-sm text-white/80">저장한 게시글</p>
+              <p className="mt-1 text-3xl font-bold">{totalElements.toLocaleString()}</p>
+            </div>
+
+            {actionError && <p className="mb-4 text-sm text-red-600">{actionError}</p>}
+
+            {posts.length === 0 ? (
+              <p className="rounded-2xl bg-white py-16 text-center text-gray-500 shadow-sm">
+                저장한 게시글이 없습니다.
+              </p>
+            ) : (
+              <div className="space-y-4">
+                {posts.map((post) => (
+                  <article key={post.id} className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm">
+                    <header className="mb-3 flex items-center gap-3">
+                      <div
+                        aria-hidden="true"
+                        className="flex h-10 w-10 items-center justify-center rounded-full bg-purple-100 font-bold text-purple-700"
+                      >
+                        {post.author.name.slice(0, 1).toUpperCase()}
                       </div>
-                      <p className="text-xs text-gray-500">{post.time}</p>
-                    </div>
-                    <button
-                      onClick={() => handleRemoveBookmark(post.id)}
-                      className="w-9 h-9 flex items-center justify-center rounded-full hover:bg-purple-50 transition-colors"
-                    >
-                      <i className="ri-bookmark-fill text-xl text-purple-600"></i>
-                    </button>
-                  </div>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate font-semibold text-gray-900">{post.author.name}</p>
+                        <p className="text-xs text-gray-500">{formatTime(post.createdAt)}</p>
+                      </div>
+                      <button
+                        type="button"
+                        aria-label="저장 취소"
+                        onClick={() => handleUnsave(post.id)}
+                        disabled={unsavingId === post.id}
+                        className="rounded-full bg-purple-50 px-3 py-2 text-sm font-semibold text-purple-700 disabled:opacity-40"
+                      >
+                        <i className="ri-bookmark-fill" /> 저장 취소
+                      </button>
+                    </header>
 
-                  {/* Content */}
-                  <Link href="/post-detail">
-                    <p className="text-sm text-gray-900 leading-relaxed mb-3">
-                      {post.content}
-                    </p>
-
-                    {/* Tags */}
-                    <div className="flex flex-wrap gap-2 mb-3">
-                      {post.tags.map(tag => (
-                        <span key={tag} className="text-xs text-purple-600 bg-purple-50 px-2 py-1 rounded-full font-medium">
-                          #{tag}
-                        </span>
-                      ))}
-                    </div>
-
-                    {/* Image */}
-                    {post.image && (
-                      <div className="rounded-xl overflow-hidden mb-3">
-                        {/* eslint-disable-next-line @next/next/no-img-element */}
-                        <img 
-                          src={post.image}
-                          alt="Post"
-                          className="w-full h-48 object-cover object-top hover:scale-105 transition-transform duration-500"
+                    <Link href={`/post-detail?id=${post.id}`} aria-label={`${post.content} 상세 보기`}>
+                      <p className="whitespace-pre-wrap leading-relaxed text-gray-800">{post.content}</p>
+                      {post.imageUrl && (
+                        // eslint-disable-next-line @next/next/no-img-element -- validated external HTTPS URL must bypass Next host allowlists
+                        <img
+                          src={post.imageUrl}
+                          alt="게시글 첨부 이미지"
+                          referrerPolicy="no-referrer"
+                          className="mt-4 max-h-96 w-full rounded-xl object-cover"
                         />
+                      )}
+                      <div className="mt-4 flex gap-4 text-sm text-gray-500">
+                        <span><i className="ri-heart-line" /> {post.likeCount.toLocaleString()}</span>
+                        <span><i className="ri-chat-3-line" /> {post.commentCount.toLocaleString()}</span>
                       </div>
-                    )}
-                  </Link>
-
-                  {/* Stats */}
-                  <div className="flex items-center justify-between pt-3 border-t border-gray-50">
-                    <div className="flex items-center gap-4 text-sm text-gray-500">
-                      <span className="flex items-center gap-1 hover:text-pink-500 transition-colors">
-                        <i className="ri-heart-line"></i>
-                        {post.likes}
-                      </span>
-                      <span className="flex items-center gap-1 hover:text-blue-500 transition-colors">
-                        <i className="ri-chat-3-line"></i>
-                        {post.comments}
-                      </span>
-                    </div>
-                    <span className="text-xs text-gray-400 font-medium">
-                      저장: {post.savedTime}
-                    </span>
-                  </div>
-                </div>
+                    </Link>
+                  </article>
+                ))}
               </div>
-            ))}
-          </div>
-        ) : (
-          /* Empty State */
-          <div className="px-4 py-16 text-center">
-            <div className="w-24 h-24 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <i className="ri-bookmark-line text-5xl text-gray-400"></i>
-            </div>
-            <h3 className="text-lg font-bold text-gray-900 mb-2">저장한 게시물이 없어요</h3>
-            <p className="text-sm text-gray-500 mb-6">
-              마음에 드는 게시물을 저장해보세요
-            </p>
-            <Link
-              href="/community"
-              className="inline-block bg-gradient-to-r from-purple-600 to-pink-600 text-white px-6 py-3 rounded-full font-medium hover:shadow-lg transition-shadow"
-            >
-              게시물 둘러보기
-            </Link>
-          </div>
+            )}
+
+            {page + 1 < totalPages && (
+              <button
+                type="button"
+                onClick={loadMore}
+                disabled={loadingMore}
+                className="mt-5 w-full rounded-xl border border-gray-200 bg-white py-3 font-semibold text-gray-700"
+              >
+                {loadingMore ? "불러오는 중" : "더 보기"}
+              </button>
+            )}
+          </>
         )}
       </PageWrapper>
     </ProtectedRoute>

--- a/web/src/lib/api-response.test.ts
+++ b/web/src/lib/api-response.test.ts
@@ -6,11 +6,19 @@ describe('isIsoInstant', () => {
     '2026-08-14T02:00:00Z',
     '2026-08-14T02:00:00.123456Z',
     '2026-08-14T11:00:00+09:00',
+    '2026-08-14T20:00:00+18:00',
   ])('accepts an ISO-8601 instant with an explicit offset: %s', (value) => {
     expect(isIsoInstant(value)).toBe(true);
   });
 
   it('rejects a date-time without an explicit UTC offset', () => {
     expect(isIsoInstant('2026-08-14T02:00:00')).toBe(false);
+  });
+
+  it.each([
+    '2026-08-14T20:00:00+18:01',
+    '2026-08-14T20:00:00-18:01',
+  ])('rejects an offset outside the Java Instant range: %s', (value) => {
+    expect(isIsoInstant(value)).toBe(false);
   });
 });

--- a/web/src/lib/api-response.ts
+++ b/web/src/lib/api-response.ts
@@ -53,10 +53,14 @@ export function isIsoDateTime(value: unknown): value is string {
 }
 
 export function isIsoInstant(value: unknown): value is string {
-  return (
-    isIsoDateTime(value) &&
-    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/.test(value)
-  );
+  if (!isIsoDateTime(value)) return false;
+  const match = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:(Z)|[+-](\d{2}):(\d{2}))$/.exec(value);
+  if (!match) return false;
+  if (match[1] === 'Z') return true;
+
+  const offsetHours = Number(match[2]);
+  const offsetMinutes = Number(match[3]);
+  return offsetHours < 18 || (offsetHours === 18 && offsetMinutes === 0);
 }
 
 export function unwrapApiResponse<T>(

--- a/web/src/lib/api/artist.test.ts
+++ b/web/src/lib/api/artist.test.ts
@@ -5,7 +5,7 @@ vi.mock('@/lib/api-client', () => ({
 }));
 
 import { apiClient } from '@/lib/api-client';
-import { fetchArtistDetail } from './artist';
+import { fetchActiveArtists, fetchArtistDetail } from './artist';
 
 const mockedGet = vi.mocked(apiClient.get);
 
@@ -54,5 +54,61 @@ describe('fetchArtistDetail', () => {
     await expect(fetchArtistDetail(artist.id)).rejects.toThrow(
       '아티스트 API 응답이 올바르지 않습니다.'
     );
+  });
+});
+
+describe('fetchActiveArtists', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const summary = {
+    id: artist.id,
+    name: artist.name,
+    englishName: artist.englishName,
+    agency: artist.agency,
+    profileImageUrl: artist.profileImageUrl,
+    isGroup: artist.isGroup,
+  };
+
+  it('loads active artist choices from the real paginated API', async () => {
+    mockedGet.mockResolvedValue({
+      data: {
+        success: true,
+        data: { content: [summary], totalElements: 1, page: 0, size: 100, totalPages: 1 },
+      },
+    });
+
+    await expect(fetchActiveArtists()).resolves.toEqual([summary]);
+    expect(mockedGet).toHaveBeenCalledWith('/artists', {
+      params: { activeOnly: true, page: 0, size: 100, sortBy: 'name', sortDir: 'asc' },
+      signal: undefined,
+    });
+  });
+
+  it('rejects repeated or incomplete rows across pages', async () => {
+    mockedGet
+      .mockResolvedValueOnce({
+        data: {
+          success: true,
+          data: { content: [summary], totalElements: 101, page: 0, size: 100, totalPages: 2 },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          success: true,
+          data: { content: [summary], totalElements: 101, page: 1, size: 100, totalPages: 2 },
+        },
+      });
+
+    await expect(fetchActiveArtists()).rejects.toThrow('아티스트 목록 API 응답이 올바르지 않습니다.');
+  });
+
+  it.each([
+    { content: [{ ...summary, id: 7 }], totalElements: 1, page: 0, size: 100, totalPages: 1 },
+    { content: [summary], totalElements: -1, page: 0, size: 100, totalPages: 1 },
+    { content: [summary], totalElements: 1, page: 0, size: 100, totalPages: 2 },
+    { content: [summary], totalElements: 101, page: 1, size: 100, totalPages: 2 },
+  ])('rejects malformed artist list payloads: %o', async (data) => {
+    mockedGet.mockResolvedValue({ data: { success: true, data } });
+    await expect(fetchActiveArtists()).rejects.toThrow('아티스트 목록 API 응답이 올바르지 않습니다.');
   });
 });

--- a/web/src/lib/api/artist.ts
+++ b/web/src/lib/api/artist.ts
@@ -24,6 +24,23 @@ export interface ArtistDetail {
   createdAt: string;
 }
 
+export interface ArtistSummary {
+  id: string;
+  name: string;
+  englishName: string | null;
+  agency: string | null;
+  profileImageUrl: string | null;
+  isGroup: boolean;
+}
+
+interface ArtistListResponse {
+  content: ArtistSummary[];
+  totalElements: number;
+  page: number;
+  size: number;
+  totalPages: number;
+}
+
 function isArtistDetail(value: unknown): value is ArtistDetail {
   if (!isRecord(value)) return false;
   return (
@@ -42,6 +59,41 @@ function isArtistDetail(value: unknown): value is ArtistDetail {
   );
 }
 
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) >= 0;
+}
+
+function isArtistSummary(value: unknown): value is ArtistSummary {
+  return isRecord(value) &&
+    isUuid(value.id) &&
+    isNonEmptyString(value.name) &&
+    isNullableString(value.englishName) &&
+    isNullableString(value.agency) &&
+    isNullableString(value.profileImageUrl) &&
+    typeof value.isGroup === 'boolean';
+}
+
+function isArtistListResponse(value: unknown): value is ArtistListResponse {
+  if (!isRecord(value)) return false;
+  if (
+    !Array.isArray(value.content) ||
+    !value.content.every(isArtistSummary) ||
+    !isNonNegativeInteger(value.totalElements) ||
+    !isNonNegativeInteger(value.page) ||
+    !Number.isInteger(value.size) ||
+    (value.size as number) <= 0 ||
+    !isNonNegativeInteger(value.totalPages)
+  ) return false;
+
+  const expectedPages = value.totalElements === 0
+    ? 0
+    : Math.ceil((value.totalElements as number) / (value.size as number));
+  return value.totalPages === expectedPages &&
+    (value.totalPages === 0
+      ? value.page === 0 && value.content.length === 0
+      : (value.page as number) < (value.totalPages as number));
+}
+
 export async function fetchArtistDetail(
   id: string,
   signal?: AbortSignal
@@ -52,4 +104,52 @@ export async function fetchArtistDetail(
     '아티스트 API 응답이 올바르지 않습니다.',
     isArtistDetail
   );
+}
+
+export async function fetchActiveArtists(signal?: AbortSignal): Promise<ArtistSummary[]> {
+  const all: ArtistSummary[] = [];
+  const seenIds = new Set<string>();
+  let page = 0;
+  let totalPages = 1;
+  let expectedTotalElements: number | null = null;
+  let expectedTotalPages: number | null = null;
+
+  do {
+    const response = await apiClient.get<ApiResponse<ArtistListResponse>>('/artists', {
+      params: { activeOnly: true, page, size: 100, sortBy: 'name', sortDir: 'asc' },
+      signal,
+    });
+    const data = unwrapApiResponse(
+      response.data,
+      '아티스트 목록 API 응답이 올바르지 않습니다.',
+      isArtistListResponse,
+    );
+    if (data.page !== page || data.size !== 100) {
+      throw new Error('아티스트 목록 API 응답이 올바르지 않습니다.');
+    }
+    if (expectedTotalElements === null) {
+      expectedTotalElements = data.totalElements;
+      expectedTotalPages = data.totalPages;
+    } else if (
+      data.totalElements !== expectedTotalElements ||
+      data.totalPages !== expectedTotalPages
+    ) {
+      throw new Error('아티스트 목록 API 응답이 올바르지 않습니다.');
+    }
+    for (const artist of data.content) {
+      if (seenIds.has(artist.id)) {
+        throw new Error('아티스트 목록 API 응답이 올바르지 않습니다.');
+      }
+      seenIds.add(artist.id);
+      all.push(artist);
+    }
+    totalPages = data.totalPages;
+    page += 1;
+  } while (page < totalPages);
+
+  if (all.length !== expectedTotalElements) {
+    throw new Error('아티스트 목록 API 응답이 올바르지 않습니다.');
+  }
+
+  return all;
 }

--- a/web/src/lib/api/community.test.ts
+++ b/web/src/lib/api/community.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/api-client';
+import {
+  createCommunityComment,
+  createCommunityPost,
+  fetchCommunityComments,
+  fetchCommunityPost,
+  fetchCommunityPosts,
+  likeCommunityPost,
+  saveCommunityPost,
+  unlikeCommunityPost,
+  unsaveCommunityPost,
+} from './community';
+
+const dto = {
+  id: '11111111-1111-1111-1111-111111111111',
+  authorId: '22222222-2222-2222-2222-222222222222',
+  authorName: 'real-author',
+  artistId: '33333333-3333-3333-3333-333333333333',
+  artistName: 'Real Artist',
+  artistProfileImageUrl: null,
+  content: '실제 PostgreSQL 게시글',
+  imageUrl: null,
+  likeCount: 2,
+  commentCount: 1,
+  createdAt: '2026-08-14T08:00:00Z',
+};
+
+const mapped = {
+  id: dto.id,
+  author: { id: dto.authorId, name: dto.authorName },
+  artist: { id: dto.artistId, name: dto.artistName, profileImageUrl: null },
+  content: dto.content,
+  imageUrl: null,
+  likeCount: 2,
+  commentCount: 1,
+  createdAt: dto.createdAt,
+};
+
+const pageDto = {
+  content: [dto],
+  page: 0,
+  size: 20,
+  totalElements: 1,
+  totalPages: 1,
+  last: true,
+};
+
+describe('community API', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('validates and maps the persisted community page', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { success: true, data: pageDto } });
+
+    await expect(fetchCommunityPosts('LATEST', 0, 20)).resolves.toEqual({
+      items: [mapped],
+      page: 0,
+      size: 20,
+      totalElements: 1,
+      totalPages: 1,
+      last: true,
+    });
+    expect(apiClient.get).toHaveBeenCalledWith('/community/posts', {
+      params: { sort: 'LATEST', page: 0, size: 20 },
+      signal: undefined,
+    });
+  });
+
+  it.each([
+    { ...pageDto, content: [{ ...dto, id: 1 }] },
+    { ...pageDto, content: [{ ...dto, createdAt: '2026-08-14T08:00:00' }] },
+    { ...pageDto, content: [{ ...dto, likeCount: -1 }] },
+    { ...pageDto, content: [{ ...dto, artistId: null, artistName: 'orphan' }] },
+    { ...pageDto, size: 0 },
+    { ...pageDto, totalPages: 2 },
+  ])('rejects malformed successful pages: %o', async (data) => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { success: true, data } });
+    await expect(fetchCommunityPosts()).rejects.toThrow('커뮤니티 API 응답이 올바르지 않습니다.');
+  });
+
+  it('fetches a validated detail without UUID number coercion', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { success: true, data: dto } });
+    await expect(fetchCommunityPost(dto.id)).resolves.toEqual(mapped);
+    expect(apiClient.get).toHaveBeenCalledWith(`/community/posts/${dto.id}`, { signal: undefined });
+  });
+
+  it('creates a post with the selected real artist UUID', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { success: true, data: dto } });
+    const request = { artistId: dto.artistId, content: dto.content };
+
+    await expect(createCommunityPost(request)).resolves.toEqual(mapped);
+    expect(apiClient.post).toHaveBeenCalledWith('/community/posts', request);
+  });
+
+  it('validates like and save mutation states', async () => {
+    vi.mocked(apiClient.post)
+      .mockResolvedValueOnce({ data: { success: true, data: { liked: true, saved: false } } })
+      .mockResolvedValueOnce({ data: { success: true, data: { liked: true, saved: true } } });
+    vi.mocked(apiClient.delete)
+      .mockResolvedValueOnce({ data: { success: true, data: { liked: false, saved: true } } })
+      .mockResolvedValueOnce({ data: { success: true, data: { liked: false, saved: false } } });
+
+    await expect(likeCommunityPost(dto.id)).resolves.toEqual({ liked: true, saved: false });
+    await expect(saveCommunityPost(dto.id)).resolves.toEqual({ liked: true, saved: true });
+    await expect(unlikeCommunityPost(dto.id)).resolves.toEqual({ liked: false, saved: true });
+    await expect(unsaveCommunityPost(dto.id)).resolves.toEqual({ liked: false, saved: false });
+  });
+});
+
+const commentDto = {
+  id: '44444444-4444-4444-4444-444444444444',
+  postId: dto.id,
+  userId: dto.authorId,
+  content: '실제 댓글',
+  status: 'APPROVED',
+  parentCommentId: null,
+  createdAt: '2026-08-14T09:00:00Z',
+  authorName: 'comment-author',
+};
+
+const commentPageDto = {
+  content: [commentDto],
+  totalElements: 1,
+  page: 0,
+  size: 20,
+  totalPages: 1,
+};
+
+describe('community comment API', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('validates persisted comments and preserves the real author name', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { success: true, data: commentPageDto } });
+
+    await expect(fetchCommunityComments(dto.id)).resolves.toEqual({
+      items: [commentDto],
+      totalElements: 1,
+      page: 0,
+      size: 20,
+      totalPages: 1,
+    });
+    expect(apiClient.get).toHaveBeenCalledWith(`/community/posts/${dto.id}/comments`, {
+      params: { page: 0, size: 20 },
+      signal: undefined,
+    });
+  });
+
+  it.each([
+    { ...commentPageDto, content: [{ ...commentDto, postId: 'not-a-uuid' }] },
+    { ...commentPageDto, content: [{ ...commentDto, createdAt: '2026-08-14T09:00:00' }] },
+    { ...commentPageDto, content: [{ ...commentDto, authorName: 7 }] },
+    { ...commentPageDto, totalPages: 2 },
+  ])('rejects malformed comment pages: %o', async (data) => {
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { success: true, data } });
+    await expect(fetchCommunityComments(dto.id)).rejects.toThrow(
+      '커뮤니티 댓글 API 응답이 올바르지 않습니다.',
+    );
+  });
+
+  it('creates a comment without sending a user id', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { success: true, data: commentDto } });
+
+    await expect(createCommunityComment(dto.id, '실제 댓글')).resolves.toEqual(commentDto);
+    expect(apiClient.post).toHaveBeenCalledWith(`/community/posts/${dto.id}/comments`, {
+      content: '실제 댓글',
+      parentCommentId: null,
+    });
+  });
+});

--- a/web/src/lib/api/community.ts
+++ b/web/src/lib/api/community.ts
@@ -1,0 +1,409 @@
+import { apiClient } from '@/lib/api-client';
+import {
+  isIsoInstant,
+  isNonEmptyString,
+  isRecord,
+  isUuid,
+  unwrapApiResponse,
+} from '@/lib/api-response';
+import type { ApiResponse } from '@/types/api';
+
+export type CommunitySort = 'LATEST' | 'POPULAR';
+
+interface CommunityPostDto {
+  id: string;
+  authorId: string;
+  authorName: string;
+  artistId: string | null;
+  artistName: string | null;
+  artistProfileImageUrl: string | null;
+  content: string;
+  imageUrl: string | null;
+  likeCount: number;
+  commentCount: number;
+  createdAt: string;
+}
+
+interface CommunityPageDto {
+  content: CommunityPostDto[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  last: boolean;
+}
+
+export interface CommunityPost {
+  id: string;
+  author: { id: string; name: string };
+  artist: { id: string; name: string; profileImageUrl: string | null } | null;
+  content: string;
+  imageUrl: string | null;
+  likeCount: number;
+  commentCount: number;
+  createdAt: string;
+}
+
+export interface CommunityPage {
+  items: CommunityPost[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  last: boolean;
+}
+
+export interface CommunityPostState {
+  liked: boolean;
+  saved: boolean;
+}
+
+export interface CreateCommunityPostInput {
+  artistId: string | null;
+  content: string;
+}
+
+type CommunityCommentStatus = 'APPROVED' | 'PENDING' | 'BLOCKED';
+
+interface CommunityCommentDto {
+  id: string;
+  postId: string;
+  userId: string;
+  content: string;
+  status: CommunityCommentStatus;
+  parentCommentId: string | null;
+  createdAt: string;
+  authorName: string | null;
+}
+
+interface CommunityCommentPageDto {
+  content: CommunityCommentDto[];
+  totalElements: number;
+  page: number;
+  size: number;
+  totalPages: number;
+}
+
+export interface CommunityComment {
+  id: string;
+  postId: string;
+  userId: string;
+  content: string;
+  status: CommunityCommentStatus;
+  parentCommentId: string | null;
+  createdAt: string;
+  authorName: string | null;
+}
+
+export interface CommunityCommentPage {
+  items: CommunityComment[];
+  totalElements: number;
+  page: number;
+  size: number;
+  totalPages: number;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) >= 0;
+}
+
+function isNullableSafeHttpsUrl(value: unknown): value is string | null {
+  if (value === null) return true;
+  if (typeof value !== 'string') return false;
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol.toLowerCase() === 'https:' &&
+      url.hostname.length > 0 &&
+      url.username === '' &&
+      url.password === '' &&
+      (url.port === '' || url.port === '443')
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isCommunityPostDto(value: unknown): value is CommunityPostDto {
+  if (!isRecord(value)) return false;
+
+  const artistIsConsistent = value.artistId === null
+    ? value.artistName === null && value.artistProfileImageUrl === null
+    : isUuid(value.artistId) &&
+      isNonEmptyString(value.artistName) &&
+      isNullableSafeHttpsUrl(value.artistProfileImageUrl);
+
+  return (
+    isUuid(value.id) &&
+    isUuid(value.authorId) &&
+    isNonEmptyString(value.authorName) &&
+    artistIsConsistent &&
+    isNonEmptyString(value.content) &&
+    isNullableSafeHttpsUrl(value.imageUrl) &&
+    isNonNegativeInteger(value.likeCount) &&
+    isNonNegativeInteger(value.commentCount) &&
+    isIsoInstant(value.createdAt)
+  );
+}
+
+function isCommunityPageDto(value: unknown): value is CommunityPageDto {
+  if (!isRecord(value)) return false;
+  if (
+    !Array.isArray(value.content) ||
+    !value.content.every(isCommunityPostDto) ||
+    !isNonNegativeInteger(value.page) ||
+    !Number.isInteger(value.size) ||
+    (value.size as number) <= 0 ||
+    !isNonNegativeInteger(value.totalElements) ||
+    !isNonNegativeInteger(value.totalPages) ||
+    typeof value.last !== 'boolean'
+  ) {
+    return false;
+  }
+
+  const page = value.page as number;
+  const size = value.size as number;
+  const totalElements = value.totalElements as number;
+  const totalPages = value.totalPages as number;
+  const expectedPages = totalElements === 0 ? 0 : Math.ceil(totalElements / size);
+
+  if (totalPages !== expectedPages || value.content.length > size) return false;
+  if (totalPages === 0) {
+    return page === 0 && value.content.length === 0 && value.last === true;
+  }
+  return page < totalPages && value.last === (page === totalPages - 1);
+}
+
+function isCommunityPostState(value: unknown): value is CommunityPostState {
+  return isRecord(value) && typeof value.liked === 'boolean' && typeof value.saved === 'boolean';
+}
+
+function isCommunityCommentDto(value: unknown): value is CommunityCommentDto {
+  return isRecord(value) &&
+    isUuid(value.id) &&
+    isUuid(value.postId) &&
+    isUuid(value.userId) &&
+    isNonEmptyString(value.content) &&
+    (value.status === 'APPROVED' || value.status === 'PENDING' || value.status === 'BLOCKED') &&
+    (value.parentCommentId === null || isUuid(value.parentCommentId)) &&
+    isIsoInstant(value.createdAt) &&
+    (value.authorName === null || isNonEmptyString(value.authorName));
+}
+
+function isCommunityCommentPageDto(value: unknown): value is CommunityCommentPageDto {
+  if (!isRecord(value)) return false;
+  if (
+    !Array.isArray(value.content) ||
+    !value.content.every(isCommunityCommentDto) ||
+    !isNonNegativeInteger(value.totalElements) ||
+    !isNonNegativeInteger(value.page) ||
+    !Number.isInteger(value.size) ||
+    (value.size as number) <= 0 ||
+    !isNonNegativeInteger(value.totalPages)
+  ) return false;
+
+  const page = value.page as number;
+  const size = value.size as number;
+  const totalElements = value.totalElements as number;
+  const totalPages = value.totalPages as number;
+  const expectedPages = totalElements === 0 ? 0 : Math.ceil(totalElements / size);
+  if (totalPages !== expectedPages || value.content.length > size) return false;
+  return totalPages === 0
+    ? page === 0 && value.content.length === 0
+    : page < totalPages;
+}
+
+function mapComment(dto: CommunityCommentDto): CommunityComment {
+  return {
+    id: dto.id,
+    postId: dto.postId,
+    userId: dto.userId,
+    content: dto.content,
+    status: dto.status,
+    parentCommentId: dto.parentCommentId,
+    createdAt: dto.createdAt,
+    authorName: dto.authorName,
+  };
+}
+
+function mapPost(dto: CommunityPostDto): CommunityPost {
+  return {
+    id: dto.id,
+    author: { id: dto.authorId, name: dto.authorName },
+    artist: dto.artistId === null
+      ? null
+      : {
+          id: dto.artistId,
+          name: dto.artistName as string,
+          profileImageUrl: dto.artistProfileImageUrl,
+        },
+    content: dto.content,
+    imageUrl: dto.imageUrl,
+    likeCount: dto.likeCount,
+    commentCount: dto.commentCount,
+    createdAt: dto.createdAt,
+  };
+}
+
+function mapPage(dto: CommunityPageDto): CommunityPage {
+  return {
+    items: dto.content.map(mapPost),
+    page: dto.page,
+    size: dto.size,
+    totalElements: dto.totalElements,
+    totalPages: dto.totalPages,
+    last: dto.last,
+  };
+}
+
+export async function fetchCommunityPosts(
+  sort: CommunitySort = 'LATEST',
+  page = 0,
+  size = 20,
+  signal?: AbortSignal,
+): Promise<CommunityPage> {
+  const response = await apiClient.get<ApiResponse<CommunityPageDto>>('/community/posts', {
+    params: { sort, page, size },
+    signal,
+  });
+  const data = unwrapApiResponse(
+    response.data,
+    '커뮤니티 API 응답이 올바르지 않습니다.',
+    isCommunityPageDto,
+  );
+  if (data.page !== page || data.size !== size) {
+    throw new Error('커뮤니티 API 응답이 올바르지 않습니다.');
+  }
+  return mapPage(data);
+}
+
+export async function fetchCommunityPost(
+  postId: string,
+  signal?: AbortSignal,
+): Promise<CommunityPost> {
+  if (!isUuid(postId)) throw new Error('게시글 ID가 올바르지 않습니다.');
+  const response = await apiClient.get<ApiResponse<CommunityPostDto>>(
+    `/community/posts/${postId}`,
+    { signal },
+  );
+  return mapPost(unwrapApiResponse(
+    response.data,
+    '커뮤니티 상세 API 응답이 올바르지 않습니다.',
+    isCommunityPostDto,
+  ));
+}
+
+export async function createCommunityPost(
+  input: CreateCommunityPostInput,
+): Promise<CommunityPost> {
+  const response = await apiClient.post<ApiResponse<CommunityPostDto>>('/community/posts', input);
+  return mapPost(unwrapApiResponse(
+    response.data,
+    '커뮤니티 작성 API 응답이 올바르지 않습니다.',
+    isCommunityPostDto,
+  ));
+}
+
+async function mutateState(method: 'post' | 'delete', path: string): Promise<CommunityPostState> {
+  const response = await apiClient[method]<ApiResponse<CommunityPostState>>(path);
+  return unwrapApiResponse(
+    response.data,
+    '커뮤니티 상태 API 응답이 올바르지 않습니다.',
+    isCommunityPostState,
+  );
+}
+
+export const likeCommunityPost = (postId: string) =>
+  mutateState('post', `/community/posts/${postId}/likes`);
+export const unlikeCommunityPost = (postId: string) =>
+  mutateState('delete', `/community/posts/${postId}/likes`);
+export const saveCommunityPost = (postId: string) =>
+  mutateState('post', `/community/posts/${postId}/saved`);
+export const unsaveCommunityPost = (postId: string) =>
+  mutateState('delete', `/community/posts/${postId}/saved`);
+
+export async function fetchCommunityPostState(
+  postId: string,
+  signal?: AbortSignal,
+): Promise<CommunityPostState> {
+  const response = await apiClient.get<ApiResponse<CommunityPostState>>(
+    `/community/me/posts/${postId}/state`,
+    { signal },
+  );
+  return unwrapApiResponse(
+    response.data,
+    '커뮤니티 상태 API 응답이 올바르지 않습니다.',
+    isCommunityPostState,
+  );
+}
+
+export async function fetchSavedCommunityPosts(
+  page = 0,
+  size = 20,
+  signal?: AbortSignal,
+): Promise<CommunityPage> {
+  const response = await apiClient.get<ApiResponse<CommunityPageDto>>('/community/me/saved', {
+    params: { page, size },
+    signal,
+  });
+  const data = unwrapApiResponse(
+    response.data,
+    '저장한 게시글 API 응답이 올바르지 않습니다.',
+    isCommunityPageDto,
+  );
+  if (data.page !== page || data.size !== size) {
+    throw new Error('저장한 게시글 API 응답이 올바르지 않습니다.');
+  }
+  return mapPage(data);
+}
+
+export async function fetchCommunityComments(
+  postId: string,
+  page = 0,
+  size = 20,
+  signal?: AbortSignal,
+): Promise<CommunityCommentPage> {
+  if (!isUuid(postId)) throw new Error('게시글 ID가 올바르지 않습니다.');
+  const response = await apiClient.get<ApiResponse<CommunityCommentPageDto>>(
+    `/community/posts/${postId}/comments`,
+    { params: { page, size }, signal },
+  );
+  const data = unwrapApiResponse(
+    response.data,
+    '커뮤니티 댓글 API 응답이 올바르지 않습니다.',
+    isCommunityCommentPageDto,
+  );
+  if (data.page !== page || data.size !== size || data.content.some((comment) => comment.postId !== postId)) {
+    throw new Error('커뮤니티 댓글 API 응답이 올바르지 않습니다.');
+  }
+  return {
+    items: data.content.map(mapComment),
+    totalElements: data.totalElements,
+    page: data.page,
+    size: data.size,
+    totalPages: data.totalPages,
+  };
+}
+
+export async function createCommunityComment(
+  postId: string,
+  content: string,
+  parentCommentId: string | null = null,
+): Promise<CommunityComment> {
+  if (!isUuid(postId) || (parentCommentId !== null && !isUuid(parentCommentId))) {
+    throw new Error('댓글 요청 ID가 올바르지 않습니다.');
+  }
+  const response = await apiClient.post<ApiResponse<CommunityCommentDto>>(
+    `/community/posts/${postId}/comments`,
+    { content, parentCommentId },
+  );
+  const data = unwrapApiResponse(
+    response.data,
+    '커뮤니티 댓글 작성 API 응답이 올바르지 않습니다.',
+    isCommunityCommentDto,
+  );
+  if (data.postId !== postId) {
+    throw new Error('커뮤니티 댓글 작성 API 응답이 올바르지 않습니다.');
+  }
+  return mapComment(data);
+}


### PR DESCRIPTION
## 변경 내용

- Flyway V122로 `community_posts`, `community_saved_posts`를 추가하고 기존 댓글의 게시글 ID 길이를 UUID에 맞게 확장했습니다.
- 실제 PostgreSQL 기반 커뮤니티 게시글 생성·목록·상세·인기순 조회를 구현했습니다.
- 좋아요·저장·취소는 JWT principal 기준으로 사용자별 격리하고, 동시 요청에도 중복 행이 생기지 않도록 처리했습니다.
- 댓글 작성자명을 실제 사용자 데이터에서 일괄 조회하고, 다른 게시글의 댓글을 부모로 지정하는 관계를 차단했습니다.
- 모더레이션 장애·비활성화·호출 예외는 게시글 공개를 차단하고 503을 반환하며, 댓글은 PENDING으로 유지합니다.
- 저장 목록 pagination은 PUBLISHED 게시글만 content와 metadata에 포함합니다.
- 커뮤니티·게시글 작성·상세·저장 화면의 정적 mock 데이터를 제거하고 실제 Spring API에 연결했습니다.
- active artist 목록과 community DTO를 런타임에서 검증하고 잘못된 UUID·페이지 metadata·Instant를 fail-closed 처리했습니다.
- 임의 사용자 이미지 URL 입력은 검증 가능한 업로드 저장소가 없어 생성 계약에서 제외했습니다.

## 검증

- Spring 전체 734 tests, 실패 0, 오류 0, 조건부 skip 4
- PostgreSQL 14: Flyway V122 적용, Hibernate validate 및 community vertical integration 통과
- PostgreSQL 16: Flyway V122 적용 통과
- Frontend Vitest: 58 files / 268 tests 통과
- TypeScript: 통과
- 변경 파일 ESLint: 통과
- Next.js production build: 통과
- 실제 PostgreSQL → Spring API → Next browser E2E: 1/1 통과
- frozen patch secret/debug scan: 이상 없음

## 운영 배포 후 확인 항목

- V122 적용 상태와 Spring health
- 비로그인 community 조회 및 인증 mutation 경계
- 로그인 사용자의 글 작성·좋아요·저장·댓글 흐름
- `/community`, `/post-detail`, `/saved` 브라우저 console 오류
