### PR TITLE
fix(chart): 차트 갱신 결과 집계 기준 정리

### DIFF
--- a/backend/src/main/kotlin/com/fanpulse/application/service/content/ChartRefreshService.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/service/content/ChartRefreshService.kt
@@ -25,11 +25,23 @@ class ChartRefreshException(message: String) : RuntimeException(message)
 data class ChartRefreshReport(
     val fetched: Int,
     val matched: Int,
-    val skipped: Int,
+    val unmatched: Int,
     val chartDate: LocalDate,
 ) {
+    /** Successful refreshes persist the entire fetched snapshot atomically. */
     val saved: Int
         get() = fetched
+
+    init {
+        require(fetched >= 0) { "Fetched count must not be negative: $fetched" }
+        require(matched in 0..fetched) {
+            "Matched count must be between 0 and fetched: matched=$matched, fetched=$fetched"
+        }
+        require(unmatched == fetched - matched) {
+            "Unmatched count must equal fetched - matched: " +
+                "unmatched=$unmatched, fetched=$fetched, matched=$matched"
+        }
+    }
 }
 
 interface ChartRefreshService {
@@ -90,7 +102,7 @@ class ChartRefreshServiceImpl(
         return ChartRefreshReport(
             fetched = feed.tracks.size,
             matched = matched,
-            skipped = feed.tracks.size - matched,
+            unmatched = feed.tracks.size - matched,
             chartDate = chartDate,
         )
     }

--- a/backend/src/main/kotlin/com/fanpulse/infrastructure/scheduler/ChartRefreshScheduler.kt
+++ b/backend/src/main/kotlin/com/fanpulse/infrastructure/scheduler/ChartRefreshScheduler.kt
@@ -35,7 +35,8 @@ class ChartRefreshScheduler(private val service: ChartRefreshService) {
             val report = service.refresh()
             chartLogger.info {
                 "Apple Music chart refresh completed: trigger=$trigger, date=${report.chartDate}, " +
-                    "fetched=${report.fetched}, matched=${report.matched}, skipped=${report.skipped}"
+                    "fetched=${report.fetched}, saved=${report.saved}, matched=${report.matched}, " +
+                    "unmatched=${report.unmatched}"
             }
         } catch (exception: Exception) {
             chartLogger.error(exception) { "Apple Music chart refresh failed: trigger=$trigger" }

--- a/backend/src/test/kotlin/com/fanpulse/application/service/content/ChartRefreshServiceTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/application/service/content/ChartRefreshServiceTest.kt
@@ -59,9 +59,10 @@ class ChartRefreshServiceTest {
         val report = service.refresh()
 
         assertEquals(3, report.fetched)
-        assertEquals(2, report.matched)
-        assertEquals(1, report.skipped)
         assertEquals(3, report.saved)
+        assertEquals(2, report.matched)
+        assertEquals(1, report.unmatched)
+        assertEquals(report.fetched, report.matched + report.unmatched)
         assertEquals(chartWeek, report.chartDate)
         assertEquals(listOf(6, 7, 63), captured.captured.entries.map { it.rank })
         val returning = captured.captured.entries[0]
@@ -81,6 +82,18 @@ class ChartRefreshServiceTest {
     }
 
     @Test
+    fun `rejects contradictory refresh report counts`() {
+        assertThrows<IllegalArgumentException> {
+            ChartRefreshReport(
+                fetched = 100,
+                matched = 30,
+                unmatched = 69,
+                chartDate = LocalDate.of(2026, 8, 10),
+            )
+        }
+    }
+
+    @Test
     fun `uses normalized exact english name without substring guessing`() {
         val redVelvet = artist("레드벨벳", englishName = "Red Velvet")
         every { source.fetchTopSongs() } returns feed(
@@ -96,7 +109,9 @@ class ChartRefreshServiceTest {
         val report = service.refresh()
 
         assertEquals(1, report.matched)
+        assertEquals(1, report.unmatched)
         assertEquals(2, report.saved)
+        assertEquals(report.fetched, report.matched + report.unmatched)
         assertEquals(listOf("Surfin' Boy", "Not Exact"), captured.captured.entries.map { it.trackTitle })
         assertEquals(redVelvet.id, captured.captured.entries[0].artistId)
         assertNull(captured.captured.entries[1].artistId)
@@ -141,7 +156,9 @@ class ChartRefreshServiceTest {
         val report = service.refresh()
 
         assertEquals(0, report.matched)
+        assertEquals(1, report.unmatched)
         assertEquals(1, report.saved)
+        assertEquals(report.fetched, report.matched + report.unmatched)
         assertNull(captured.captured.entries.single().artistId)
         assertEquals("Unknown", captured.captured.entries.single().artistName)
     }


### PR DESCRIPTION
## 변경 배경

Apple Music Top 100 전체 항목을 저장하도록 변경하면서, FanPulse에 등록되지 않은 아티스트의 곡도 정상적으로 저장되게 되었습니다.

하지만 기존 갱신 결과에서는 미등록 아티스트 항목을 `skipped`로 집계하고 있어 다음과 같이 저장 결과와 집계 결과가 모순되는 문제가 있었습니다.

```text
fetched=100
saved=100
matched=30
skipped=70
```

실제로 저장된 미등록 아티스트 항목을 `skipped`가 아닌 `unmatched`로 구분해 차트 갱신 결과의 의미를 명확하게 정리합니다.

## 변경 내용

- `ChartRefreshReport.skipped`를 `unmatched`로 변경
- 차트 갱신 완료 로그에 `saved` 건수 추가
- 집계 결과에 다음 불변식 검증 추가
  - `fetched >= 0`
  - `0 <= matched <= fetched`
  - `matched + unmatched == fetched`
- 일부 매칭, 전체 미매칭, 잘못된 집계 조합에 대한 회귀 테스트 추가

## 변경 후 집계 예시

```text
fetched=100
saved=100
matched=30
unmatched=70
```

## 영향 범위

이번 변경은 차트 갱신 결과 객체와 운영 로그의 집계 의미를 정리하는 변경입니다.

다음 로직은 변경하지 않았습니다.

- Apple Music API 호출 및 응답 파싱
- FanPulse 아티스트 매칭 로직
- 차트 스냅샷 저장 및 교체 트랜잭션
- 데이터베이스 스키마 및 Flyway 마이그레이션
- 차트 조회 API 응답
- 프론트엔드 차트 화면
- 스케줄러 주기 및 ShedLock 설정

## 테스트

- FanPulse 등록 아티스트와 미등록 아티스트가 함께 있는 경우
- 영문 이름 정확 매칭과 미매칭이 함께 있는 경우
- 모든 곡이 미등록 아티스트인 경우
- `matched + unmatched != fetched`인 잘못된 집계 객체 생성 차단

## 확인 사항

- [x] 변경 범위를 차트 집계 및 로그로 제한
- [x] 기존 저장·조회 동작 비변경
- [x] 집계 불변식 검증 추가
- [x] 회귀 테스트 추가
- [ ] GitHub Actions 전체 검증