### PR TITLE
Apple Music Top 100 전체 차트 표시

### DIFF
--- a/backend/src/main/kotlin/com/fanpulse/application/dto/content/ChartDtos.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/dto/content/ChartDtos.kt
@@ -54,8 +54,8 @@ data class ChartEntryResponse(
     @Schema(description = "Track ID")
     val trackId: UUID,
 
-    @Schema(description = "Artist ID")
-    val artistId: UUID,
+    @Schema(description = "Artist ID when the chart artist is registered in FanPulse")
+    val artistId: UUID?,
 
     @Schema(description = "Track title")
     val trackTitle: String,
@@ -76,7 +76,10 @@ data class ChartEntryResponse(
     val rankChange: Int?,
 
     @Schema(description = "Whether this is a new entry")
-    val isNew: Boolean
+    val isNew: Boolean,
+
+    @Schema(description = "Official Apple Music artwork URL")
+    val artworkUrl: String?,
 ) {
     companion object {
         fun from(entry: ChartEntry): ChartEntryResponse = ChartEntryResponse(
@@ -90,7 +93,8 @@ data class ChartEntryResponse(
             peakRank = entry.peakRank,
             weeksOnChart = entry.weeksOnChart,
             rankChange = entry.rankChange,
-            isNew = entry.isNew
+            isNew = entry.isNew,
+            artworkUrl = entry.artworkUrl,
         )
     }
 }

--- a/backend/src/main/kotlin/com/fanpulse/application/service/content/ChartRefreshService.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/service/content/ChartRefreshService.kt
@@ -29,7 +29,7 @@ data class ChartRefreshReport(
     val chartDate: LocalDate,
 ) {
     val saved: Int
-        get() = matched
+        get() = fetched
 }
 
 interface ChartRefreshService {
@@ -59,13 +59,6 @@ class ChartRefreshServiceImpl(
         }
 
         val aliasMap = uniqueArtistAliases(artistPort.findAllActiveUnpaged())
-        val matchedTracks = feed.tracks.mapNotNull { track ->
-            aliasMap[normalizeArtistName(track.artistName)]?.let { artist -> track to artist }
-        }
-        if (matchedTracks.isEmpty()) {
-            throw ChartRefreshException("Apple Music chart had no exact FanPulse artist matches")
-        }
-
         val chartDate = feed.updatedAt.atZone(KOREA_ZONE).toLocalDate()
             .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
         val existing = chartPort.findByTypeAndDate(ChartType.APPLE_MUSIC, chartDate)
@@ -75,26 +68,29 @@ class ChartRefreshServiceImpl(
             .orEmpty()
         val replacement = Chart.create(ChartType.APPLE_MUSIC, chartDate)
 
-        matchedTracks.forEach { (track, artist) ->
+        feed.tracks.forEach { track ->
+            val artist = aliasMap[normalizeArtistName(track.artistName)]
             val trackId = AppleMusicTrackIds.toUuid(track.externalId)
             val previous = previousByTrackId[trackId]
             replacement.addEntry(
                 rank = track.rank,
                 trackId = trackId,
-                artistId = artist.id,
+                artistId = artist?.id,
                 trackTitle = track.title,
-                artistName = artist.name,
+                artistName = artist?.name ?: track.artistName,
                 previousRank = previous?.rank,
                 peakRank = previous?.let { minOf(it.peakRank, track.rank) } ?: track.rank,
                 weeksOnChart = previous?.weeksOnChart?.plus(1) ?: 1,
+                artworkUrl = track.artworkUrl,
             )
         }
         writer.replace(existing, replacement)
 
+        val matched = feed.tracks.count { aliasMap.containsKey(normalizeArtistName(it.artistName)) }
         return ChartRefreshReport(
             fetched = feed.tracks.size,
-            matched = matchedTracks.size,
-            skipped = feed.tracks.size - matchedTracks.size,
+            matched = matched,
+            skipped = feed.tracks.size - matched,
             chartDate = chartDate,
         )
     }

--- a/backend/src/main/kotlin/com/fanpulse/domain/content/Chart.kt
+++ b/backend/src/main/kotlin/com/fanpulse/domain/content/Chart.kt
@@ -63,15 +63,17 @@ class Chart private constructor(
     fun addEntry(
         rank: Int,
         trackId: UUID,
-        artistId: UUID,
+        artistId: UUID?,
         trackTitle: String,
         artistName: String,
         previousRank: Int? = null,
         peakRank: Int? = null,
-        weeksOnChart: Int = 1
+        weeksOnChart: Int = 1,
+        artworkUrl: String? = null,
     ) {
         require(rank > 0) { "Rank must be positive: $rank" }
         require(trackTitle.isNotBlank()) { "Track title cannot be blank" }
+        require(artistName.isNotBlank()) { "Artist name cannot be blank" }
 
         val entry = ChartEntry(
             id = UUID.randomUUID(),
@@ -83,7 +85,8 @@ class Chart private constructor(
             artistName = artistName,
             previousRank = previousRank,
             peakRank = peakRank ?: rank,
-            weeksOnChart = weeksOnChart
+            weeksOnChart = weeksOnChart,
+            artworkUrl = artworkUrl,
         )
         _entries.add(entry)
     }
@@ -129,13 +132,13 @@ class ChartEntry(
     @Column(name = "track_id", columnDefinition = "uuid", nullable = false)
     val trackId: UUID,
 
-    @Column(name = "artist_id", columnDefinition = "uuid", nullable = false)
-    val artistId: UUID,
+    @Column(name = "artist_id", columnDefinition = "uuid")
+    val artistId: UUID?,
 
     @Column(name = "track_title", length = 255, nullable = false)
     val trackTitle: String,
 
-    @Column(name = "artist_name", length = 100, nullable = false)
+    @Column(name = "artist_name", length = 255, nullable = false)
     val artistName: String,
 
     @Column(name = "previous_rank")
@@ -145,7 +148,10 @@ class ChartEntry(
     val peakRank: Int,
 
     @Column(name = "weeks_on_chart", nullable = false)
-    val weeksOnChart: Int
+    val weeksOnChart: Int,
+
+    @Column(name = "artwork_url", length = 512)
+    val artworkUrl: String? = null,
 ) {
     /**
      * Rank change compared to previous chart.

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/external/applemusic/AppleMusicArtworkUrls.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/external/applemusic/AppleMusicArtworkUrls.kt
@@ -1,0 +1,50 @@
+package com.fanpulse.infrastructure.external.applemusic
+
+import java.net.URI
+
+object AppleMusicArtworkUrls {
+    private val HOST = Regex("^is[1-9]-ssl\\.mzstatic\\.com$")
+    private const val MAX_LENGTH = 512
+
+    fun parseOptional(raw: String?): String? {
+        val value = raw?.trim().orEmpty()
+        if (value.isEmpty()) return null
+        return canonicalize(value)
+    }
+
+    internal fun canonicalize(raw: String): String {
+        if (raw.length > MAX_LENGTH || raw.any { it.isISOControl() || it.isWhitespace() }) {
+            throw AppleMusicChartSourceException("Apple Music artwork url was invalid")
+        }
+        val uri = try {
+            URI(raw)
+        } catch (exc: Exception) {
+            throw AppleMusicChartSourceException("Apple Music artwork url was invalid", exc)
+        }
+        val host = uri.host?.lowercase()
+        val rawPath = uri.rawPath
+        val path = uri.path
+        if (
+            uri.scheme?.lowercase() != "https" ||
+            !uri.userInfo.isNullOrEmpty() ||
+            host == null ||
+            !HOST.matches(host) ||
+            (uri.port != -1 && uri.port != 443) ||
+            !uri.rawQuery.isNullOrEmpty() ||
+            !uri.rawFragment.isNullOrEmpty() ||
+            rawPath.isNullOrEmpty() ||
+            path.isNullOrEmpty() ||
+            rawPath != path ||
+            rawPath.contains(Regex("(?i)%2e|%2f|%5c")) ||
+            path.contains("/./") ||
+            path.contains("/../") ||
+            path.endsWith("/.") ||
+            path.endsWith("/..") ||
+            !path.startsWith("/image/thumb/") ||
+            !(path.endsWith(".jpg") || path.endsWith(".jpeg") || path.endsWith(".png"))
+        ) {
+            throw AppleMusicChartSourceException("Apple Music artwork url was invalid")
+        }
+        return "https://$host$path"
+    }
+}

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/external/applemusic/AppleMusicChartHttpClient.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/external/applemusic/AppleMusicChartHttpClient.kt
@@ -21,6 +21,7 @@ data class AppleMusicChartTrack(
     val externalId: String,
     val title: String,
     val artistName: String,
+    val artworkUrl: String? = null,
 )
 
 data class AppleMusicChartFeed(
@@ -119,6 +120,7 @@ class AppleMusicChartHttpClient(
                 externalId = id,
                 title = title,
                 artistName = artist,
+                artworkUrl = AppleMusicArtworkUrls.parseOptional(result.artworkUrl100),
             )
         }
         return AppleMusicChartFeed(updatedAt, tracks)
@@ -133,5 +135,6 @@ class AppleMusicChartHttpClient(
         val id: String? = null,
         val name: String? = null,
         val artistName: String? = null,
+        val artworkUrl100: String? = null,
     )
 }

--- a/backend/src/main/resources/db/migration/V125__chart_unmatched_rows_and_artwork.sql
+++ b/backend/src/main/resources/db/migration/V125__chart_unmatched_rows_and_artwork.sql
@@ -1,0 +1,9 @@
+-- Keep unmatched Apple Music chart rows and official artwork.
+ALTER TABLE chart_entries
+    ALTER COLUMN artist_id DROP NOT NULL;
+
+ALTER TABLE chart_entries
+    ALTER COLUMN artist_name TYPE VARCHAR(255);
+
+ALTER TABLE chart_entries
+    ADD COLUMN artwork_url VARCHAR(512);

--- a/backend/src/test/kotlin/com/fanpulse/application/service/concert/KopisConcertPostgresVerticalIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/application/service/concert/KopisConcertPostgresVerticalIntegrationTest.kt
@@ -56,7 +56,8 @@ class KopisConcertPostgresVerticalIntegrationTest {
         dataSource.connection.use { connection ->
             assertThat(connection.metaData.databaseProductName).isEqualTo("PostgreSQL")
         }
-        assertThat(flyway.info().current().version.toString()).isEqualTo("124")
+        assertThat(flyway.info().applied().map { it.version.toString() }).contains("124", "125")
+        assertThat(flyway.info().current().version.toString()).isEqualTo("125")
         assertThat(columnLength("artist")).isEqualTo(1_000)
         assertThat(columnLength("venue_address")).isEqualTo(756)
 

--- a/backend/src/test/kotlin/com/fanpulse/application/service/content/AppleMusicChartLiveIntegrationTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/application/service/content/AppleMusicChartLiveIntegrationTest.kt
@@ -40,12 +40,10 @@ class AppleMusicChartLiveIntegrationTest {
 
         assertThat(report.fetched).isBetween(1, 100)
         assertThat(report.matched).isGreaterThan(0)
-        assertThat(report.saved).isEqualTo(report.matched)
+        assertThat(report.saved).isEqualTo(report.fetched)
         assertThat(chart.chartType).isEqualTo("APPLE_MUSIC")
-        assertThat(chart.entries).hasSize(report.matched)
-        assertThat(chart.entries).allSatisfy { entry ->
-            assertThat(entry.rank).isPositive()
-            assertThat(entry.trackTitle).isNotBlank()
+        assertThat(chart.entries).hasSize(report.fetched)
+        assertThat(chart.entries.filter { it.artistId != null }).allSatisfy { entry ->
             assertThat(entry.artistName).isIn("aespa", "BLACKPINK", "RIIZE")
         }
     }

--- a/backend/src/test/kotlin/com/fanpulse/application/service/content/ChartRefreshServiceTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/application/service/content/ChartRefreshServiceTest.kt
@@ -30,7 +30,7 @@ class ChartRefreshServiceTest {
     private val service = ChartRefreshServiceImpl(source, artistPort, chartPort, writer, clock)
 
     @Test
-    fun `stores only exact active artist matches and preserves global rank`() {
+    fun `stores full chart ranks and only links exact active artist matches`() {
         val aespa = artist("aespa")
         val blackpink = artist("BLACKPINK")
         val chartWeek = LocalDate.of(2026, 8, 10)
@@ -61,13 +61,20 @@ class ChartRefreshServiceTest {
         assertEquals(3, report.fetched)
         assertEquals(2, report.matched)
         assertEquals(1, report.skipped)
+        assertEquals(3, report.saved)
         assertEquals(chartWeek, report.chartDate)
-        assertEquals(listOf(6, 63), captured.captured.entries.map { it.rank })
-        val returning = captured.captured.entries.first()
+        assertEquals(listOf(6, 7, 63), captured.captured.entries.map { it.rank })
+        val returning = captured.captured.entries[0]
+        assertEquals(aespa.id, returning.artistId)
         assertEquals(10, returning.previousRank)
         assertEquals(5, returning.peakRank)
         assertEquals(4, returning.weeksOnChart)
-        val newcomer = captured.captured.entries.last()
+        val unmatched = captured.captured.entries[1]
+        assertNull(unmatched.artistId)
+        assertEquals("Unknown Artist", unmatched.artistName)
+        assertEquals("Unknown Song", unmatched.trackTitle)
+        val newcomer = captured.captured.entries[2]
+        assertEquals(blackpink.id, newcomer.artistId)
         assertNull(newcomer.previousRank)
         assertEquals(63, newcomer.peakRank)
         assertEquals(1, newcomer.weeksOnChart)
@@ -89,7 +96,10 @@ class ChartRefreshServiceTest {
         val report = service.refresh()
 
         assertEquals(1, report.matched)
-        assertEquals(listOf("Surfin' Boy"), captured.captured.entries.map { it.trackTitle })
+        assertEquals(2, report.saved)
+        assertEquals(listOf("Surfin' Boy", "Not Exact"), captured.captured.entries.map { it.trackTitle })
+        assertEquals(redVelvet.id, captured.captured.entries[0].artistId)
+        assertNull(captured.captured.entries[1].artistId)
     }
 
     @Test
@@ -120,12 +130,20 @@ class ChartRefreshServiceTest {
     }
 
     @Test
-    fun `does not replace existing data when no artist matches`() {
+    fun `saves unmatched rows when no FanPulse artist matches`() {
         every { source.fetchTopSongs() } returns feed(track(1, "401", "Song", "Unknown"))
         every { artistPort.findAllActiveUnpaged() } returns listOf(artist("aespa"))
+        every { chartPort.findByTypeAndDate(any(), any()) } returns null
+        every { chartPort.findLatestBeforeType(any(), any()) } returns null
+        val captured = slot<Chart>()
+        every { writer.replace(null, capture(captured)) } answers { captured.captured }
 
-        assertThrows<ChartRefreshException> { service.refresh() }
-        verify(exactly = 0) { writer.replace(any(), any()) }
+        val report = service.refresh()
+
+        assertEquals(0, report.matched)
+        assertEquals(1, report.saved)
+        assertNull(captured.captured.entries.single().artistId)
+        assertEquals("Unknown", captured.captured.entries.single().artistName)
     }
 
     private fun artist(name: String, englishName: String? = null): Artist = Artist.create(

--- a/backend/src/test/kotlin/com/fanpulse/infrastructure/external/applemusic/AppleMusicChartHttpClientTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/infrastructure/external/applemusic/AppleMusicChartHttpClientTest.kt
@@ -38,6 +38,43 @@ class AppleMusicChartHttpClientTest {
     }
 
     @Test
+    fun `parses canonical Apple artwork urls`() {
+        val feed = client.parseResponse(
+            """
+            {
+              "feed": {
+                "updated": "Fri, 14 Aug 2026 00:19:10 +0000",
+                "results": [
+                  {
+                    "id":"101",
+                    "name":"First",
+                    "artistName":"aespa",
+                    "artworkUrl100":"https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/ab/cd/ef/cover/100x100bb.jpg"
+                  }
+                ]
+              }
+            }
+            """.trimIndent().toByteArray()
+        )
+
+        assertThat(feed.tracks.single().artworkUrl)
+            .isEqualTo("https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/ab/cd/ef/cover/100x100bb.jpg")
+    }
+
+    @Test
+    fun `rejects non-canonical artwork urls instead of returning partial data`() {
+        val malicious =
+            """
+            {"feed":{"updated":"Fri, 14 Aug 2026 00:19:10 +0000","results":[
+              {"id":"101","name":"One","artistName":"aespa","artworkUrl100":"https://evil.example/image/thumb/x.jpg"}
+            ]}}
+            """.trimIndent().toByteArray()
+
+        assertThatThrownBy { client.parseResponse(malicious) }
+            .isInstanceOf(AppleMusicChartSourceException::class.java)
+    }
+
+    @Test
     fun `rejects malformed rows instead of returning partial data`() {
         val malformed =
             """

--- a/web/src/app/chart/page.test.tsx
+++ b/web/src/app/chart/page.test.tsx
@@ -32,6 +32,21 @@ const apiChart = {
       weeksOnChart: 5,
       rankChange: 2,
       isNew: false,
+      artworkUrl: 'https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/ab/cd/ef/cover/100x100bb.jpg',
+    },
+    {
+      id: 'entry-2',
+      rank: 2,
+      trackId: 'track-2',
+      artistId: null,
+      trackTitle: 'Unmatched Track',
+      artistName: 'Unknown Artist',
+      previousRank: null,
+      peakRank: 2,
+      weeksOnChart: 1,
+      rankChange: null,
+      isNew: true,
+      artworkUrl: null,
     },
   ],
 };
@@ -59,6 +74,12 @@ describe('ChartPage', () => {
       'href',
       '/artists/artist-123'
     );
+    expect(screen.getByRole('img', { name: 'API Track' })).toHaveAttribute(
+      'src',
+      'https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/ab/cd/ef/cover/100x100bb.jpg'
+    );
+    expect(screen.getByText('Unmatched Track')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Unmatched Track/ })).not.toBeInTheDocument();
     expect(screen.queryByText('Super Shy')).not.toBeInTheDocument();
   });
 
@@ -101,6 +122,6 @@ describe('ChartPage', () => {
 
     render(<ChartPage />);
 
-    expect(screen.getByText('연결된 차트 항목이 없습니다')).toBeInTheDocument();
+    expect(screen.getByText('차트 항목이 없습니다')).toBeInTheDocument();
   });
 });

--- a/web/src/app/chart/page.tsx
+++ b/web/src/app/chart/page.tsx
@@ -23,6 +23,66 @@ function RankChange({ entry }: { entry: ChartEntry }) {
   );
 }
 
+function Artwork({ entry }: { entry: ChartEntry }) {
+  if (entry.artworkUrl) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={entry.artworkUrl}
+        alt={entry.trackTitle}
+        width={56}
+        height={56}
+        className="h-14 w-14 flex-shrink-0 rounded-xl object-cover bg-gray-100"
+      />
+    );
+  }
+
+  return (
+    <div
+      aria-hidden="true"
+      className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-xl bg-gray-100 text-gray-400"
+    >
+      <i className="ri-music-2-line text-xl" />
+    </div>
+  );
+}
+
+function ChartRow({ entry }: { entry: ChartEntry }) {
+  const body = (
+    <>
+      <span className="w-10 text-center text-lg font-bold text-gray-700">
+        {entry.rank}
+      </span>
+      <Artwork entry={entry} />
+      <div className="min-w-0 flex-1">
+        <h2 className="font-bold text-gray-900">{entry.trackTitle}</h2>
+        <p className="mt-1 text-sm text-gray-600">{entry.artistName}</p>
+        <p className="mt-1 text-xs text-gray-500">
+          최고 {entry.peakRank}위 · {entry.weeksOnChart}주 차트인
+        </p>
+      </div>
+      <RankChange entry={entry} />
+    </>
+  );
+
+  if (entry.artistId) {
+    return (
+      <Link
+        href={`/artists/${entry.artistId}`}
+        className="flex items-center gap-4 rounded-2xl bg-white p-4 shadow-sm transition-shadow hover:shadow-md"
+      >
+        {body}
+      </Link>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-4 rounded-2xl bg-white p-4 shadow-sm">
+      {body}
+    </div>
+  );
+}
+
 export default function ChartPage() {
   const { chart, state, error, retry } = useLatestChart('APPLE_MUSIC');
 
@@ -34,7 +94,7 @@ export default function ChartPage() {
           <div className="mb-4 rounded-2xl border border-gray-200 bg-white p-4">
             <h1 className="font-bold text-gray-900">Apple Music Korea Top 100</h1>
             <p className="mt-1 text-sm text-gray-500">
-              FanPulse에 등록된 아티스트와 정확히 연결된 곡만 표시합니다.
+              Apple Music Korea 실시간 Top 100입니다. 등록된 아티스트만 상세 페이지로 연결됩니다.
             </p>
             {chart && (
               <time className="mt-2 block text-xs text-gray-500" dateTime={chart.chartDate}>
@@ -61,29 +121,13 @@ export default function ChartPage() {
           )}
 
           {state === 'success' && chart?.entries.length === 0 && (
-            <p className="py-12 text-center text-gray-500">연결된 차트 항목이 없습니다</p>
+            <p className="py-12 text-center text-gray-500">차트 항목이 없습니다</p>
           )}
 
           {state === 'success' && chart && chart.entries.length > 0 && (
             <div className="space-y-3">
               {chart.entries.map((entry) => (
-                <Link
-                  key={entry.id}
-                  href={`/artists/${entry.artistId}`}
-                  className="flex items-center gap-4 rounded-2xl bg-white p-4 shadow-sm transition-shadow hover:shadow-md"
-                >
-                  <span className="w-10 text-center text-lg font-bold text-gray-700">
-                    {entry.rank}
-                  </span>
-                  <div className="min-w-0 flex-1">
-                    <h2 className="font-bold text-gray-900">{entry.trackTitle}</h2>
-                    <p className="mt-1 text-sm text-gray-600">{entry.artistName}</p>
-                    <p className="mt-1 text-xs text-gray-500">
-                      최고 {entry.peakRank}위 · {entry.weeksOnChart}주 차트인
-                    </p>
-                  </div>
-                  <RankChange entry={entry} />
-                </Link>
+                <ChartRow key={entry.id} entry={entry} />
               ))}
             </div>
           )}

--- a/web/src/lib/api/chart.test.ts
+++ b/web/src/lib/api/chart.test.ts
@@ -29,6 +29,7 @@ const chartResponse = {
       weeksOnChart: 4,
       rankChange: 1,
       isNew: false,
+      artworkUrl: 'https://is1-ssl.mzstatic.com/image/thumb/Music211/v4/ab/cd/ef/cover/100x100bb.jpg',
     },
   ],
 };
@@ -64,6 +65,56 @@ describe('fetchLatestChart', () => {
     { ...chartResponse, entries: [{ ...chartResponse.entries[0], artistId: 'not-a-uuid' }] },
   ])('rejects malformed successful chart payload: %o', async (data) => {
     mockedGet.mockResolvedValue({ data: { success: true, data } });
+
+    await expect(fetchLatestChart('APPLE_MUSIC')).rejects.toThrow(
+      '차트 API 응답이 올바르지 않습니다.'
+    );
+  });
+
+  it('accepts unmatched rows with a null artistId and official artwork', async () => {
+    const unmatched = {
+      ...chartResponse,
+      entries: [
+        {
+          ...chartResponse.entries[0],
+          artistId: null,
+        },
+      ],
+    };
+    mockedGet.mockResolvedValue({ data: { success: true, data: unmatched } });
+
+    await expect(fetchLatestChart('APPLE_MUSIC')).resolves.toEqual(unmatched);
+  });
+
+  it('rejects a successful payload whose artwork host is not Apple', async () => {
+    mockedGet.mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          ...chartResponse,
+          entries: [{ ...chartResponse.entries[0], artworkUrl: 'https://evil.example/cover.jpg' }],
+        },
+      },
+    });
+
+    await expect(fetchLatestChart('APPLE_MUSIC')).rejects.toThrow(
+      '차트 API 응답이 올바르지 않습니다.'
+    );
+  });
+
+  it('rejects a successful payload whose artwork path is encoded', async () => {
+    mockedGet.mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          ...chartResponse,
+          entries: [{
+            ...chartResponse.entries[0],
+            artworkUrl: 'https://is1-ssl.mzstatic.com/image/thumb/%2e%2e/secret.jpg',
+          }],
+        },
+      },
+    });
 
     await expect(fetchLatestChart('APPLE_MUSIC')).rejects.toThrow(
       '차트 API 응답이 올바르지 않습니다.'

--- a/web/src/lib/api/chart.ts
+++ b/web/src/lib/api/chart.ts
@@ -38,7 +38,7 @@ export interface ChartEntry {
   id: string;
   rank: number;
   trackId: string;
-  artistId: string;
+  artistId: string | null;
   trackTitle: string;
   artistName: string;
   previousRank: number | null;
@@ -46,6 +46,7 @@ export interface ChartEntry {
   weeksOnChart: number;
   rankChange: number | null;
   isNew: boolean;
+  artworkUrl: string | null;
 }
 
 export interface ChartResponse {
@@ -56,20 +57,47 @@ export interface ChartResponse {
   createdAt: string;
 }
 
+function isNullableAppleArtworkUrl(value: unknown): value is string | null {
+  if (value === null) return true;
+  if (typeof value !== 'string') return false;
+  try {
+    const url = new URL(value);
+    const pathname = url.pathname;
+    const rawPath = url.href.slice(url.origin.length).split('?')[0].split('#')[0];
+    return (
+      url.protocol === 'https:' &&
+      /^is[1-9]-ssl\.mzstatic\.com$/.test(url.hostname) &&
+      (url.port === '' || url.port === '443') &&
+      url.username === '' &&
+      url.password === '' &&
+      url.search === '' &&
+      url.hash === '' &&
+      pathname.startsWith('/image/thumb/') &&
+      !pathname.includes('/../') &&
+      !pathname.includes('/./') &&
+      !/%2e|%2f|%5c/i.test(rawPath) &&
+      (pathname.endsWith('.jpg') || pathname.endsWith('.jpeg') || pathname.endsWith('.png'))
+    );
+  } catch {
+    return false;
+  }
+}
+
 function isChartEntry(value: unknown): value is ChartEntry {
   if (!isRecord(value)) return false;
   return (
     isUuid(value.id) &&
     isPositiveInteger(value.rank) &&
     isUuid(value.trackId) &&
-    isUuid(value.artistId) &&
+    (value.artistId === null || isUuid(value.artistId)) &&
     isNonEmptyString(value.trackTitle) &&
     isNonEmptyString(value.artistName) &&
     (value.previousRank === null || isPositiveInteger(value.previousRank)) &&
     isPositiveInteger(value.peakRank) &&
     isPositiveInteger(value.weeksOnChart) &&
     isNullableInteger(value.rankChange) &&
-    typeof value.isNew === 'boolean'
+    typeof value.isNew === 'boolean' &&
+    isNullableAppleArtworkUrl(value.artworkUrl)
   );
 }
 


### PR DESCRIPTION
## 변경 내용
- Apple Music 차트를 등록 아티스트만 남기지 않고 Top 100 전체 순위로 저장합니다.
- FanPulse에 정확히 매칭된 아티스트만 `artistId`를 넣고 상세 페이지로 연결합니다.
- 공식 `mzstatic` 앨범 커버만 허용하고, 잘못된 artwork URL은 수집을 거부합니다.
- Flyway V125로 `artist_id` null 허용, 아티스트명 255자, `artwork_url`을 추가합니다.

## 검증
- ChartRefreshService / Chart / AppleMusicChartHttpClient focused 테스트 통과
- Frontend chart API·페이지 테스트 13개 통과
- TypeScript / 변경 파일 ESLint 통과

## 운영 확인 계획
- CI 통과 후 squash merge
- Hostinger 배포 전 snapshot
- 배포 후 `/charts/APPLE_MUSIC/latest`가 100건인지, 미매칭 곡의 `artistId`가 null인지 확인
- Vercel 차트 화면에서 1~100위와 앨범 커버 표시 확인