### PR TITLE
fix: 커뮤니티 검토 후속 오류 수정

### DIFF
--- a/backend/src/main/kotlin/com/fanpulse/application/service/community/CommunityServiceImpl.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/service/community/CommunityServiceImpl.kt
@@ -40,6 +40,7 @@ class CommunityServiceImpl(
         }
         val content = request.content.trim()
         require(content.isNotEmpty()) { "게시글 내용은 비어 있을 수 없습니다" }
+        require(content.length <= 5_000) { "게시글 내용은 5,000자를 초과할 수 없습니다" }
 
         val moderationResult = try {
             moderation.checkContent(content)
@@ -52,6 +53,7 @@ class CommunityServiceImpl(
         val moderationModel = moderationResult.modelUsed.trim().lowercase()
         if (
             moderationResult.error != null ||
+            moderationModel.isBlank() ||
             moderationModel == "fallback" ||
             moderationModel == "noop"
         ) {
@@ -59,7 +61,10 @@ class CommunityServiceImpl(
                 "모더레이션 서비스를 사용할 수 없어 게시글을 저장하지 않았습니다"
             )
         }
-        require(!moderationResult.isFlagged && !moderationResult.action.equals("block", ignoreCase = true)) {
+        require(
+            !moderationResult.isFlagged &&
+                moderationResult.action.equals("allow", ignoreCase = true)
+        ) {
             "허용되지 않는 게시글 내용입니다"
         }
 
@@ -110,9 +115,12 @@ class CommunityServiceImpl(
     @Transactional
     override fun unsave(userId: UUID, postId: UUID): CommunityPostState {
         requireUser(userId)
-        lockPublishedPost(postId)
+        posts.findByIdForUpdate(postId) ?: throw NoSuchElementException("게시글을 찾을 수 없습니다")
         savedPosts.deleteByUserIdAndPostId(userId, postId)
-        return getState(userId, postId)
+        return CommunityPostState(
+            liked = likes.existsByUserIdAndTargetTypeAndTargetId(userId, POST_TARGET_TYPE, postId),
+            saved = false
+        )
     }
 
     override fun getState(userId: UUID, postId: UUID): CommunityPostState {

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/persistence/community/CommunityRepositories.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/persistence/community/CommunityRepositories.kt
@@ -21,6 +21,12 @@ interface CommunityPostJpaRepository : JpaRepository<CommunityPost, UUID> {
     fun findPublishedByIdForUpdate(@Param("id") id: UUID): CommunityPost?
 
     @Query(
+        value = "SELECT * FROM community_posts WHERE id = :id FOR UPDATE",
+        nativeQuery = true
+    )
+    fun findByIdForUpdate(@Param("id") id: UUID): CommunityPost?
+
+    @Query(
         value = """
             SELECT p.*
             FROM community_posts p

--- a/backend/src/test/kotlin/com/fanpulse/application/service/community/CommunityServiceIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/application/service/community/CommunityServiceIntegrationTest.kt
@@ -12,6 +12,7 @@ import com.fanpulse.infrastructure.persistence.content.ArtistJpaRepository
 import com.fanpulse.infrastructure.persistence.identity.UserJpaRepositoryInterface
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
@@ -189,6 +190,25 @@ class CommunityServiceIntegrationTest {
     }
 
     @Test
+    fun `only an explicit allow verdict with a named source publishes a post`() {
+        val owner = users.save(User(email = "moderation-verdict@example.com", username = "moderation-verdict"))
+
+        listOf("review", "", "unknown").forEach { action ->
+            every { moderation.checkContent(any()) } returns allow().copy(action = action)
+            assertThatThrownBy {
+                service.createPost(owner.id, CreateCommunityPostRequest(null, "명시적 허용만 게시됩니다"))
+            }.isInstanceOf(IllegalArgumentException::class.java)
+        }
+
+        every { moderation.checkContent(any()) } returns allow().copy(modelUsed = "   ")
+        assertThatThrownBy {
+            service.createPost(owner.id, CreateCommunityPostRequest(null, "출처 없는 판정은 게시되지 않습니다"))
+        }.isInstanceOf(CommunityModerationUnavailableException::class.java)
+
+        assertThat(posts.count()).isZero()
+    }
+
+    @Test
     fun `moderation exceptions never publish and map to the unavailable error`() {
         val owner = users.save(User(email = "moderation-throw@example.com", username = "moderation-throw"))
         every { moderation.checkContent(any()) } throws IllegalStateException("connection refused")
@@ -225,15 +245,34 @@ class CommunityServiceIntegrationTest {
     }
 
     @Test
+    fun `a user can unsave their row after the post is removed`() {
+        val owner = users.save(User(email = "removed-unsave@example.com", username = "removed-unsave"))
+        every { moderation.checkContent(any()) } returns allow()
+        val post = service.createPost(owner.id, CreateCommunityPostRequest(null, "삭제 후 저장 취소"))
+        service.save(owner.id, post.id)
+        entityManager.entityManager.createNativeQuery("UPDATE community_posts SET status = 'REMOVED' WHERE id = :id")
+            .setParameter("id", post.id)
+            .executeUpdate()
+        entityManager.flush()
+        entityManager.clear()
+
+        val state = service.unsave(owner.id, post.id)
+
+        assertThat(state.saved).isFalse()
+        assertThat(savedPosts.existsByUserIdAndPostId(owner.id, post.id)).isFalse()
+    }
+
+    @Test
     fun `rejects content longer than the server limit`() {
         val owner = users.save(User(email = "long-post@example.com", username = "long-post"))
-        every { moderation.checkContent(any()) } returns allow()
 
+        val oversizedContent = "가".repeat(5001)
         assertThatThrownBy {
-            service.createPost(owner.id, CreateCommunityPostRequest(null, "가".repeat(5001)))
+            service.createPost(owner.id, CreateCommunityPostRequest(null, oversizedContent))
         }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("5,000자")
+        verify(exactly = 0) { moderation.checkContent(oversizedContent) }
     }
 
     @TestConfiguration

--- a/web/src/app/community/page.test.tsx
+++ b/web/src/app/community/page.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import CommunityPage from './page';
 import { fetchCommunityPosts } from '@/lib/api/community';
@@ -87,5 +87,40 @@ describe('CommunityPage', () => {
     await waitFor(() => {
       expect(fetchCommunityPosts).toHaveBeenLastCalledWith('POPULAR', 0, 20, expect.any(AbortSignal));
     });
+  });
+
+  it('discards an old load-more response after the sort changes', async () => {
+    const stalePost = { ...post, id: '44444444-4444-4444-4444-444444444444', content: '이전 정렬 게시글' };
+    const popularPost = { ...post, id: '55555555-5555-5555-5555-555555555555', content: '현재 인기 게시글' };
+    let resolveStale: ((value: typeof page) => void) | undefined;
+    vi.mocked(fetchCommunityPosts).mockImplementation((sort, requestPage) => {
+      if (sort === 'LATEST' && requestPage === 0) {
+        return Promise.resolve({ ...page, totalElements: 2, totalPages: 2, last: false });
+      }
+      if (sort === 'LATEST' && requestPage === 1) {
+        return new Promise((resolve) => { resolveStale = resolve; });
+      }
+      return Promise.resolve({ ...page, items: [popularPost] });
+    });
+
+    render(<CommunityPage />);
+    await screen.findByText(post.content);
+    fireEvent.click(screen.getByRole('button', { name: '더 보기' }));
+    fireEvent.click(screen.getByRole('button', { name: '인기' }));
+    await screen.findByText(popularPost.content);
+
+    await act(async () => {
+      resolveStale?.({
+        ...page,
+        items: [stalePost],
+        page: 1,
+        totalElements: 2,
+        totalPages: 2,
+        last: true,
+      });
+    });
+
+    expect(screen.queryByText(stalePost.content)).not.toBeInTheDocument();
+    expect(screen.getByText(popularPost.content)).toBeInTheDocument();
   });
 });

--- a/web/src/app/community/page.tsx
+++ b/web/src/app/community/page.tsx
@@ -5,7 +5,7 @@ import PageWrapper from "@/components/layout/PageWrapper";
 import { fetchCommunityPosts, type CommunityPost, type CommunitySort } from "@/lib/api/community";
 import { motion } from "framer-motion";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 const PAGE_SIZE = 20;
 
@@ -28,10 +28,15 @@ export default function CommunityPage() {
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState(false);
   const [retryKey, setRetryKey] = useState(0);
+  const generationRef = useRef(0);
+  const loadMoreControllerRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     const controller = new AbortController();
+    const generation = ++generationRef.current;
+    loadMoreControllerRef.current?.abort();
     setLoading(true);
+    setLoadingMore(false);
     setError(false);
     setPosts([]);
     setPage(0);
@@ -39,26 +44,44 @@ export default function CommunityPage() {
 
     fetchCommunityPosts(sort, 0, PAGE_SIZE, controller.signal)
       .then((result) => {
+        if (generationRef.current !== generation) return;
         setPosts(result.items);
         setPage(result.page);
         setLast(result.last);
       })
       .catch(() => {
-        if (!controller.signal.aborted) setError(true);
+        if (!controller.signal.aborted && generationRef.current === generation) setError(true);
       })
       .finally(() => {
-        if (!controller.signal.aborted) setLoading(false);
+        if (!controller.signal.aborted && generationRef.current === generation) setLoading(false);
       });
 
-    return () => controller.abort();
+    return () => {
+      controller.abort();
+      loadMoreControllerRef.current?.abort();
+    };
   }, [sort, retryKey]);
+
+  const changeSort = (nextSort: CommunitySort) => {
+    if (nextSort === sort) return;
+    generationRef.current += 1;
+    loadMoreControllerRef.current?.abort();
+    setLoadingMore(false);
+    setSort(nextSort);
+  };
 
   const loadMore = async () => {
     if (loadingMore || last) return;
+    const generation = generationRef.current;
+    const requestedSort = sort;
+    const controller = new AbortController();
+    loadMoreControllerRef.current?.abort();
+    loadMoreControllerRef.current = controller;
     setLoadingMore(true);
     setError(false);
     try {
-      const result = await fetchCommunityPosts(sort, page + 1, PAGE_SIZE);
+      const result = await fetchCommunityPosts(requestedSort, page + 1, PAGE_SIZE, controller.signal);
+      if (controller.signal.aborted || generationRef.current !== generation || sort !== requestedSort) return;
       setPosts((current) => {
         const seen = new Set(current.map((post) => post.id));
         return [...current, ...result.items.filter((post) => !seen.has(post.id))];
@@ -66,9 +89,10 @@ export default function CommunityPage() {
       setPage(result.page);
       setLast(result.last);
     } catch {
-      setError(true);
+      if (!controller.signal.aborted && generationRef.current === generation) setError(true);
     } finally {
-      setLoadingMore(false);
+      if (generationRef.current === generation) setLoadingMore(false);
+      if (loadMoreControllerRef.current === controller) loadMoreControllerRef.current = null;
     }
   };
 
@@ -90,7 +114,7 @@ export default function CommunityPage() {
         <div className="sticky top-16 z-30 border-b border-gray-200 bg-white">
           <div className="mx-auto flex max-w-7xl">
             <button
-              onClick={() => setSort("LATEST")}
+              onClick={() => changeSort("LATEST")}
               className={`relative flex-1 py-4 text-sm font-medium transition-colors ${
                 sort === "LATEST" ? "text-purple-600" : "text-gray-500"
               }`}
@@ -104,7 +128,7 @@ export default function CommunityPage() {
               )}
             </button>
             <button
-              onClick={() => setSort("POPULAR")}
+              onClick={() => changeSort("POPULAR")}
               className={`relative flex-1 py-4 text-sm font-medium transition-colors ${
                 sort === "POPULAR" ? "text-purple-600" : "text-gray-500"
               }`}

--- a/web/src/app/saved/page.test.tsx
+++ b/web/src/app/saved/page.test.tsx
@@ -34,9 +34,15 @@ const page = {
   last: true,
 };
 
+const nextPost = {
+  ...post,
+  id: '33333333-3333-3333-3333-333333333333',
+  content: '다시 채워진 저장 게시글',
+};
+
 describe('SavedPage', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     vi.mocked(fetchSavedCommunityPosts).mockResolvedValue(page);
     vi.mocked(unsaveCommunityPost).mockResolvedValue({ liked: false, saved: false });
   });
@@ -67,11 +73,34 @@ describe('SavedPage', () => {
   });
 
   it('removes a post only after the real unsave API succeeds', async () => {
+    vi.mocked(fetchSavedCommunityPosts)
+      .mockResolvedValueOnce(page)
+      .mockResolvedValueOnce({ ...page, items: [], totalElements: 0, totalPages: 0 });
     render(<SavedPage />);
     await screen.findByText('실제로 저장한 게시글');
     fireEvent.click(screen.getByRole('button', { name: '저장 취소' }));
 
     await waitFor(() => expect(unsaveCommunityPost).toHaveBeenCalledWith(post.id));
     expect(await screen.findByText('저장한 게시글이 없습니다.')).toBeInTheDocument();
+    expect(fetchSavedCommunityPosts).toHaveBeenLastCalledWith(0, 20);
+  });
+
+  it('refetches page zero after unsave so shifted rows and metadata stay authoritative', async () => {
+    vi.mocked(fetchSavedCommunityPosts)
+      .mockResolvedValueOnce({ ...page, totalElements: 21, totalPages: 2, last: false })
+      .mockResolvedValueOnce({
+        ...page,
+        items: [nextPost],
+        totalElements: 20,
+        totalPages: 1,
+        last: true,
+      });
+    render(<SavedPage />);
+    await screen.findByText(post.content);
+    fireEvent.click(screen.getByRole('button', { name: '저장 취소' }));
+
+    expect(await screen.findByText(nextPost.content)).toBeInTheDocument();
+    expect(screen.getByText('20')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '더 보기' })).not.toBeInTheDocument();
   });
 });

--- a/web/src/app/saved/page.tsx
+++ b/web/src/app/saved/page.tsx
@@ -9,7 +9,7 @@ import {
   type CommunityPost,
 } from "@/lib/api/community";
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 function formatTime(value: string) {
   return new Intl.DateTimeFormat("ko-KR", {
@@ -29,38 +29,56 @@ export default function SavedPage() {
   const [actionError, setActionError] = useState<string | null>(null);
   const [unsavingId, setUnsavingId] = useState<string | null>(null);
   const [retryKey, setRetryKey] = useState(0);
+  const generationRef = useRef(0);
+  const loadMoreControllerRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     const controller = new AbortController();
+    const generation = ++generationRef.current;
+    loadMoreControllerRef.current?.abort();
     setLoading(true);
+    setLoadingMore(false);
     setError(null);
     setPosts([]);
     fetchSavedCommunityPosts(0, 20, controller.signal)
       .then((result) => {
-        if (controller.signal.aborted) return;
+        if (controller.signal.aborted || generationRef.current !== generation) return;
         setPosts(result.items);
         setPage(result.page);
         setTotalPages(result.totalPages);
         setTotalElements(result.totalElements);
       })
       .catch(() => {
-        if (!controller.signal.aborted) setError("저장한 게시글을 불러오지 못했습니다.");
+        if (!controller.signal.aborted && generationRef.current === generation) {
+          setError("저장한 게시글을 불러오지 못했습니다.");
+        }
       })
       .finally(() => {
-        if (!controller.signal.aborted) setLoading(false);
+        if (!controller.signal.aborted && generationRef.current === generation) setLoading(false);
       });
-    return () => controller.abort();
+    return () => {
+      controller.abort();
+      loadMoreControllerRef.current?.abort();
+    };
   }, [retryKey]);
 
   const handleUnsave = async (postId: string) => {
     if (unsavingId) return;
     setUnsavingId(postId);
     setActionError(null);
+    const generation = ++generationRef.current;
+    loadMoreControllerRef.current?.abort();
+    setLoadingMore(false);
     try {
       const result = await unsaveCommunityPost(postId);
       if (result.saved) throw new Error("unsave failed");
-      setPosts((current) => current.filter((post) => post.id !== postId));
-      setTotalElements((current) => Math.max(0, current - 1));
+      if (generationRef.current !== generation) return;
+      const refreshed = await fetchSavedCommunityPosts(0, 20);
+      if (generationRef.current !== generation) return;
+      setPosts(refreshed.items);
+      setPage(refreshed.page);
+      setTotalPages(refreshed.totalPages);
+      setTotalElements(refreshed.totalElements);
     } catch {
       setActionError("저장을 취소하지 못했습니다.");
     } finally {
@@ -69,11 +87,16 @@ export default function SavedPage() {
   };
 
   const loadMore = async () => {
-    if (loadingMore || page + 1 >= totalPages) return;
+    if (loadingMore || unsavingId || page + 1 >= totalPages) return;
+    const generation = generationRef.current;
+    const controller = new AbortController();
+    loadMoreControllerRef.current?.abort();
+    loadMoreControllerRef.current = controller;
     setLoadingMore(true);
     setActionError(null);
     try {
-      const result = await fetchSavedCommunityPosts(page + 1, 20);
+      const result = await fetchSavedCommunityPosts(page + 1, 20, controller.signal);
+      if (controller.signal.aborted || generationRef.current !== generation) return;
       setPosts((current) => {
         const seen = new Set(current.map((post) => post.id));
         return [...current, ...result.items.filter((post) => !seen.has(post.id))];
@@ -82,9 +105,12 @@ export default function SavedPage() {
       setTotalPages(result.totalPages);
       setTotalElements(result.totalElements);
     } catch {
-      setActionError("저장한 게시글을 더 불러오지 못했습니다.");
+      if (!controller.signal.aborted && generationRef.current === generation) {
+        setActionError("저장한 게시글을 더 불러오지 못했습니다.");
+      }
     } finally {
-      setLoadingMore(false);
+      if (generationRef.current === generation) setLoadingMore(false);
+      if (loadMoreControllerRef.current === controller) loadMoreControllerRef.current = null;
     }
   };
 

--- a/web/src/lib/api/community.test.ts
+++ b/web/src/lib/api/community.test.ts
@@ -93,6 +93,15 @@ describe('community API', () => {
     expect(apiClient.get).toHaveBeenCalledWith(`/community/posts/${dto.id}`, { signal: undefined });
   });
 
+  it('rejects a detail whose id differs from the requested post id', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: { success: true, data: { ...dto, id: '99999999-9999-9999-9999-999999999999' } },
+    });
+    await expect(fetchCommunityPost(dto.id)).rejects.toThrow(
+      '커뮤니티 상세 API 응답이 올바르지 않습니다.',
+    );
+  });
+
   it('creates a post with the selected real artist UUID', async () => {
     vi.mocked(apiClient.post).mockResolvedValue({ data: { success: true, data: dto } });
     const request = { artistId: dto.artistId, content: dto.content };
@@ -158,6 +167,8 @@ describe('community comment API', () => {
     { ...commentPageDto, content: [{ ...commentDto, postId: 'not-a-uuid' }] },
     { ...commentPageDto, content: [{ ...commentDto, createdAt: '2026-08-14T09:00:00' }] },
     { ...commentPageDto, content: [{ ...commentDto, authorName: 7 }] },
+    { ...commentPageDto, content: [{ ...commentDto, status: 'PENDING' }] },
+    { ...commentPageDto, content: [{ ...commentDto, status: 'BLOCKED' }] },
     { ...commentPageDto, totalPages: 2 },
   ])('rejects malformed comment pages: %o', async (data) => {
     vi.mocked(apiClient.get).mockResolvedValue({ data: { success: true, data } });
@@ -174,5 +185,11 @@ describe('community comment API', () => {
       content: '실제 댓글',
       parentCommentId: null,
     });
+  });
+
+  it('preserves a PENDING status returned by the authenticated create endpoint', async () => {
+    const pending = { ...commentDto, status: 'PENDING' };
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { success: true, data: pending } });
+    await expect(createCommunityComment(dto.id, pending.content)).resolves.toEqual(pending);
   });
 });

--- a/web/src/lib/api/community.ts
+++ b/web/src/lib/api/community.ts
@@ -194,7 +194,7 @@ function isCommunityCommentPageDto(value: unknown): value is CommunityCommentPag
   if (!isRecord(value)) return false;
   if (
     !Array.isArray(value.content) ||
-    !value.content.every(isCommunityCommentDto) ||
+    !value.content.every((comment) => isCommunityCommentDto(comment) && comment.status === 'APPROVED') ||
     !isNonNegativeInteger(value.totalElements) ||
     !isNonNegativeInteger(value.page) ||
     !Number.isInteger(value.size) ||
@@ -286,11 +286,15 @@ export async function fetchCommunityPost(
     `/community/posts/${postId}`,
     { signal },
   );
-  return mapPost(unwrapApiResponse(
+  const data = unwrapApiResponse(
     response.data,
     '커뮤니티 상세 API 응답이 올바르지 않습니다.',
     isCommunityPostDto,
-  ));
+  );
+  if (data.id !== postId) {
+    throw new Error('커뮤니티 상세 API 응답이 올바르지 않습니다.');
+  }
+  return mapPost(data);
 }
 
 export async function createCommunityPost(


### PR DESCRIPTION
## 변경 내용

- 게시글은 명시적인 허용 판정일 때만 저장하고 5,000자 초과 입력은 외부 호출 전에 거부합니다.
- 삭제된 게시글도 본인이 저장한 행은 취소할 수 있도록 principal 범위 삭제를 보강했습니다.
- 상세 응답 ID가 요청 ID와 다르면 거부하고, 공개 댓글 목록은 APPROVED만 허용합니다.
- 정렬 변경 전 load-more 응답이 새 목록에 섞이지 않도록 요청 세대와 취소 처리를 추가했습니다.
- 저장 취소 후 page 0을 다시 읽어 row 이동과 pagination metadata를 서버 값으로 동기화합니다.

## 검증

- Spring 전체 suite 통과
- frontend 전체 58 files / 274 tests 통과
- TypeScript 통과
- 변경 파일 ESLint 통과
- Next production build 통과
- 독립 검토 통과, blocker 0
