### PR TITLE
fix(auth): 웹·모바일 토큰 갱신 경계 분리

### DIFF
--- a/backend/src/main/kotlin/com/fanpulse/application/service/identity/AuthService.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/service/identity/AuthService.kt
@@ -24,7 +24,16 @@ interface AuthService {
     fun refreshToken(request: RefreshTokenRequest): TokenResponse
 
     /**
-     * 사용자의 토큰을 무효화하여 로그아웃 처리한다.
+     * 현재 클라이언트 세션의 Refresh Token만 무효화한다.
+     * 토큰이 이미 무효화됐거나 저장소에 없어도 로그아웃은 멱등적으로 완료한다.
+     *
+     * @param refreshToken 현재 세션의 Refresh Token
+     */
+    fun logoutCurrentSession(refreshToken: String)
+
+    /**
+     * 사용자의 모든 Refresh Token을 무효화하여 전체 세션에서 로그아웃 처리한다.
+     *
      * @param userId 로그아웃할 사용자의 ID
      */
     fun logout(userId: UUID)

--- a/backend/src/main/kotlin/com/fanpulse/application/service/identity/AuthServiceImpl.kt
+++ b/backend/src/main/kotlin/com/fanpulse/application/service/identity/AuthServiceImpl.kt
@@ -125,15 +125,30 @@ class AuthServiceImpl(
     }
 
     /**
-     * 사용자의 모든 리프레시 토큰을 무효화하여 로그아웃 처리한다.
+     * 현재 세션의 Refresh Token만 무효화한다.
+     * 존재하지 않거나 이미 무효화된 토큰도 멱등적으로 처리한다.
+     */
+    @Transactional
+    override fun logoutCurrentSession(refreshToken: String) {
+        if (refreshToken.isBlank()) {
+            return
+        }
+
+        logger.debug { "현재 세션 로그아웃 요청" }
+        refreshTokenPort.invalidate(refreshToken)
+        logger.info { "현재 세션 로그아웃 완료" }
+    }
+
+    /**
+     * 사용자의 모든 리프레시 토큰을 무효화하여 전체 세션에서 로그아웃 처리한다.
      *
      * @param userId 로그아웃할 사용자 ID
      */
     @Transactional
     override fun logout(userId: UUID) {
-        logger.debug { "로그아웃 요청. 사용자: $userId" }
+        logger.debug { "전체 세션 로그아웃 요청. 사용자: $userId" }
         refreshTokenPort.invalidateAllByUserId(userId)
-        logger.info { "로그아웃 완료. 사용자: $userId" }
+        logger.info { "전체 세션 로그아웃 완료. 사용자: $userId" }
     }
 
     /**

--- a/backend/src/main/kotlin/com/fanpulse/interfaces/rest/identity/AuthController.kt
+++ b/backend/src/main/kotlin/com/fanpulse/interfaces/rest/identity/AuthController.kt
@@ -2,6 +2,7 @@ package com.fanpulse.interfaces.rest.identity
 
 import com.fanpulse.application.dto.identity.*
 import com.fanpulse.application.identity.InvalidTokenException
+import com.fanpulse.application.identity.RefreshTokenReusedException
 import com.fanpulse.application.service.identity.AuthService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -27,8 +28,7 @@ private val logger = KotlinLogging.logger {}
 class AuthController(
     private val authService: AuthService,
     @Value("\${app.cookie.secure:false}") private val cookieSecure: Boolean,
-    @Value("\${app.cookie.domain:}") private val cookieDomain: String,
-    @Value("\${app.cookie.max-age:604800}") private val cookieMaxAge: Int // 7일
+    @Value("\${app.cookie.domain:}") private val cookieDomain: String
 ) {
     companion object {
         const val ACCESS_TOKEN_COOKIE = "fanpulse_access_token"
@@ -49,10 +49,14 @@ class AuthController(
         logger.debug { "Google login request" }
         val authResponse = authService.googleLogin(request)
 
-        // httpOnly 쿠키로 토큰 설정
-        setAuthCookies(response, authResponse.accessToken, authResponse.refreshToken)
+        setAuthCookies(
+            response = response,
+            accessToken = authResponse.accessToken,
+            refreshToken = authResponse.refreshToken,
+            accessMaxAgeSeconds = authResponse.expiresIn,
+            refreshMaxAgeSeconds = authResponse.refreshExpiresIn
+        )
 
-        // 응답에는 토큰 제외하고 사용자 정보만 반환
         return ResponseEntity.ok(
             GoogleLoginResponse(
                 userId = authResponse.userId,
@@ -62,44 +66,101 @@ class AuthController(
         )
     }
 
+    /**
+     * 모바일 클라이언트용 토큰 갱신 엔드포인트.
+     *
+     * Refresh Token은 요청 본문으로만 받고, 새 토큰은 응답 본문과 Set-Cookie로 반환한다.
+     * 웹 브라우저는 토큰을 응답 본문에 노출하지 않는 `/web/refresh`를 사용한다.
+     */
     @PostMapping("/refresh")
-    @Operation(summary = "Refresh access token")
+    @Operation(summary = "Refresh tokens for mobile clients")
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "Token refreshed successfully"),
+        ApiResponse(responseCode = "400", description = "Refresh token body is missing or blank"),
         ApiResponse(responseCode = "401", description = "Invalid refresh token")
     )
