### PR TITLE
수정: Ready 전환 리뷰 요청을 웹훅 서버 형식에 맞춘다

### DIFF
--- a/.github/workflows/pr-review-notify.yml
+++ b/.github/workflows/pr-review-notify.yml
@@ -41,6 +41,11 @@ jobs:
           WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}
           PR_TITLE_RAW: ${{ github.event.pull_request.title }}
         run: |
+          WEBHOOK_EVENT="${{ github.event.action }}"
+          if [ "$WEBHOOK_EVENT" = "ready_for_review" ]; then
+            WEBHOOK_EVENT="opened"
+          fi
+
           TITLE_JSON=$(echo "$PR_TITLE_RAW" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip()))")
           PAYLOAD=$(cat <<EOF
           {
@@ -51,7 +56,7 @@ jobs:
             "head": "${{ github.event.pull_request.head.ref }}",
             "base": "${{ github.event.pull_request.base.ref }}",
             "sha": "${{ github.event.pull_request.head.sha }}",
-            "event": "${{ github.event.action }}",
+            "event": "${WEBHOOK_EVENT}",
             "url": "${{ github.event.pull_request.html_url }}"
           }
           EOF
@@ -75,8 +80,9 @@ jobs:
 
           echo "Response: $BODY (HTTP $HTTP_CODE)"
 
-          if [ "$HTTP_CODE" -ge 400 ]; then
-            echo "::warning::Webhook call failed with HTTP $HTTP_CODE"
+          if [[ ! "$HTTP_CODE" =~ ^2[0-9]{2}$ ]]; then
+            echo "::error::Webhook call failed with HTTP $HTTP_CODE"
+            exit 1
           fi
 
       - name: Auto-approve docs-only PR


### PR DESCRIPTION
## 변경 내용
- Draft에서 Ready로 전환된 리뷰 요청은 기존 웹훅 서버가 허용하는 `opened` 이벤트로 정규화합니다.
- 웹훅 응답이 2xx가 아니면 GitHub Actions 작업을 실패 처리합니다.

## 원인
- `ready_for_review` 트리거 자체는 실행됐지만 웹훅 서버가 새로운 이벤트 값을 `invalid payload`로 거절했습니다.
- 기존 워크플로는 HTTP 400도 경고만 남기고 성공 처리해 장애가 숨겨졌습니다.

## 검증
- 이벤트 정규화 회귀검증 통과
- 비-2xx 실패 처리 회귀검증 통과
- YAML 구문 및 git diff 검사 통과
