### PR TITLE
수정: Draft 해제 시 자동 코드리뷰를 실행한다

### DIFF
--- a/.github/workflows/pr-review-notify.yml
+++ b/.github/workflows/pr-review-notify.yml
@@ -2,7 +2,7 @@ name: PR Review Notify
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: pr-notify-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## 변경 내용
- PR이 Draft에서 Ready for review로 전환될 때 자동 코드리뷰 알림을 실행합니다.
- 기존 opened, synchronize, reopened 동작은 유지합니다.

## 원인
- PR #291이 Draft 상태로 열려 최초 작업이 건너뛰어졌습니다.
- 이후 Ready로 전환됐지만 ready_for_review 이벤트를 구독하지 않아 코드리뷰가 시작되지 않았습니다.

## 검증
- 이벤트 목록 회귀검증 통과
- YAML 구문 검사 통과
- git diff 검사 통과