-    fun refresh(
-        request: HttpServletRequest,
-        response: HttpServletResponse,
-        @RequestBody(required = false) body: RefreshTokenRequest?
+    fun refreshMobile(
+        @Valid @RequestBody request: RefreshTokenRequest,
+        response: HttpServletResponse
     ): ResponseEntity<TokenResponse> {
-        logger.debug { "Token refresh request" }
+        logger.debug { "Mobile token refresh request" }
+        val tokenResponse = authService.refreshToken(request)
 
-        // 1순위: 쿠키, 2순위: request body (모바일 앱 지원)
-        val refreshToken = request.cookies?.find { it.name == REFRESH_TOKEN_COOKIE }?.value
-            ?: body?.refreshToken
-            ?: return ResponseEntity.status(401).build()
+        // Android CookieJar 호환을 위해 Set-Cookie도 함께 갱신한다.
+        setAuthCookies(
+            response = response,
+            accessToken = tokenResponse.accessToken,
+            refreshToken = tokenResponse.refreshToken,
+            accessMaxAgeSeconds = tokenResponse.expiresIn,
+            refreshMaxAgeSeconds = tokenResponse.refreshExpiresIn
+        )
 
-        val tokenResponse = authService.refreshToken(RefreshTokenRequest(refreshToken))
-
-        // 웹: 쿠키 갱신
-        setAuthCookies(response, tokenResponse.accessToken, tokenResponse.refreshToken)
-
-        // 모바일: 응답 바디로 토큰 반환
         return ResponseEntity.ok(tokenResponse)
     }
 
-    @PostMapping("/logout")
-    @Operation(summary = "Logout and clear auth cookies")
+    /**
+     * 웹 브라우저용 토큰 갱신 엔드포인트.
+     *
+     * httpOnly Refresh Cookie만 사용하며 새 토큰은 Set-Cookie로만 전달한다.
+     * 응답 본문에는 Access/Refresh Token을 노출하지 않는다.
+     */
+    @PostMapping("/web/refresh")
+    @Operation(summary = "Refresh web authentication cookies")
     @ApiResponses(
-        ApiResponse(responseCode = "200", description = "Logout successful")
+        ApiResponse(responseCode = "204", description = "Authentication cookies refreshed"),
+        ApiResponse(responseCode = "401", description = "Refresh cookie is missing or invalid")
     )
-    fun logout(response: HttpServletResponse): ResponseEntity<Unit> {
+    fun refreshWeb(
+        request: HttpServletRequest,
+        response: HttpServletResponse
+    ): ResponseEntity<Void> {
+        logger.debug { "Web cookie refresh request" }
+
+        val refreshToken = findCookie(request, REFRESH_TOKEN_COOKIE)
+        if (refreshToken == null) {
+            clearAuthCookies(response)
+            return ResponseEntity.status(401).build()
+        }
+
+        return try {
+            val tokenResponse = authService.refreshToken(RefreshTokenRequest(refreshToken))
+            setAuthCookies(
+                response = response,
+                accessToken = tokenResponse.accessToken,
+                refreshToken = tokenResponse.refreshToken,
+                accessMaxAgeSeconds = tokenResponse.expiresIn,
+                refreshMaxAgeSeconds = tokenResponse.refreshExpiresIn
+            )
+            ResponseEntity.noContent().build()
+        } catch (exception: InvalidTokenException) {
+            clearAuthCookies(response)
+            throw exception
+        } catch (exception: RefreshTokenReusedException) {
+            clearAuthCookies(response)
+            throw exception
+        }
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "Logout current session and clear auth cookies")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "Logout successful"),
+        ApiResponse(responseCode = "400", description = "Refresh token body is blank")
+    )
+    fun logout(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        @Valid @RequestBody(required = false) body: RefreshTokenRequest?
+    ): ResponseEntity<Unit> {
         logger.debug { "Logout request" }
 
-        // 쿠키 삭제
-        clearAuthCookies(response)
+        // 명시적인 모바일 요청 본문을 우선하고, 웹은 httpOnly 쿠키를 사용한다.
+        val refreshToken = body?.refreshToken ?: findCookie(request, REFRESH_TOKEN_COOKIE)
+        refreshToken
+            ?.takeIf { it.isNotBlank() }
+            ?.let(authService::logoutCurrentSession)
 
+        clearAuthCookies(response)
         return ResponseEntity.ok().build()
     }
 
@@ -112,7 +173,7 @@ class AuthController(
     fun getCurrentUser(request: HttpServletRequest): ResponseEntity<AuthStatusResponse> {
         // 1순위: Authorization 헤더 (모바일 앱), 2순위: 쿠키 (웹)
         val accessToken = extractTokenFromHeader(request)
-            ?: request.cookies?.find { it.name == ACCESS_TOKEN_COOKIE }?.value
+            ?: findCookie(request, ACCESS_TOKEN_COOKIE)
             ?: return ResponseEntity.ok(AuthStatusResponse(authenticated = false))
 
         return try {
@@ -136,21 +197,28 @@ class AuthController(
     private fun setAuthCookies(
         response: HttpServletResponse,
         accessToken: String,
-        refreshToken: String
+        refreshToken: String,
+        accessMaxAgeSeconds: Long,
+        refreshMaxAgeSeconds: Long
     ) {
-        val accessCookie = createCookie(ACCESS_TOKEN_COOKIE, accessToken, cookieMaxAge)
-        val refreshCookie = createCookie(REFRESH_TOKEN_COOKIE, refreshToken, cookieMaxAge * 2)
+        val accessCookie = createCookie(
+            ACCESS_TOKEN_COOKIE,
+            accessToken,
+            toCookieMaxAge(accessMaxAgeSeconds)
+        )
+        val refreshCookie = createCookie(
+            REFRESH_TOKEN_COOKIE,
+            refreshToken,
+            toCookieMaxAge(refreshMaxAgeSeconds)
+        )
 
         response.addCookie(accessCookie)
         response.addCookie(refreshCookie)
     }
 
     private fun clearAuthCookies(response: HttpServletResponse) {
-        val accessCookie = createCookie(ACCESS_TOKEN_COOKIE, "", 0)
-        val refreshCookie = createCookie(REFRESH_TOKEN_COOKIE, "", 0)
-
-        response.addCookie(accessCookie)
-        response.addCookie(refreshCookie)
+        response.addCookie(createCookie(ACCESS_TOKEN_COOKIE, "", 0))
+        response.addCookie(createCookie(REFRESH_TOKEN_COOKIE, "", 0))
     }
 
     private fun createCookie(name: String, value: String, maxAge: Int): Cookie {
@@ -165,6 +233,21 @@ class AuthController(
             setAttribute("SameSite", "Lax")
         }
     }
+
+    private fun toCookieMaxAge(seconds: Long): Int {
+        if (seconds !in 1..Int.MAX_VALUE.toLong()) {
+            logger.warn {
+                "Cookie max age was outside the supported range and was clamped: $seconds"
+            }
+        }
+        return seconds.coerceIn(1, Int.MAX_VALUE.toLong()).toInt()
+    }
+
+    private fun findCookie(request: HttpServletRequest, name: String): String? =
+        request.cookies
+            ?.firstOrNull { it.name == name }
+            ?.value
+            ?.takeIf { it.isNotBlank() }
 
     private fun extractTokenFromHeader(request: HttpServletRequest): String? {
         val authHeader = request.getHeader("Authorization") ?: return null

--- a/backend/src/main/kotlin/com/fanpulse/interfaces/rest/identity/AuthController.kt
+++ b/backend/src/main/kotlin/com/fanpulse/interfaces/rest/identity/AuthController.kt
@@ -76,15 +76,18 @@ class AuthController(
     @Operation(summary = "Refresh tokens for mobile clients")
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "Token refreshed successfully"),
-        ApiResponse(responseCode = "400", description = "Refresh token body is missing or blank"),
-        ApiResponse(responseCode = "401", description = "Invalid refresh token")
+        ApiResponse(responseCode = "401", description = "Refresh token body is missing, blank, or invalid")
     )
     fun refreshMobile(
-        @Valid @RequestBody request: RefreshTokenRequest,
+        @RequestBody(required = false) request: RefreshTokenRequest?,
         response: HttpServletResponse
     ): ResponseEntity<TokenResponse> {
         logger.debug { "Mobile token refresh request" }
-        val tokenResponse = authService.refreshToken(request)
+
+        // 기존 모바일 계약: 누락·빈 토큰은 유효하지 않은 인증 정보로 보고 401을 반환한다.
+        val validRequest = request?.takeIf { it.refreshToken.isNotBlank() }
+            ?: return ResponseEntity.status(401).build()
+        val tokenResponse = authService.refreshToken(validRequest)
 
         // Android CookieJar 호환을 위해 Set-Cookie도 함께 갱신한다.
         setAuthCookies(

--- a/backend/src/test/kotlin/com/fanpulse/application/identity/AuthServiceTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/application/identity/AuthServiceTest.kt
@@ -55,7 +55,6 @@ class AuthServiceTest {
         @Test
         @DisplayName("유효한 Google ID Token으로 로그인할 수 있어야 한다")
         fun `should login with valid Google ID token`() {
-            // Given
             val request = GoogleLoginRequest(idToken = "valid_google_id_token")
             val user = User.registerWithOAuth(
                 email = Email.of("user@gmail.com"),
@@ -68,10 +67,8 @@ class AuthServiceTest {
             every { tokenPort.getAccessTokenExpirationSeconds() } returns 3600L
             every { tokenPort.getRefreshTokenExpirationSeconds() } returns 604800L
 
-            // When
             val result = authService.googleLogin(request)
 
-            // Then
             assertNotNull(result)
             assertEquals("access_token", result.accessToken)
             assertEquals("refresh_token", result.refreshToken)
@@ -86,11 +83,9 @@ class AuthServiceTest {
         @Test
         @DisplayName("유효하지 않은 Google ID Token으로는 로그인할 수 없어야 한다")
         fun `should reject login with invalid Google ID token`() {
-            // Given
             val request = GoogleLoginRequest(idToken = "invalid_token")
             every { googleLoginHandler.handle(any()) } throws InvalidGoogleTokenException()
 
-            // When & Then
             assertThrows<InvalidGoogleTokenException> {
                 authService.googleLogin(request)
             }
@@ -99,11 +94,9 @@ class AuthServiceTest {
         @Test
         @DisplayName("이메일이 검증되지 않은 Google 계정으로는 로그인할 수 없어야 한다")
         fun `should reject login with unverified Google email`() {
-            // Given
             val request = GoogleLoginRequest(idToken = "valid_but_unverified")
             every { googleLoginHandler.handle(any()) } throws OAuthEmailNotVerifiedException()
 
-            // When & Then
             assertThrows<OAuthEmailNotVerifiedException> {
                 authService.googleLogin(request)
             }
@@ -117,7 +110,6 @@ class AuthServiceTest {
         @Test
         @DisplayName("유효한 Refresh Token으로 새 Access Token을 발급받을 수 있어야 한다")
         fun `should refresh access token with valid refresh token`() {
-            // Given
             val refreshToken = "valid_refresh_token"
             val userId = UUID.randomUUID()
             val user = User.registerWithOAuth(
@@ -128,17 +120,17 @@ class AuthServiceTest {
             every { tokenPort.validateToken(refreshToken) } returns true
             every { tokenPort.getTokenType(refreshToken) } returns "refresh"
             every { tokenPort.getUserIdFromToken(refreshToken) } returns userId
-            every { refreshTokenPort.findAndInvalidateByToken(refreshToken) } returns TokenInvalidationResult.Invalidated
+            every {
+                refreshTokenPort.findAndInvalidateByToken(refreshToken)
+            } returns TokenInvalidationResult.Invalidated
             every { userPort.findById(userId) } returns user
             every { tokenPort.generateAccessToken(userId) } returns "new_access_token"
             every { tokenPort.generateRefreshToken(userId) } returns "new_refresh_token"
             every { tokenPort.getAccessTokenExpirationSeconds() } returns 3600L
             every { tokenPort.getRefreshTokenExpirationSeconds() } returns 604800L
 
-            // When
             val result = authService.refreshToken(RefreshTokenRequest(refreshToken))
 
-            // Then
             assertEquals("new_access_token", result.accessToken)
             assertEquals("new_refresh_token", result.refreshToken)
             assertEquals(3600L, result.expiresIn)
@@ -148,16 +140,16 @@ class AuthServiceTest {
         @Test
         @DisplayName("저장소에 미등록된 Refresh Token은 거부해야 한다")
         fun `should reject refresh token not found in rotation store`() {
-            // Given
             val refreshToken = "unregistered_refresh_token"
             val userId = UUID.randomUUID()
 
             every { tokenPort.validateToken(refreshToken) } returns true
             every { tokenPort.getTokenType(refreshToken) } returns "refresh"
             every { tokenPort.getUserIdFromToken(refreshToken) } returns userId
-            every { refreshTokenPort.findAndInvalidateByToken(refreshToken) } returns TokenInvalidationResult.NotFound
+            every {
+                refreshTokenPort.findAndInvalidateByToken(refreshToken)
+            } returns TokenInvalidationResult.NotFound
 
-            // When & Then
             assertThrows<InvalidTokenException> {
                 authService.refreshToken(RefreshTokenRequest(refreshToken))
             }
@@ -166,11 +158,9 @@ class AuthServiceTest {
         @Test
         @DisplayName("유효하지 않은 Refresh Token으로는 갱신할 수 없어야 한다")
         fun `should reject refresh with invalid token`() {
-            // Given
             val invalidToken = "invalid_token"
             every { tokenPort.validateToken(invalidToken) } returns false
 
-            // When & Then
             assertThrows<InvalidTokenException> {
                 authService.refreshToken(RefreshTokenRequest(invalidToken))
             }
@@ -179,12 +169,10 @@ class AuthServiceTest {
         @Test
         @DisplayName("Access Token으로는 갱신할 수 없어야 한다")
         fun `should reject refresh with access token`() {
-            // Given
             val accessToken = "access_token"
             every { tokenPort.validateToken(accessToken) } returns true
             every { tokenPort.getTokenType(accessToken) } returns "access"
 
-            // When & Then
             assertThrows<InvalidTokenException> {
                 authService.refreshToken(RefreshTokenRequest(accessToken))
             }
@@ -196,15 +184,32 @@ class AuthServiceTest {
     inner class Logout {
 
         @Test
-        @DisplayName("로그아웃 시 모든 Refresh Token이 무효화되어야 한다")
+        @DisplayName("현재 세션 로그아웃은 전달된 Refresh Token만 무효화해야 한다")
+        fun `should invalidate only current refresh token on session logout`() {
+            val refreshToken = "current_refresh_token"
+
+            authService.logoutCurrentSession(refreshToken)
+
+            verify(exactly = 1) { refreshTokenPort.invalidate(refreshToken) }
+            verify(exactly = 0) { refreshTokenPort.invalidateAllByUserId(any()) }
+        }
+
+        @Test
+        @DisplayName("빈 Refresh Token 로그아웃은 저장소를 변경하지 않아야 한다")
+        fun `should keep current session logout idempotent for blank token`() {
+            authService.logoutCurrentSession("   ")
+
+            verify(exactly = 0) { refreshTokenPort.invalidate(any()) }
+            verify(exactly = 0) { refreshTokenPort.invalidateAllByUserId(any()) }
+        }
+
+        @Test
+        @DisplayName("전체 로그아웃 시 모든 Refresh Token이 무효화되어야 한다")
         fun `should invalidate all refresh tokens on logout`() {
-            // Given
             val userId = UUID.randomUUID()
 
-            // When
             authService.logout(userId)
 
-            // Then
             verify(exactly = 1) { refreshTokenPort.invalidateAllByUserId(userId) }
         }
     }

--- a/backend/src/test/kotlin/com/fanpulse/interfaces/rest/identity/AuthControllerTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/interfaces/rest/identity/AuthControllerTest.kt
@@ -10,7 +10,11 @@ import com.fanpulse.infrastructure.security.JwtTokenProvider
 import com.fanpulse.infrastructure.security.SecurityConfig
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
+import io.mockk.verify
+import jakarta.servlet.http.Cookie
 import org.junit.jupiter.api.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
@@ -25,7 +29,7 @@ import java.util.*
 /**
  * AuthController TDD Tests
  *
- * Tests Google OAuth login and token refresh endpoints.
+ * 웹 httpOnly 쿠키와 모바일 토큰 응답의 경계를 포함한 인증 API 계약을 검증한다.
  */
 @WebMvcTest(AuthController::class)
 @Import(SecurityConfig::class, com.fanpulse.interfaces.rest.GlobalExceptionHandler::class)
@@ -70,9 +74,8 @@ class AuthControllerTest {
     inner class GoogleLogin {
 
         @Test
-        @DisplayName("유효한 Google ID Token으로 로그인하면 200과 토큰을 반환해야 한다")
-        fun `should return 200 with tokens when Google login is successful`() {
-            // Given
+        @DisplayName("로그인 성공 시 사용자 정보와 수명에 맞는 httpOnly 쿠키를 반환해야 한다")
+        fun `should return user info and aligned cookies when Google login is successful`() {
             val request = GoogleLoginRequest(idToken = "valid_google_id_token")
             val userId = UUID.randomUUID()
             val response = AuthResponse(
@@ -84,11 +87,9 @@ class AuthControllerTest {
                 expiresIn = 3600L,
                 refreshExpiresIn = 604800L
             )
-
             every { authService.googleLogin(any()) } returns response
 
-            // When & Then
-            mockMvc.post("/api/v1/auth/google") {
+            val result = mockMvc.post("/api/v1/auth/google") {
                 contentType = MediaType.APPLICATION_JSON
                 content = objectMapper.writeValueAsString(request)
             }.andExpect {
@@ -96,22 +97,23 @@ class AuthControllerTest {
                 jsonPath("$.userId") { value(userId.toString()) }
                 jsonPath("$.email") { value("user@gmail.com") }
                 jsonPath("$.username") { value("googleuser") }
-                // 토큰은 httpOnly 쿠키로만 전달, 응답 바디에 미포함
                 jsonPath("$.accessToken") { doesNotExist() }
                 jsonPath("$.refreshToken") { doesNotExist() }
-                cookie { value("fanpulse_access_token", "access_token") }
-                cookie { value("fanpulse_refresh_token", "refresh_token") }
-            }
+                cookie { value(AuthController.ACCESS_TOKEN_COOKIE, "access_token") }
+                cookie { value(AuthController.REFRESH_TOKEN_COOKIE, "refresh_token") }
+            }.andReturn()
+
+            val cookies = result.response.cookies.associateBy { it.name }
+            assertEquals(3600, cookies.getValue(AuthController.ACCESS_TOKEN_COOKIE).maxAge)
+            assertEquals(604800, cookies.getValue(AuthController.REFRESH_TOKEN_COOKIE).maxAge)
         }
 
         @Test
         @DisplayName("유효하지 않은 Google ID Token으로 로그인하면 401을 반환해야 한다")
         fun `should return 401 when Google ID token is invalid`() {
-            // Given
             val request = GoogleLoginRequest(idToken = "invalid_token")
             every { authService.googleLogin(any()) } throws InvalidGoogleTokenException()
 
-            // When & Then
             mockMvc.post("/api/v1/auth/google") {
                 contentType = MediaType.APPLICATION_JSON
                 content = objectMapper.writeValueAsString(request)
@@ -123,11 +125,9 @@ class AuthControllerTest {
         @Test
         @DisplayName("이메일이 검증되지 않은 Google 계정으로 로그인하면 400을 반환해야 한다")
         fun `should return 400 when Google email is not verified`() {
-            // Given
             val request = GoogleLoginRequest(idToken = "valid_but_unverified")
             every { authService.googleLogin(any()) } throws OAuthEmailNotVerifiedException()
 
-            // When & Then
             mockMvc.post("/api/v1/auth/google") {
                 contentType = MediaType.APPLICATION_JSON
                 content = objectMapper.writeValueAsString(request)
@@ -138,43 +138,55 @@ class AuthControllerTest {
     }
 
     @Nested
-    @DisplayName("POST /api/v1/auth/refresh")
-    inner class RefreshToken {
+    @DisplayName("POST /api/v1/auth/refresh - 모바일")
+    inner class MobileRefreshToken {
 
         @Test
-        @DisplayName("유효한 Refresh 토큰으로 갱신하면 200과 새 토큰을 반환해야 한다")
-        fun `should return 200 with new tokens when refresh is successful`() {
-            // Given
-            val request = mapOf("refreshToken" to "valid_refresh_token")
+        @DisplayName("요청 본문의 Refresh Token으로 갱신하면 새 토큰과 쿠키를 반환해야 한다")
+        fun `should return token body and cookies for mobile refresh`() {
+            val request = RefreshTokenRequest("valid_refresh_token")
             val response = TokenResponse(
                 accessToken = "new_access_token",
                 expiresIn = 3600L,
                 refreshToken = "new_refresh_token",
                 refreshExpiresIn = 604800L
             )
+            every { authService.refreshToken(request) } returns response
 
-            every { authService.refreshToken(any()) } returns response
-
-            // When & Then
-            mockMvc.post("/api/v1/auth/refresh") {
+            val result = mockMvc.post("/api/v1/auth/refresh") {
                 contentType = MediaType.APPLICATION_JSON
                 content = objectMapper.writeValueAsString(request)
             }.andExpect {
                 status { isOk() }
                 jsonPath("$.accessToken") { value("new_access_token") }
                 jsonPath("$.refreshToken") { value("new_refresh_token") }
+                cookie { value(AuthController.ACCESS_TOKEN_COOKIE, "new_access_token") }
+                cookie { value(AuthController.REFRESH_TOKEN_COOKIE, "new_refresh_token") }
+            }.andReturn()
+
+            val cookies = result.response.cookies.associateBy { it.name }
+            assertEquals(3600, cookies.getValue(AuthController.ACCESS_TOKEN_COOKIE).maxAge)
+            assertEquals(604800, cookies.getValue(AuthController.REFRESH_TOKEN_COOKIE).maxAge)
+        }
+
+        @Test
+        @DisplayName("쿠키만으로 모바일 갱신 경로를 호출하면 400을 반환해야 한다")
+        fun `should reject cookie only refresh on mobile endpoint`() {
+            mockMvc.post("/api/v1/auth/refresh") {
+                cookie(Cookie(AuthController.REFRESH_TOKEN_COOKIE, "cookie_refresh_token"))
+            }.andExpect {
+                status { isBadRequest() }
             }
+
+            verify(exactly = 0) { authService.refreshToken(any()) }
         }
 
         @Test
         @DisplayName("유효하지 않은 토큰으로 갱신하면 401을 반환해야 한다")
         fun `should return 401 when refresh token is invalid`() {
-            // Given
-            val request = mapOf("refreshToken" to "invalid_token")
+            val request = RefreshTokenRequest("invalid_token")
+            every { authService.refreshToken(request) } throws InvalidTokenException()
 
-            every { authService.refreshToken(any()) } throws InvalidTokenException()
-
-            // When & Then
             mockMvc.post("/api/v1/auth/refresh") {
                 contentType = MediaType.APPLICATION_JSON
                 content = objectMapper.writeValueAsString(request)
@@ -186,12 +198,9 @@ class AuthControllerTest {
         @Test
         @DisplayName("Refresh Token 재사용 시 401을 반환해야 한다")
         fun `should return 401 when refresh token is reused`() {
-            // Given
-            val request = mapOf("refreshToken" to "reused_token")
+            val request = RefreshTokenRequest("reused_token")
+            every { authService.refreshToken(request) } throws RefreshTokenReusedException()
 
-            every { authService.refreshToken(any()) } throws RefreshTokenReusedException()
-
-            // When & Then
             mockMvc.post("/api/v1/auth/refresh") {
                 contentType = MediaType.APPLICATION_JSON
                 content = objectMapper.writeValueAsString(request)
@@ -202,22 +211,161 @@ class AuthControllerTest {
     }
 
     @Nested
+    @DisplayName("POST /api/v1/auth/web/refresh - 웹")
+    inner class WebRefreshToken {
+
+        @Test
+        @DisplayName("Refresh Cookie로 갱신하면 204와 새 쿠키만 반환해야 한다")
+        fun `should rotate cookies without exposing tokens in response body`() {
+            val response = TokenResponse(
+                accessToken = "new_access_token",
+                expiresIn = 3600L,
+                refreshToken = "new_refresh_token",
+                refreshExpiresIn = 604800L
+            )
+            every {
+                authService.refreshToken(RefreshTokenRequest("cookie_refresh_token"))
+            } returns response
+
+            val result = mockMvc.post("/api/v1/auth/web/refresh") {
+                cookie(Cookie(AuthController.REFRESH_TOKEN_COOKIE, "cookie_refresh_token"))
+            }.andExpect {
+                status { isNoContent() }
+                content { string("") }
+                cookie { value(AuthController.ACCESS_TOKEN_COOKIE, "new_access_token") }
+                cookie { value(AuthController.REFRESH_TOKEN_COOKIE, "new_refresh_token") }
+            }.andReturn()
+
+            val cookies = result.response.cookies.associateBy { it.name }
+            assertEquals(3600, cookies.getValue(AuthController.ACCESS_TOKEN_COOKIE).maxAge)
+            assertEquals(604800, cookies.getValue(AuthController.REFRESH_TOKEN_COOKIE).maxAge)
+        }
+
+        @Test
+        @DisplayName("요청 본문만 있고 Refresh Cookie가 없으면 401을 반환해야 한다")
+        fun `should reject body token on web refresh endpoint`() {
+            mockMvc.post("/api/v1/auth/web/refresh") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(
+                    RefreshTokenRequest("body_refresh_token")
+                )
+            }.andExpect {
+                status { isUnauthorized() }
+            }
+
+            verify(exactly = 0) { authService.refreshToken(any()) }
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 Refresh Cookie이면 401과 쿠키 삭제를 반환해야 한다")
+        fun `should return 401 and clear cookies when web refresh cookie is invalid`() {
+            every {
+                authService.refreshToken(RefreshTokenRequest("invalid_cookie_token"))
+            } throws InvalidTokenException()
+
+            val result = mockMvc.post("/api/v1/auth/web/refresh") {
+                cookie(Cookie(AuthController.REFRESH_TOKEN_COOKIE, "invalid_cookie_token"))
+            }.andExpect {
+                status { isUnauthorized() }
+            }.andReturn()
+
+            val cookies = result.response.cookies.associateBy { it.name }
+            assertEquals(0, cookies.getValue(AuthController.ACCESS_TOKEN_COOKIE).maxAge)
+            assertEquals(0, cookies.getValue(AuthController.REFRESH_TOKEN_COOKIE).maxAge)
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/auth/logout")
+    inner class Logout {
+
+        @Test
+        @DisplayName("웹 로그아웃 시 현재 Refresh Cookie를 무효화하고 쿠키를 삭제해야 한다")
+        fun `should invalidate current cookie session and clear cookies`() {
+            every { authService.logoutCurrentSession("cookie_refresh_token") } just Runs
+
+            val result = mockMvc.post("/api/v1/auth/logout") {
+                cookie(Cookie(AuthController.REFRESH_TOKEN_COOKIE, "cookie_refresh_token"))
+            }.andExpect {
+                status { isOk() }
+            }.andReturn()
+
+            verify(exactly = 1) {
+                authService.logoutCurrentSession("cookie_refresh_token")
+            }
+            val cookies = result.response.cookies.associateBy { it.name }
+            assertEquals(0, cookies.getValue(AuthController.ACCESS_TOKEN_COOKIE).maxAge)
+            assertEquals(0, cookies.getValue(AuthController.REFRESH_TOKEN_COOKIE).maxAge)
+        }
+
+        @Test
+        @DisplayName("모바일 로그아웃은 요청 본문의 Refresh Token을 우선 사용해야 한다")
+        fun `should prefer explicit mobile token when logging out`() {
+            every { authService.logoutCurrentSession("body_refresh_token") } just Runs
+
+            mockMvc.post("/api/v1/auth/logout") {
+                cookie(Cookie(AuthController.REFRESH_TOKEN_COOKIE, "cookie_refresh_token"))
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(
+                    RefreshTokenRequest("body_refresh_token")
+                )
+            }.andExpect {
+                status { isOk() }
+            }
+
+            verify(exactly = 1) {
+                authService.logoutCurrentSession("body_refresh_token")
+            }
+            verify(exactly = 0) {
+                authService.logoutCurrentSession("cookie_refresh_token")
+            }
+        }
+
+        @Test
+        @DisplayName("토큰이 없는 로그아웃 요청도 멱등적으로 성공하고 쿠키를 삭제해야 한다")
+        fun `should keep logout idempotent without refresh token`() {
+            val result = mockMvc.post("/api/v1/auth/logout") {}
+                .andExpect {
+                    status { isOk() }
+                }.andReturn()
+
+            verify(exactly = 0) { authService.logoutCurrentSession(any()) }
+            val cookies = result.response.cookies.associateBy { it.name }
+            assertEquals(0, cookies.getValue(AuthController.ACCESS_TOKEN_COOKIE).maxAge)
+            assertEquals(0, cookies.getValue(AuthController.REFRESH_TOKEN_COOKIE).maxAge)
+        }
+    }
+
+    @Nested
     @DisplayName("Request Validation Tests")
     inner class ValidationTests {
 
         @Test
         @DisplayName("빈 idToken으로 Google 로그인하면 400을 반환해야 한다")
         fun `should return 400 when idToken is blank`() {
-            // Given
             val request = GoogleLoginRequest(idToken = "")
 
-            // When & Then
             mockMvc.post("/api/v1/auth/google") {
                 contentType = MediaType.APPLICATION_JSON
                 content = objectMapper.writeValueAsString(request)
             }.andExpect {
                 status { isBadRequest() }
             }
+        }
+
+        @Test
+        @DisplayName("빈 Refresh Token 본문으로 모바일 갱신하면 400을 반환해야 한다")
+        fun `should return 400 when refresh token is blank`() {
+            mockMvc.post("/api/v1/auth/refresh") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(
+                    RefreshTokenRequest("")
+                )
+            }.andExpect {
+                status { isBadRequest() }
+            }
+
+            verify(exactly = 0) { authService.refreshToken(any()) }
         }
     }
 }

--- a/backend/src/test/kotlin/com/fanpulse/interfaces/rest/identity/AuthControllerTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/interfaces/rest/identity/AuthControllerTest.kt
@@ -16,6 +16,7 @@ import io.mockk.just
 import io.mockk.verify
 import jakarta.servlet.http.Cookie
 import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.context.annotation.Import

--- a/backend/src/test/kotlin/com/fanpulse/interfaces/rest/identity/AuthControllerTest.kt
+++ b/backend/src/test/kotlin/com/fanpulse/interfaces/rest/identity/AuthControllerTest.kt
@@ -171,12 +171,12 @@ class AuthControllerTest {
         }
 
         @Test
-        @DisplayName("쿠키만으로 모바일 갱신 경로를 호출하면 400을 반환해야 한다")
+        @DisplayName("쿠키만으로 모바일 갱신 경로를 호출하면 401을 반환해야 한다")
         fun `should reject cookie only refresh on mobile endpoint`() {
             mockMvc.post("/api/v1/auth/refresh") {
                 cookie(Cookie(AuthController.REFRESH_TOKEN_COOKIE, "cookie_refresh_token"))
             }.andExpect {
-                status { isBadRequest() }
+                status { isUnauthorized() }
             }
 
             verify(exactly = 0) { authService.refreshToken(any()) }
@@ -355,15 +355,15 @@ class AuthControllerTest {
         }
 
         @Test
-        @DisplayName("빈 Refresh Token 본문으로 모바일 갱신하면 400을 반환해야 한다")
-        fun `should return 400 when refresh token is blank`() {
+        @DisplayName("빈 Refresh Token 본문으로 모바일 갱신하면 401을 반환해야 한다")
+        fun `should return 401 when refresh token is blank`() {
             mockMvc.post("/api/v1/auth/refresh") {
                 contentType = MediaType.APPLICATION_JSON
                 content = objectMapper.writeValueAsString(
                     RefreshTokenRequest("")
                 )
             }.andExpect {
-                status { isBadRequest() }
+                status { isUnauthorized() }
             }
 
             verify(exactly = 0) { authService.refreshToken(any()) }

--- a/web/src/lib/api-client.test.ts
+++ b/web/src/lib/api-client.test.ts
@@ -1,0 +1,48 @@
+import axios from "axios";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { API_BASE_URL, refreshWebSession } from "./api-client";
+
+describe("refreshWebSession", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("동시에 호출돼도 웹 갱신 요청을 한 번만 실행한다", async () => {
+    let resolveRequest: (() => void) | undefined;
+    const pendingRequest = new Promise<void>((resolve) => {
+      resolveRequest = resolve;
+    });
+    const postSpy = vi
+      .spyOn(axios, "post")
+      .mockReturnValue(pendingRequest as never);
+
+    const first = refreshWebSession();
+    const second = refreshWebSession();
+
+    expect(first).toBe(second);
+    expect(postSpy).toHaveBeenCalledTimes(1);
+    expect(postSpy).toHaveBeenCalledWith(
+      `${API_BASE_URL.replace(/\/$/, "")}/auth/web/refresh`,
+      undefined,
+      expect.objectContaining({
+        withCredentials: true,
+        timeout: 30000,
+      })
+    );
+
+    resolveRequest?.();
+    await Promise.all([first, second]);
+  });
+
+  it("갱신 실패 후에는 다음 호출에서 새 요청을 실행한다", async () => {
+    const postSpy = vi
+      .spyOn(axios, "post")
+      .mockRejectedValueOnce(new Error("refresh failed"))
+      .mockResolvedValueOnce({} as never);
+
+    await expect(refreshWebSession()).rejects.toThrow("refresh failed");
+    await expect(refreshWebSession()).resolves.toBeUndefined();
+
+    expect(postSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -1,7 +1,47 @@
-import axios, { AxiosError, AxiosInstance } from "axios";
+import axios, {
+  AxiosError,
+  AxiosInstance,
+  InternalAxiosRequestConfig,
+} from "axios";
 
 export const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_BASE_URL ?? "https://api.fanpulse.app/api/v1";
+
+const WEB_REFRESH_URL = `${API_BASE_URL.replace(/\/$/, "")}/auth/web/refresh`;
+const AUTO_REFRESH_EXCLUDED_PATHS = [
+  "/auth/google",
+  "/auth/refresh",
+  "/auth/web/refresh",
+  "/auth/logout",
+];
+
+type RetriableRequestConfig = InternalAxiosRequestConfig & {
+  _fanPulseRetried?: boolean;
+};
+
+let refreshPromise: Promise<void> | null = null;
+
+/**
+ * 웹 httpOnly Refresh Cookie를 사용해 인증 쿠키를 회전한다.
+ *
+ * 동시에 여러 요청이 401을 반환해도 실제 갱신 요청은 하나만 실행한다.
+ * 기본 axios 클라이언트를 사용해 apiClient 응답 인터셉터의 재귀 호출을 피한다.
+ */
+export function refreshWebSession(): Promise<void> {
+  if (refreshPromise === null) {
+    refreshPromise = axios
+      .post<void>(WEB_REFRESH_URL, undefined, {
+        withCredentials: true,
+        timeout: 30000,
+      })
+      .then(() => undefined)
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+
+  return refreshPromise;
+}
 
 /**
  * Axios 인스턴스
@@ -14,20 +54,53 @@ export const apiClient: AxiosInstance = axios.create({
   headers: {
     "Content-Type": "application/json",
   },
-  withCredentials: true, // httpOnly 쿠키 자동 전송
+  withCredentials: true,
 });
 
-// Response 인터셉터: 401 에러 처리
+function shouldSkipAutoRefresh(url?: string): boolean {
+  if (!url) return true;
+  return AUTO_REFRESH_EXCLUDED_PATHS.some((path) => url.includes(path));
+}
+
+function redirectToLogin(): void {
+  if (
+    typeof window !== "undefined" &&
+    window.location.pathname !== "/login"
+  ) {
+    window.location.href = "/login";
+  }
+}
+
+// Response 인터셉터: 401이면 웹 쿠키를 한 번 갱신한 후 원래 요청을 재시도한다.
 apiClient.interceptors.response.use(
   (response) => response,
-  (error: AxiosError) => {
-    if (error.response?.status === 401) {
-      // 인증 만료 시 로그인 페이지로 리다이렉트
-      if (typeof window !== "undefined") {
-        window.location.href = "/login";
-      }
+  async (error: AxiosError) => {
+    const status = error.response?.status;
+    const requestConfig = error.config as RetriableRequestConfig | undefined;
+
+    if (
+      status !== 401 ||
+      !requestConfig ||
+      typeof window === "undefined" ||
+      shouldSkipAutoRefresh(requestConfig.url)
+    ) {
+      return Promise.reject(error);
     }
-    return Promise.reject(error);
+
+    if (requestConfig._fanPulseRetried) {
+      redirectToLogin();
+      return Promise.reject(error);
+    }
+
+    requestConfig._fanPulseRetried = true;
+
+    try {
+      await refreshWebSession();
+      return apiClient.request(requestConfig);
+    } catch {
+      redirectToLogin();
+      return Promise.reject(error);
+    }
   }
 );
 

--- a/web/src/lib/auth.test.ts
+++ b/web/src/lib/auth.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./api-client", () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+  refreshWebSession: vi.fn(),
+  toFanPulseError: vi.fn((error: unknown) => error),
+  FanPulseApiError: class FanPulseApiError extends Error {},
+}));
+
+import { apiClient, refreshWebSession } from "./api-client";
+import { checkAuthStatus, logout } from "./auth";
+
+describe("auth client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("이미 인증된 상태면 Refresh Cookie를 사용하지 않는다", async () => {
+    const authenticated = {
+      authenticated: true,
+      user: {
+        id: "11111111-1111-1111-1111-111111111111",
+        email: "user@example.com",
+        username: "tester",
+      },
+    };
+    vi.mocked(apiClient.get).mockResolvedValueOnce({
+      data: authenticated,
+    } as never);
+
+    await expect(checkAuthStatus()).resolves.toEqual(authenticated);
+
+    expect(refreshWebSession).not.toHaveBeenCalled();
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("Access Cookie가 만료되면 웹 세션을 갱신한 뒤 인증 상태를 다시 조회한다", async () => {
+    const authenticated = {
+      authenticated: true,
+      user: {
+        id: "22222222-2222-2222-2222-222222222222",
+        email: "restored@example.com",
+        username: "restored",
+      },
+    };
+    vi.mocked(apiClient.get)
+      .mockResolvedValueOnce({
+        data: { authenticated: false },
+      } as never)
+      .mockResolvedValueOnce({
+        data: authenticated,
+      } as never);
+    vi.mocked(refreshWebSession).mockResolvedValueOnce(undefined);
+
+    await expect(checkAuthStatus()).resolves.toEqual(authenticated);
+
+    expect(refreshWebSession).toHaveBeenCalledTimes(1);
+    expect(apiClient.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("Refresh Cookie도 유효하지 않으면 최초 비인증 상태를 유지한다", async () => {
+    const unauthenticated = { authenticated: false };
+    vi.mocked(apiClient.get).mockResolvedValueOnce({
+      data: unauthenticated,
+    } as never);
+    vi.mocked(refreshWebSession).mockRejectedValueOnce(
+      new Error("refresh expired")
+    );
+
+    await expect(checkAuthStatus()).resolves.toEqual(unauthenticated);
+
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("로그아웃 API가 실패해도 클라이언트 로그아웃 흐름은 완료한다", async () => {
+    const consoleSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    vi.mocked(apiClient.post).mockRejectedValueOnce(
+      new Error("network failed")
+    );
+
+    await expect(logout()).resolves.toBeUndefined();
+
+    expect(apiClient.post).toHaveBeenCalledWith("/auth/logout");
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    consoleSpy.mockRestore();
+  });
+});

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,4 +1,9 @@
-import { apiClient, FanPulseApiError, toFanPulseError } from "./api-client";
+import {
+  apiClient,
+  FanPulseApiError,
+  refreshWebSession,
+  toFanPulseError,
+} from "./api-client";
 
 // Re-export for backward compatibility
 export { FanPulseApiError } from "./api-client";
@@ -43,27 +48,42 @@ export async function loginWithGoogle(params: {
 
 /**
  * 로그아웃
- * - 백엔드에서 쿠키 삭제
+ * - 백엔드에서 현재 Refresh Token을 무효화하고 인증 쿠키를 삭제
  */
 export async function logout(): Promise<void> {
   try {
     await apiClient.post("/auth/logout");
   } catch (error) {
-    // 로그아웃 실패해도 클라이언트에서는 로그아웃 처리
+    // 서버 요청이 실패해도 클라이언트 인증 상태는 제거한다.
     console.error("Logout failed:", error);
   }
 }
 
+async function requestAuthStatus(): Promise<AuthStatusResponse> {
+  const response = await apiClient.get<AuthStatusResponse>("/auth/me");
+  return response.data;
+}
+
 /**
  * 인증 상태 확인
- * - 서버에서 쿠키 기반으로 인증 상태 반환
+ *
+ * Access Cookie가 만료되어 `/auth/me`가 비인증 상태를 반환하면
+ * httpOnly Refresh Cookie로 세션을 한 번 갱신한 뒤 상태를 다시 확인한다.
  */
 export async function checkAuthStatus(): Promise<AuthStatusResponse> {
   try {
-    const response = await apiClient.get<AuthStatusResponse>("/auth/me");
-    return response.data;
-  } catch (error) {
-    // 401이면 인증되지 않은 상태
+    const current = await requestAuthStatus();
+    if (current.authenticated) {
+      return current;
+    }
+
+    try {
+      await refreshWebSession();
+      return await requestAuthStatus();
+    } catch {
+      return current;
+    }
+  } catch {
     return { authenticated: false };
   }
 }


### PR DESCRIPTION
## 변경 배경

기존 `/api/v1/auth/refresh`는 웹의 httpOnly Refresh Cookie와 모바일 요청 본문을 동시에 처리하면서, 갱신된 Access/Refresh Token을 항상 JSON 응답으로 반환했습니다.

웹에서는 JavaScript가 Refresh Token 자체를 읽을 수 없도록 httpOnly 쿠키를 사용하고 있었지만, 쿠키 기반 갱신 응답에서 새 토큰을 본문으로 돌려주면 이 경계가 약해집니다. 또한 로그아웃은 쿠키만 제거하고 서버 저장소의 Refresh Token을 무효화하지 않았고, Access Token 만료 시 웹은 Refresh Token이 남아 있어도 바로 로그인 화면으로 이동했습니다.

웹과 모바일의 인증 계약을 분리하면서 기존 Android 계약은 유지하고, 현재 세션 로그아웃 및 웹 자동 갱신 흐름을 연결합니다.

## 변경 내용

### 백엔드
- `POST /api/v1/auth/refresh`
  - 모바일 전용 요청 본문 계약 유지
  - 새 토큰 JSON 응답 및 Android CookieJar용 Set-Cookie 유지
  - 누락·빈 토큰·쿠키만 전달된 요청은 기존 계약과 동일하게 `401 Unauthorized`
- `POST /api/v1/auth/web/refresh` 추가
  - httpOnly Refresh Cookie만 사용
  - 성공 시 `204 No Content`
  - 새 토큰은 Set-Cookie로만 전달
  - 누락·무효·재사용 토큰이면 인증 쿠키 제거
- `POST /api/v1/auth/logout`
  - 현재 Refresh Token을 서버 저장소에서 무효화
  - 웹 쿠키와 모바일 요청 본문 모두 지원
  - 토큰이 없는 요청도 멱등적으로 성공
- 인증 쿠키 Max-Age를 JWT 실제 만료 시간과 일치시킴
- 기존 사용자 전체 세션 무효화 로직은 유지

### 웹
- 401 발생 시 Refresh Cookie를 한 번 갱신한 뒤 원 요청 재시도
- 동시 401 요청은 하나의 갱신 요청을 공유
- 재시도 후에도 401이면 로그인 화면으로 이동
- `/auth/me`가 비인증 상태를 반환하면 Refresh Cookie로 복구 후 다시 확인
- 로그인·갱신·로그아웃 API에는 자동 갱신을 적용하지 않아 재귀 호출 방지

## 호환성

- Android의 `POST /auth/refresh` 요청·응답 및 실패 상태 코드 계약 유지
- Google 로그인 응답 구조 유지
- JWT 생성 및 Rotation/CAS 재사용 탐지 로직 비변경
- DB 스키마 및 Flyway 마이그레이션 없음
- 보호 API 계약 비변경

## 테스트

- 웹·모바일 갱신 경계
- 모바일 누락·빈 토큰의 기존 `401` 계약
- 웹 갱신 응답의 토큰 본문 미노출
- 쿠키 수명과 JWT 만료 시간 정합성
- 현재 세션 로그아웃 무효화 및 멱등성
- 동시 401 단일 갱신
- Access Cookie 만료 후 인증 상태 복구
- 갱신 실패 후 정상 재시도 가능 여부

## CI 검증

- 백엔드 전체 테스트 및 PostgreSQL 검증 통과
- 프론트 전체 테스트 통과
- TypeScript 검사 통과
- 프로덕션 빌드 통과

## 확인 사항

- [x] 모바일 기존 계약 유지
- [x] 웹 응답 본문 토큰 노출 제거
- [x] 서버 Refresh Token 로그아웃 무효화 연결
- [x] 회귀 테스트 추가
- [x] GitHub Actions 전체 검증